### PR TITLE
fix : springdoc 버전 변경 (#22)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     runtimeOnly 'com.h2database:h2'
 }
 


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타

## Related Issues
close #21 

## 변경 사항
> springdoc-openapi 버전을 2.3.0에서 2.8.6으로 업그레이드했습니다. 기존 버전이 현재 Spring Boot 버전과 호환되지 않아 Swagger UI 로드 시 500 에러가 발생하는 문제를 수정했습니다.

## 테스트 결과
> Swagger UI(`/swagger-ui/index.html`) 정상 로드 확인
```
(base) heeyoon1302@gimhuiyun-ui-MacBookAir replan % git commit -m "fix : springdoc 버전 변경"
││███▊···········│ 25% EXECUTING [879ms]
>> :
BUILD SUCCESSFUL in 1s
```
<img width="730" height="688" alt="스크린샷 2026-03-27 오전 1 00 39" src="https://github.com/user-attachments/assets/89e2c50b-9557-4725-8f86-f79d44a018ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 변경사항**
  * 개발 도구 라이브러리 의존성이 최신 버전으로 업데이트되었습니다. 이를 통해 안정성과 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->