### PR TITLE
Feat : 로그아웃 및 유저정보조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/plana/replan/domain/auth/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/auth/controller/AuthController.java
@@ -1,13 +1,13 @@
-package plana.replan.domain.user.controller;
+package plana.replan.domain.auth.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import plana.replan.domain.user.dto.LoginRequestDto;
-import plana.replan.domain.user.dto.LoginResponseDto;
-import plana.replan.domain.user.dto.SignUpRequestDto;
-import plana.replan.domain.user.service.AuthService;
+import plana.replan.domain.auth.dto.LoginRequestDto;
+import plana.replan.domain.auth.dto.LoginResponseDto;
+import plana.replan.domain.auth.dto.SignUpRequestDto;
+import plana.replan.domain.auth.service.AuthService;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/src/main/java/plana/replan/domain/auth/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/auth/controller/AuthController.java
@@ -9,6 +9,8 @@ import plana.replan.domain.auth.dto.LoginRequestDto;
 import plana.replan.domain.auth.dto.LoginResponseDto;
 import plana.replan.domain.auth.dto.SignUpRequestDto;
 import plana.replan.domain.auth.service.AuthService;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtErrorCode;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -31,6 +33,9 @@ public class AuthController {
   @PostMapping("/reissue")
   public ResponseEntity<LoginResponseDto> reissue(HttpServletRequest request) {
     String authHeader = request.getHeader("Authorization");
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
+    }
     String refreshToken = authHeader.substring(7);
     return ResponseEntity.ok(authService.reissue(refreshToken));
   }
