### PR TITLE
Fix : Swagger 관련 버그 수정

### DIFF
--- a/src/main/java/plana/replan/domain/auth/controller/AuthController.java
+++ b/src/main/java/plana/replan/domain/auth/controller/AuthController.java
@@ -264,6 +264,9 @@ public class AuthController {
       throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
     }
     String refreshToken = authHeader.substring(7);
+    if (refreshToken.isBlank()) {
+      throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
+    }
     return ResponseEntity.ok(authService.reissue(refreshToken));
   }
 
@@ -337,6 +340,9 @@ public class AuthController {
       throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
     }
     String accessToken = authHeader.substring(7);
+    if (accessToken.isBlank()) {
+      throw new CustomException(JwtErrorCode.EMPTY_TOKEN);
+    }
     authService.logout(accessToken);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/plana/replan/domain/user/controller/UserController.java
+++ b/src/main/java/plana/replan/domain/user/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
 
                     **참고**: userId가 null이거나 DB에 존재하지 않으면 404 반환
                     """,
-      security = @SecurityRequirement(name = "bearerAuth"))
+      security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
     @ApiResponse(
         responseCode = "200",


### PR DESCRIPTION
## PR 타입
- [x] 버그 수정
- [x] 문서 관련

## Related Issues
- closes #

## 변경 사항

**[문서] Auth/User 컨트롤러 Swagger API 문서화**
- `@Tag`로 Auth / User 컨트롤러 그룹핑
- `@Operation`에 호출 주체, 단계별 비즈니스 로직, 보안 설계 의도 명시
- `@ApiResponses`로 성공/실패 케이스별 응답 코드 및 실제 JSON 예시 추가
- `@SecurityRequirement` 추가 및 SwaggerConfig의 SecurityScheme 이름과 일치하도록 수정

**[버그] Authorization 헤더 관련 엣지 케이스 수정**
- `@RequestHeader`의 `required = true` 기본값으로 인해 헤더 누락 시 500 반환되던 문제 → `required = false`로 수정하여 401 EMPTY_TOKEN 반환
- `Authorization: Bearer ` (토큰 없이 prefix만 존재) 케이스가 통과되던 문제 → `isBlank()` 체크 추가하여 차단 (reissue, logout 공통 적용)


## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 요청 시 비어 있는 토큰에 대한 검증을 강화했습니다. 토큰 재발급 및 로그아웃 요청에서 유효하지 않은 토큰으로 인한 오류를 더 정확하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->