### PR TITLE
feat: JWT 회원가입/로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/plana/replan/domain/user/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/user/controller/AuthController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.user.dto.LoginRequestDto;
+import plana.replan.domain.user.dto.LoginResponseDto;
 import plana.replan.domain.user.dto.SignUpRequestDto;
 import plana.replan.domain.user.service.AuthService;
 
@@ -21,5 +23,10 @@ public class AuthController {
   public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequestDto request) {
     authService.signUp(request);
     return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto request) {
+    return ResponseEntity.ok(authService.login(request));
   }
 }

--- a/src/main/java/plana/replan/domain/user/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/user/controller/AuthController.java
@@ -1,0 +1,25 @@
+package plana.replan.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.user.dto.SignUpRequestDto;
+import plana.replan.domain.user.service.AuthService;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequestDto request) {
+    authService.signUp(request);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/plana/replan/domain/user/dto/LoginRequestDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "이메일 형식이 올바르지 않습니다.")
+  private String email;
+
+  @NotBlank(message = "비밀번호는 필수입니다.")
+  private String password;
+}

--- a/src/main/java/plana/replan/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package plana.replan.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
@@ -2,6 +2,7 @@ package plana.replan.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
@@ -1,0 +1,22 @@
+package plana.replan.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequestDto {
+
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "이메일 형식이 올바르지 않습니다.")
+  private String email;
+
+  //    @NotBlank(message = "비밀번호는 필수입니다.")
+  //    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+  //    private String password;
+
+  @NotBlank(message = "닉네임은 필수입니다.")
+  private String nickname;
+}

--- a/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
@@ -13,9 +13,9 @@ public class SignUpRequestDto {
   @Email(message = "이메일 형식이 올바르지 않습S니다.")
   private String email;
 
-  //    @NotBlank(message = "비밀번호는 필수입니다.")
-  //    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-  //    private String password;
+  @NotBlank(message = "비밀번호는 필수입니다.")
+  @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+  private String password;
 
   @NotBlank(message = "닉네임은 필수입니다.")
   private String nickname;

--- a/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/SignUpRequestDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class SignUpRequestDto {
 
   @NotBlank(message = "이메일은 필수입니다.")
-  @Email(message = "이메일 형식이 올바르지 않습니다.")
+  @Email(message = "이메일 형식이 올바르지 않습S니다.")
   private String email;
 
   //    @NotBlank(message = "비밀번호는 필수입니다.")

--- a/src/main/java/plana/replan/domain/user/entity/Provider.java
+++ b/src/main/java/plana/replan/domain/user/entity/Provider.java
@@ -1,0 +1,8 @@
+package plana.replan.domain.user.entity;
+
+public enum Provider {
+  LOCAL,
+  KAKAO,
+  GOOGLE,
+  NAVER
+}

--- a/src/main/java/plana/replan/domain/user/entity/Role.java
+++ b/src/main/java/plana/replan/domain/user/entity/Role.java
@@ -1,0 +1,6 @@
+package plana.replan.domain.user.entity;
+
+public enum Role {
+  ROLE_USER,
+  ROLE_ADMIN
+}

--- a/src/main/java/plana/replan/domain/user/entity/User.java
+++ b/src/main/java/plana/replan/domain/user/entity/User.java
@@ -1,0 +1,43 @@
+package plana.replan.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column private String password;
+
+  @Column(nullable = false)
+  private String nickname;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Provider provider;
+
+  @Builder
+  public User(String email, String password, String nickname, Role role, Provider provider) {
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+    this.role = role;
+    this.provider = provider;
+  }
+}

--- a/src/main/java/plana/replan/domain/user/entity/User.java
+++ b/src/main/java/plana/replan/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package plana.replan.domain.user.entity;
 
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,10 +35,10 @@ public class User {
 
   @Builder
   public User(String email, String password, String nickname, Role role, Provider provider) {
-    this.email = email;
-    this.password = password;
-    this.nickname = nickname;
-    this.role = role;
-    this.provider = provider;
+    this.email = Objects.requireNonNull(email, "이메일은 필수입니다.");
+    this.nickname = Objects.requireNonNull(nickname, "닉네임은 필수입니다.");
+    this.role = Objects.requireNonNull(role, "역할은 필수입니다.");
+    this.provider = Objects.requireNonNull(provider, "제공자는 필수입니다.");
+    this.password = password; // OAuth는 null 가능
   }
 }

--- a/src/main/java/plana/replan/domain/user/entity/UserErrorCode.java
+++ b/src/main/java/plana/replan/domain/user/entity/UserErrorCode.java
@@ -1,0 +1,16 @@
+package plana.replan.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+  USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+  DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
+  INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/plana/replan/domain/user/exception/UserErrorCode.java
@@ -1,4 +1,4 @@
-package plana.replan.domain.user.entity;
+package plana.replan.domain.user.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/plana/replan/domain/user/repository/UserRepository.java
+++ b/src/main/java/plana/replan/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.user.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  // 이메일로 유저를 조회할
+  Optional<User> findByEmail(String email);
+
+  // 회원가입할 때 이미 가입된 이메일인지 체크하는 용도예요
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/plana/replan/domain/user/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/user/service/AuthService.java
@@ -1,0 +1,45 @@
+package plana.replan.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.user.dto.SignUpRequestDto;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional
+  public void signUp(SignUpRequestDto request) {
+
+    // 1. 이메일 중복 체크
+    if (userRepository.existsByEmail(request.getEmail())) {
+      throw new CustomException(UserErrorCode.DUPLICATE_EMAIL);
+    }
+
+    // 2. 비밀번호 암호화
+    String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+    // 3. User 엔티티 생성 및 저장
+    User user =
+        User.builder()
+            .email(request.getEmail())
+            .password(encodedPassword)
+            .nickname(request.getNickname())
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+
+    userRepository.save(user);
+  }
+}

