### PR TITLE
fix: CORS 에러 해결 (#60)

### DIFF
--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration config = new CorsConfiguration();
     config.addAllowedOrigin("http://localhost:3000");
+    config.addAllowedOrigin("https://re-plan-fe.vercel.app");
     config.addAllowedMethod("*");
     config.addAllowedHeader("*");
     config.setAllowCredentials(true);


### PR DESCRIPTION
## 변경 사항
- `SecurityConfig`에 `https://re-plan-fe.vercel.app` CORS 허용 origin 추가

## 원인
Vercel에 배포된 프론트엔드에서 API 호출 시 CORS 에러 발생

## 해결 방법
`corsConfigurationSource()`에 Vercel 도메인을 allowed origin으로 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 크로스 오리진 요청(CORS) 처리 개선으로 프론트엔드 애플리케이션이 백엔드 API와 정상적으로 통신할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->