@@ -38,6 +43,9 @@ public class AuthController {
   @PostMapping("/logout")
   public ResponseEntity<Void> logout(HttpServletRequest request) {
     String authHeader = request.getHeader("Authorization");
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
+    }
     String accessToken = authHeader.substring(7);
     authService.logout(accessToken);
     return ResponseEntity.ok().build();

--- a/src/main/java/plana/replan/domain/auth/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package plana.replan.domain.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,15 +29,16 @@ public class AuthController {
   }
 
   @PostMapping("/reissue")
-  public ResponseEntity<LoginResponseDto> reissue(
-      @RequestHeader("Authorization") String authHeader) {
-    String refreshToken = authHeader.substring(7); // "Bearer " 제거
+  public ResponseEntity<LoginResponseDto> reissue(HttpServletRequest request) {
+    String authHeader = request.getHeader("Authorization");
+    String refreshToken = authHeader.substring(7);
     return ResponseEntity.ok(authService.reissue(refreshToken));
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
-    String accessToken = authHeader.substring(7); // "Bearer " 제거
+  public ResponseEntity<Void> logout(HttpServletRequest request) {
+    String authHeader = request.getHeader("Authorization");
+    String accessToken = authHeader.substring(7);
     authService.logout(accessToken);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/plana/replan/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/plana/replan/domain/auth/dto/LoginRequestDto.java
@@ -1,23 +1,18 @@
-package plana.replan.domain.user.dto;
+package plana.replan.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class SignUpRequestDto {
+public class LoginRequestDto {
 
   @NotBlank(message = "이메일은 필수입니다.")
-  @Email(message = "이메일 형식이 올바르지 않습S니다.")
+  @Email(message = "이메일 형식이 올바르지 않습니다.")
   private String email;
 
   @NotBlank(message = "비밀번호는 필수입니다.")
-  @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
   private String password;
-
-  @NotBlank(message = "닉네임은 필수입니다.")
-  private String nickname;
 }

--- a/src/main/java/plana/replan/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/plana/replan/domain/auth/dto/LoginResponseDto.java
@@ -1,4 +1,4 @@
-package plana.replan.domain.user.dto;
+package plana.replan.domain.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/plana/replan/domain/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/plana/replan/domain/auth/dto/SignUpRequestDto.java
@@ -1,18 +1,23 @@
-package plana.replan.domain.user.dto;
+package plana.replan.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class LoginRequestDto {
+public class SignUpRequestDto {
 
   @NotBlank(message = "이메일은 필수입니다.")
-  @Email(message = "이메일 형식이 올바르지 않습니다.")
+  @Email(message = "이메일 형식이 올바르지 않습S니다.")
   private String email;
 
   @NotBlank(message = "비밀번호는 필수입니다.")
+  @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
   private String password;
+
+  @NotBlank(message = "닉네임은 필수입니다.")
+  private String nickname;
 }

--- a/src/main/java/plana/replan/domain/auth/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/auth/service/AuthService.java
@@ -58,11 +58,11 @@ public class AuthService {
     User user =
         userRepository
             .findByEmail(request.getEmail())
-            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(UserErrorCode.LOGIN_FAILED));
 
     // 2. 비밀번호 검증
     if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-      throw new CustomException(UserErrorCode.INVALID_PASSWORD);
+      throw new CustomException(UserErrorCode.LOGIN_FAILED);
     }
 
     // 3. 토큰 발급

--- a/src/main/java/plana/replan/domain/auth/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package plana.replan.domain.user.service;
+package plana.replan.domain.auth.service;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -6,9 +6,9 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import plana.replan.domain.user.dto.LoginRequestDto;
-import plana.replan.domain.user.dto.LoginResponseDto;
-import plana.replan.domain.user.dto.SignUpRequestDto;
+import plana.replan.domain.auth.dto.LoginRequestDto;
+import plana.replan.domain.auth.dto.LoginResponseDto;
+import plana.replan.domain.auth.dto.SignUpRequestDto;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;

--- a/src/main/java/plana/replan/domain/auth/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/auth/service/AuthService.java
@@ -66,7 +66,8 @@ public class AuthService {
     }
 
     // 3. 토큰 발급
-    String accessToken = jwtUtil.generateAccessToken(user.getEmail(), user.getRole().name());
+    String accessToken =
+        jwtUtil.generateAccessToken(user.getEmail(), user.getRole().name(), user.getId());
     String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
 
     // 4. Refresh Token Redis에 저장 (7일)
@@ -107,7 +108,7 @@ public class AuthService {
             .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
     // 6. 새 토큰 발급
-    String newAccessToken = jwtUtil.generateAccessToken(email, user.getRole().name());
+    String newAccessToken = jwtUtil.generateAccessToken(email, user.getRole().name(), user.getId());
     String newRefreshToken = jwtUtil.generateRefreshToken(email);
 
     // 7. Redis Refresh Token 덮어쓰기 (Rotation)

--- a/src/main/java/plana/replan/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/plana/replan/domain/auth/service/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package plana.replan.domain.user.service;
+package plana.replan.domain.auth.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/plana/replan/domain/user/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/user/controller/AuthController.java
@@ -33,4 +33,11 @@ public class AuthController {
     String refreshToken = authHeader.substring(7); // "Bearer " 제거
     return ResponseEntity.ok(authService.reissue(refreshToken));
   }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
+    String accessToken = authHeader.substring(7); // "Bearer " 제거
+    authService.logout(accessToken);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/plana/replan/domain/user/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/user/controller/AuthController.java
@@ -3,10 +3,7 @@ package plana.replan.domain.user.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import plana.replan.domain.user.dto.LoginRequestDto;
 import plana.replan.domain.user.dto.LoginResponseDto;
 import plana.replan.domain.user.dto.SignUpRequestDto;
@@ -28,5 +25,12 @@ public class AuthController {
   @PostMapping("/login")
   public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto request) {
     return ResponseEntity.ok(authService.login(request));
+  }
+
+  @PostMapping("/reissue")
+  public ResponseEntity<LoginResponseDto> reissue(
+      @RequestHeader("Authorization") String authHeader) {
+    String refreshToken = authHeader.substring(7); // "Bearer " 제거
+    return ResponseEntity.ok(authService.reissue(refreshToken));
   }
 }

--- a/src/main/java/plana/replan/domain/user/controller/UserController.java
+++ b/src/main/java/plana/replan/domain/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package plana.replan.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.user.dto.UserResponseDto;
+import plana.replan.domain.user.service.UserService;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @GetMapping("/me")
+  public ResponseEntity<UserResponseDto> getMyInfo(@AuthenticationPrincipal Long userId) {
+    return ResponseEntity.ok(userService.getMyInfo(userId));
+  }
+}

--- a/src/main/java/plana/replan/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/plana/replan/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,23 @@
+package plana.replan.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
+
+@Getter
+@AllArgsConstructor
+public class UserResponseDto {
+
+  private Long userId;
+  private String email;
+  private String nickname;
+  private Role role;
+  private Provider provider;
+
+  public static UserResponseDto from(User user) {
+    return new UserResponseDto(
+        user.getId(), user.getEmail(), user.getNickname(), user.getRole(), user.getProvider());
+  }
+}

--- a/src/main/java/plana/replan/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/plana/replan/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ import plana.replan.global.exception.ErrorCode;
 public enum UserErrorCode implements ErrorCode {
   USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
   DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
-  INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다.");
+  INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
+  LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/user/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/user/service/AuthService.java
@@ -1,6 +1,8 @@
 package plana.replan.domain.user.service;
 
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class AuthService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtUtil jwtUtil;
+  private final StringRedisTemplate redisTemplate;
 
   @Transactional
   public void signUp(SignUpRequestDto request) {
@@ -64,6 +67,15 @@ public class AuthService {
     // 3. 토큰 발급
     String accessToken = jwtUtil.generateAccessToken(user.getEmail(), user.getRole().name());
     String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+
+    // 4. Refresh Token Redis에 저장 (7일)
+    redisTemplate
+        .opsForValue()
+        .set(
+            "refresh:" + user.getEmail(),
+            refreshToken,
+            jwtUtil.getRefreshExpiration(),
+            TimeUnit.MILLISECONDS);
 
     return new LoginResponseDto(accessToken, refreshToken);
   }

--- a/src/main/java/plana/replan/domain/user/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/user/service/AuthService.java
@@ -121,4 +121,14 @@ public class AuthService {
 
     return new LoginResponseDto(newAccessToken, newRefreshToken);
   }
+
+  public void logout(String accessToken) {
+
+    // 1. Access Token 검증 및 이메일 추출
+    jwtUtil.validateToken(accessToken);
+    String email = jwtUtil.getEmail(accessToken);
+
+    // 2. Redis에서 Refresh Token 삭제
+    redisTemplate.delete("refresh:" + email);
+  }
 }

--- a/src/main/java/plana/replan/domain/user/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/user/service/AuthService.java
@@ -15,6 +15,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtErrorCode;
 import plana.replan.global.jwt.JwtUtil;
 
 @Service
@@ -78,5 +79,46 @@ public class AuthService {
             TimeUnit.MILLISECONDS);
 
     return new LoginResponseDto(accessToken, refreshToken);
+  }
+
+  public LoginResponseDto reissue(String refreshToken) {
+
+    // 1. JWT 서명 검증 및 이메일 추출
+    jwtUtil.validateToken(refreshToken);
+    String email = jwtUtil.getEmail(refreshToken);
+
+    // 2. Redis에서 Refresh Token 조회
+    String savedRefreshToken = redisTemplate.opsForValue().get("refresh:" + email);
+
+    // 3. Redis에 없으면 (로그아웃 or 만료)
+    if (savedRefreshToken == null) {
+      throw new CustomException(JwtErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    // 4. 클라이언트가 보낸 토큰이랑 Redis에 있는 토큰 비교
+    if (!savedRefreshToken.equals(refreshToken)) {
+      throw new CustomException(JwtErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    // 5. 유저 조회 (role 가져오기 위해)
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 6. 새 토큰 발급
+    String newAccessToken = jwtUtil.generateAccessToken(email, user.getRole().name());
+    String newRefreshToken = jwtUtil.generateRefreshToken(email);
+
+    // 7. Redis Refresh Token 덮어쓰기 (Rotation)
+    redisTemplate
+        .opsForValue()
+        .set(
+            "refresh:" + email,
+            newRefreshToken,
+            jwtUtil.getRefreshExpiration(),
+            TimeUnit.MILLISECONDS);
+
+    return new LoginResponseDto(newAccessToken, newRefreshToken);
   }
 }

--- a/src/main/java/plana/replan/domain/user/service/UserService.java
+++ b/src/main/java/plana/replan/domain/user/service/UserService.java
@@ -17,6 +17,9 @@ public class UserService {
 
   @Transactional(readOnly = true)
   public UserResponseDto getMyInfo(Long userId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
     User user =
         userRepository
             .findById(userId)

--- a/src/main/java/plana/replan/domain/user/service/UserService.java
+++ b/src/main/java/plana/replan/domain/user/service/UserService.java
@@ -1,0 +1,26 @@
+package plana.replan.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.user.dto.UserResponseDto;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  @Transactional(readOnly = true)
+  public UserResponseDto getMyInfo(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    return UserResponseDto.from(user);
+  }
+}

--- a/src/main/java/plana/replan/global/jwt/JwtErrorCode.java
+++ b/src/main/java/plana/replan/global/jwt/JwtErrorCode.java
@@ -10,7 +10,9 @@ public enum JwtErrorCode implements ErrorCode {
   INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(401, "만료된 토큰입니다."),
   UNSUPPORTED_TOKEN(401, "지원하지 않는 토큰입니다."),
-  EMPTY_TOKEN(401, "토큰이 없습니다.");
+  EMPTY_TOKEN(401, "토큰이 없습니다."),
+  INVALID_REFRESH_TOKEN(401, "유효하지 않은 Refresh Token입니다."),
+  REFRESH_TOKEN_NOT_FOUND(401, "Refresh Token이 존재하지 않습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/global/jwt/JwtFilter.java
+++ b/src/main/java/plana/replan/global/jwt/JwtFilter.java
@@ -90,8 +90,6 @@ public class JwtFilter extends OncePerRequestFilter {
     response.setCharacterEncoding("UTF-8");
     ErrorResponse errorResponse = ErrorResponse.of(errorCode);
     String json = objectMapper.writeValueAsString(errorResponse);
-    System.out.println("sendErrorResponse: " + json); // ← 추가
     response.getWriter().write(json);
-    response.getWriter().flush(); // ← 추가
   }
 }

--- a/src/main/java/plana/replan/global/jwt/JwtFilter.java
+++ b/src/main/java/plana/replan/global/jwt/JwtFilter.java
@@ -36,13 +36,13 @@ public class JwtFilter extends OncePerRequestFilter {
     try {
       jwtUtil.validateToken(token);
 
-      String email = jwtUtil.getEmail(token);
+      Long userId = jwtUtil.getUserId(token);
       String role = jwtUtil.getRole(token);
 
       // 4. SecurityContext에 인증 정보 저장
       UsernamePasswordAuthenticationToken authentication =
           new UsernamePasswordAuthenticationToken(
-              email, // principal (현재 유저)
+              userId, // principal (현재 유저)
               null, // credentials (비밀번호, JWT에선 필요없음)
               List.of(new SimpleGrantedAuthority(role)) // 권한
               );
@@ -50,8 +50,6 @@ public class JwtFilter extends OncePerRequestFilter {
       SecurityContextHolder.getContext().setAuthentication(authentication);
 
     } catch (CustomException e) {
-      // 5. 토큰이 유효하지 않으면 SecurityContext 비워두고 통과
-      // → SecurityConfig에서 인증 필요한 API면 401 반환
       SecurityContextHolder.clearContext();
     }
 

--- a/src/main/java/plana/replan/global/jwt/JwtFilter.java
+++ b/src/main/java/plana/replan/global/jwt/JwtFilter.java
@@ -19,6 +19,12 @@ public class JwtFilter extends OncePerRequestFilter {
   private final JwtUtil jwtUtil;
 
   @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return path.startsWith("/api/auth/");
+  }
+
+  @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {

--- a/src/main/java/plana/replan/global/jwt/JwtFilter.java
+++ b/src/main/java/plana/replan/global/jwt/JwtFilter.java
@@ -1,5 +1,8 @@
 package plana.replan.global.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,16 +10,23 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.ErrorCode;
+import plana.replan.global.exception.ErrorResponse;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ← 추가
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -57,6 +67,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
     } catch (CustomException e) {
       SecurityContextHolder.clearContext();
+      sendErrorResponse(response, e.getErrorCode());
+      return;
     }
 
     filterChain.doFilter(request, response);
@@ -69,5 +81,17 @@ public class JwtFilter extends OncePerRequestFilter {
       return bearerToken.substring(7); // "Bearer " 이후 토큰만 추출
     }
     return null;
+  }
+
+  private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+      throws IOException {
+    response.setStatus(errorCode.getStatus());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+    String json = objectMapper.writeValueAsString(errorResponse);
+    System.out.println("sendErrorResponse: " + json); // ← 추가
+    response.getWriter().write(json);
+    response.getWriter().flush(); // ← 추가
   }
 }

--- a/src/main/java/plana/replan/global/jwt/JwtUtil.java
+++ b/src/main/java/plana/replan/global/jwt/JwtUtil.java
@@ -29,10 +29,11 @@ public class JwtUtil {
   }
 
   // Access Token 발급
-  public String generateAccessToken(String email, String role) {
+  public String generateAccessToken(String email, String role, Long userId) {
     return Jwts.builder()
         .subject(email)
         .claim("role", role)
+        .claim("userId", userId)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + accessExpiration))
         .signWith(key)
@@ -57,6 +58,10 @@ public class JwtUtil {
   // 토큰에서 역할 추출
   public String getRole(String token) {
     return getClaims(token).get("role", String.class);
+  }
+
+  public Long getUserId(String token) {
+    return getClaims(token).get("userId", Long.class);
   }
 
   // 토큰 유효성 검증

--- a/src/main/java/plana/replan/global/jwt/JwtUtil.java
+++ b/src/main/java/plana/replan/global/jwt/JwtUtil.java
@@ -65,6 +65,10 @@ public class JwtUtil {
     return true;
   }
 
+  public long getRefreshExpiration() {
+    return refreshExpiration;
+  }
+
   private Claims getClaims(String token) {
     try {
       return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 management:
   endpoints:


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
#25 


## 변경 사항

### Redis 연동
- Redis 의존성 추가 및 yaml 설정
- 로그인 시 Refresh Token Redis 저장 (TTL 7일)

### 인증 API
- Access Token 재발급 API 구현 `POST /api/auth/reissue`
  - Refresh Token Rotation 적용
- 로그아웃 API 구현 `POST /api/auth/logout`
  - Redis에서 Refresh Token 삭제

### 유저 API
- 유저 정보 조회 API 구현 `GET /api/users/me`
  - Access Token에서 userId 추출하여 조회

### 기타
- JWT Access Token에 userId claim 추가
- SecurityContext에 userId 저장으로 변경
- reissue, logout Swagger 인증 헤더 자동 주입으로 변경


## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 인증 API 통합 및 재배치: 회원가입/로그인/토큰 재발급/로그아웃 (/api/auth) 추가
  * 내 정보 조회 엔드포인트 추가 (GET /api/users/me)
  * 로그인 응답에 액세스·리프레시 토큰 발급 및 재발급 지원
  * JWT에 사용자 식별자(userId) 포함 및 인증처리 개선

* **Chores**
  * Redis 연동 및 설정 추가 — 리프레시 토큰 저장/관리

* **Bug Fixes**
  * 인증 오류 응답 처리 및 관련 에러 코드 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->