--- a/src/main/java/plana/replan/domain/user/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/user/service/AuthService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.user.dto.LoginRequestDto;
+import plana.replan.domain.user.dto.LoginResponseDto;
 import plana.replan.domain.user.dto.SignUpRequestDto;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
@@ -11,6 +13,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class AuthService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
 
   @Transactional
   public void signUp(SignUpRequestDto request) {
@@ -41,5 +45,26 @@ public class AuthService {
             .build();
 
     userRepository.save(user);
+  }
+
+  @Transactional(readOnly = true)
+  public LoginResponseDto login(LoginRequestDto request) {
+
+    // 1. 이메일로 유저 조회
+    User user =
+        userRepository
+            .findByEmail(request.getEmail())
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 2. 비밀번호 검증
+    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+      throw new CustomException(UserErrorCode.INVALID_PASSWORD);
+    }
+
+    // 3. 토큰 발급
+    String accessToken = jwtUtil.generateAccessToken(user.getEmail(), user.getRole().name());
+    String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+
+    return new LoginResponseDto(accessToken, refreshToken);
   }
 }

--- a/src/main/java/plana/replan/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/plana/replan/domain/user/service/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package plana.replan.domain.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다: " + email));
+
+    // 스프링 시큐리티가 제공하는 User 객체로 변환
+    return org.springframework.security.core.userdetails.User.builder()
+        .username(user.getEmail())
+        .password(user.getPassword())
+        .authorities(List.of(new SimpleGrantedAuthority(user.getRole().name())))
+        .build();
+  }
+}

--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -1,19 +1,37 @@
 package plana.replan.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import plana.replan.global.jwt.JwtFilter;
+import plana.replan.global.jwt.JwtUtil;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtUtil jwtUtil;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
+    http
+        // 1. CSRF 비활성화 (JWT는 세션 안 쓰니까 불필요)
+        .csrf(AbstractHttpConfigurer::disable)
+
+        // 2. 세션 Stateless 설정
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        // 3. URL 권한 설정
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(
@@ -21,10 +39,22 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/v3/api-docs",
                         "/swagger-ui.html",
-                        "/actuator/health")
+                        "/actuator/health",
+                        "/api/auth/**" // 로그인, 회원가입은 인증 없이 허용
+                        )
                     .permitAll()
                     .anyRequest()
-                    .authenticated());
+                    .authenticated())
+
+        // 4. JwtFilter를 UsernamePasswordAuthenticationFilter 앞에 등록
+        .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
     return http.build();
+  }
+
+  // 5. PasswordEncoder Bean 등록
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 }

--- a/src/main/java/plana/replan/global/jwt/JwtErrorCode.java
+++ b/src/main/java/plana/replan/global/jwt/JwtErrorCode.java
@@ -1,0 +1,17 @@
+package plana.replan.global.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+  INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+  EXPIRED_TOKEN(401, "만료된 토큰입니다."),
+  UNSUPPORTED_TOKEN(401, "지원하지 않는 토큰입니다."),
+  EMPTY_TOKEN(401, "토큰이 없습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/global/jwt/JwtFilter.java
+++ b/src/main/java/plana/replan/global/jwt/JwtFilter.java
@@ -1,0 +1,69 @@
+package plana.replan.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import plana.replan.global.exception.CustomException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwtUtil;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    // 1. 헤더에서 토큰 꺼내기
+    String token = resolveToken(request);
+
+    // 2. 토큰 없으면 그냥 통과 (로그인, 회원가입 등 공개 API)
+    if (token == null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    // 3. 토큰 검증 및 인증 정보 저장
+    try {
+      jwtUtil.validateToken(token);
+
+      String email = jwtUtil.getEmail(token);
+      String role = jwtUtil.getRole(token);
+
+      // 4. SecurityContext에 인증 정보 저장
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(
+              email, // principal (현재 유저)
+              null, // credentials (비밀번호, JWT에선 필요없음)
+              List.of(new SimpleGrantedAuthority(role)) // 권한
+              );
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    } catch (CustomException e) {
+      // 5. 토큰이 유효하지 않으면 SecurityContext 비워두고 통과
+      // → SecurityConfig에서 인증 필요한 API면 401 반환
+      SecurityContextHolder.clearContext();
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  // Authorization 헤더에서 Bearer 토큰 추출
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7); // "Bearer " 이후 토큰만 추출
+    }
+    return null;
+  }
+}

--- a/src/main/java/plana/replan/global/jwt/JwtUtil.java
+++ b/src/main/java/plana/replan/global/jwt/JwtUtil.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +23,7 @@ public class JwtUtil {
       @Value("${jwt.secret}") String secret,
       @Value("${jwt.access-expiration}") long accessExpiration,
       @Value("${jwt.refresh-expiration}") long refreshExpiration) {
-    this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     this.accessExpiration = accessExpiration;
     this.refreshExpiration = refreshExpiration;
   }

--- a/src/main/java/plana/replan/global/jwt/JwtUtil.java
+++ b/src/main/java/plana/replan/global/jwt/JwtUtil.java
@@ -1,0 +1,81 @@
+package plana.replan.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import plana.replan.global.exception.CustomException;
+
+@Component
+public class JwtUtil {
+
+  private final SecretKey key;
+  private final long accessExpiration;
+  private final long refreshExpiration;
+
+  public JwtUtil(
+      @Value("${jwt.secret}") String secret,
+      @Value("${jwt.access-expiration}") long accessExpiration,
+      @Value("${jwt.refresh-expiration}") long refreshExpiration) {
+    this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    this.accessExpiration = accessExpiration;
+    this.refreshExpiration = refreshExpiration;
+  }
+
+  // Access Token 발급
+  public String generateAccessToken(String email, String role) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("role", role)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+        .signWith(key)
+        .compact();
+  }
+
+  // Refresh Token 발급
+  public String generateRefreshToken(String email) {
+    return Jwts.builder()
+        .subject(email)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+        .signWith(key)
+        .compact();
+  }
+
+  // 토큰에서 이메일 추출
+  public String getEmail(String token) {
+    return getClaims(token).getSubject();
+  }
+
+  // 토큰에서 역할 추출
+  public String getRole(String token) {
+    return getClaims(token).get("role", String.class);
+  }
+
+  // 토큰 유효성 검증
+  public boolean validateToken(String token) {
+    getClaims(token); // 예외 던지면 알아서 터짐
+    return true;
+  }
+
+  private Claims getClaims(String token) {
+    try {
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      // 만료된 토큰
+      throw new CustomException(JwtErrorCode.EXPIRED_TOKEN);
+    } catch (JwtException e) {
+      // 변조되거나 잘못된 토큰
+      throw new CustomException(JwtErrorCode.INVALID_TOKEN);
+    } catch (IllegalArgumentException e) {
+      // 토큰이 null이거나 빈 문자열
+      throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,18 @@
 spring:
   application:
     name: replan
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 management:
   endpoints:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,8 @@ management:
   endpoint:
     health:
       show-details: never
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: 900000
+  refresh-expiration: 604800000

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+jwt:
+  secret: testSecretKeyForTestingPurposeOnly1234
+  access-expiration: 900000
+  refresh-expiration: 604800000


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
#25 


## 변경 사항
- JWT의존성 추가
- appplication.yaml 파일 수정
- User 엔티티 추가
  - User 클래스 추가
  - 역할 이넘 타입 - 유저, 관리자
  - 프로바이더 이넘 타입 - 로컬,네이버,카카오,구글
- JWT 의존성 추가 (jjwt 0.13.0)
- PostgreSQL 드라이버 변경 (MySQL → PostgreSQL)
- yaml 환경변수 설정 (DB, JWT)
- User 엔티티 추가
- JWT 유틸 클래스 구현 (토큰 발급/검증)
- JwtFilter 구현 (요청마다 토큰 검증)
- SecurityConfig 설정 (JWT 필터 등록, PasswordEncoder)
- UserRepository 구현
- UserDetailsService 구현
- UserErrorCode 추가
- 테스트 환경 H2 설정 추가


## 테스트 결과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * JWT 토큰 인증 도입 — 액세스 15분, 리프레시 7일 유효 및 관련 토큰 발급/검증 기능 추가.
  * 사용자 계정 확장 — 역할(ROLE_USER/ROLE_ADMIN) 및 인증 제공자(LOCAL, KAKAO, GOOGLE, NAVER) 지원 추가; User 엔티티 도입.

* **변경/설정**
  * 런타임 데이터베이스를 PostgreSQL로 전환 및 애플리케이션용 PostgreSQL 연결·JPA 설정 추가.
  * JWT 런타임 라이브러리 추가.

* **테스트**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->