### PR TITLE
feat: 목표(Goal) CRUD API 구현 (#75)

### DIFF
--- a/.claude/rules/jpa.md
+++ b/.claude/rules/jpa.md
@@ -1,0 +1,30 @@
+# JPA 규칙
+
+## DB 함수 작성 규칙
+
+이 프로젝트는 **PostgreSQL**을 사용한다. JPQL에서 DB 함수 호출 시 반드시 PostgreSQL 호환 문법을 사용한다.
+
+### 금지
+```java
+// MySQL 방언 — PostgreSQL에서 동작 안 함
+FUNCTION('YEAR', g.dueDate)
+FUNCTION('MONTH', g.dueDate)
+FUNCTION('DAY', g.dueDate)
+```
+
+### 허용 (표준 SQL)
+```java
+// PostgreSQL 포함 대부분 DB에서 동작
+EXTRACT(YEAR FROM g.dueDate)
+EXTRACT(MONTH FROM g.dueDate)
+EXTRACT(DAY FROM g.dueDate)
+```
+
+## @Query 작성 위치
+
+복잡한 조건(메서드명으로 표현 불가)은 Repository 인터페이스에 `@Query`로 작성한다.
+
+```java
+@Query("SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year ORDER BY g.id DESC")
+List<Goal> findByUserAndYear(@Param("user") User user, @Param("year") int year, Pageable pageable);
+```

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,9 @@ out/
 src/main/resources/application-local.yaml
 docker-compose.yml
 
-# 클로드
-.claude
+# 클로드 (rules만 추적, 나머지는 무시)
+.claude/commands
+.claude/settings*
 
 #로컬 DB및 레디스
 postgres_data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,50 @@
 ```
 
 빌드가 실패하면 해당 작업은 완료된 것으로 간주하지 않는다.
+
+### Swagger API 명세 (모든 API 필수)
+
+**Controller는 반드시 Docs 인터페이스와 구현 클래스로 분리한다.**
+- `XxxControllerDocs.java` — 모든 Swagger 어노테이션 (`@Operation`, `@ApiResponses`, `@Parameter`, `@Tag`)
+- `XxxController.java` — `implements XxxControllerDocs`, HTTP 매핑 어노테이션 + 메서드 구현만
+
+**`XxxControllerDocs` 인터페이스에 반드시 포함할 항목:**
+
+1. **`@Operation`** — `summary`(한 줄 요약) + `description`(아래 표 구조 포함)
+
+2. **description 표 구조** — 필수 여부는 이모지 사용 (✅ 필수 / ❌ 선택)
+
+   - **Request Headers 표** (모든 API)
+     ```
+     | 헤더명 | 필수 여부 | 타입 | 설명 |
+     | Authorization | ✅ 필수 | String | Bearer {accessToken} |
+     | Content-Type  | ✅ 필수 | String | application/json (POST/PUT만) |
+     ```
+   - **Request Body 표** (POST/PUT)
+     ```
+     | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+     ```
+   - **Path Variable 표** (DELETE/GET with path)
+     ```
+     | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+     ```
+   - **Query Parameters 표** (GET with query)
+     ```
+     | 파라미터명 | 필수 여부 | 타입 | 기본값 | 설명 | 예시 |
+     ```
+   - **Response Elements 표** (GET 조회 API)
+     ```
+     | 필드명 | 타입 | 설명 |
+     ```
+   - **무한스크롤 사용법** (페이지네이션 API)
+     ```
+     Step 1. 첫 요청 — cursor 없이 호출
+     Step 2. 다음 페이지 — nextCursor를 cursor에 전달
+     Step 3. 종료 — hasNext=false 또는 nextCursor=null이면 마지막 페이지
+     ```
+
+3. **`@ApiResponses`** — 200 성공 + 발생 가능한 모든 에러 코드, 각각 `@ExampleObject`로 JSON 응답 예시 포함. 401은 "토큰 없음"과 "만료된 토큰" 두 케이스를 각각 ExampleObject로 작성
+
+4. **`@Parameter`** — 쿼리/경로 파라미터마다 `description` + `example`
+
+5. **DTO** — 모든 필드에 `@Schema(description = "...", example = "...")`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@
 
 빌드가 실패하면 해당 작업은 완료된 것으로 간주하지 않는다.
 
+### PR / 커밋 작성 규칙
+- PR 본문, 커밋 메시지에 AI가 작성했다는 흔적을 절대 남기지 않는다.
+- `Co-Authored-By: Claude`, `🤖 Generated with Claude Code` 등 일체 금지.
+- 사람이 직접 작성한 것처럼 자연스럽게 작성한다.
+
 ### Swagger API 명세 (모든 API 필수)
 
 **Controller는 반드시 Docs 인터페이스와 구현 클래스로 분리한다.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,4 @@
 4. **`@Parameter`** — 쿼리/경로 파라미터마다 `description` + `example`
 
 5. **DTO** — 모든 필드에 `@Schema(description = "...", example = "...")`
+   > **예외:** `List<다른DTO>` 타입 필드는 참조 DTO에 example이 있으면 `example` 생략 가능. 직접 example 문자열을 작성하면 DTO 변경 시 문서가 낡아지는 문제가 생긴다.

--- a/src/main/java/plana/replan/domain/goal/controller/GoalController.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalController.java
@@ -1,0 +1,45 @@
+package plana.replan.domain.goal.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import plana.replan.domain.goal.dto.GoalCreateRequest;
+import plana.replan.domain.goal.dto.GoalPageResponse;
+import plana.replan.domain.goal.dto.GoalResponse;
+import plana.replan.domain.goal.service.GoalService;
+import plana.replan.global.common.ApiResult;
+
+@RestController
+@RequestMapping("/api/goals")
+@RequiredArgsConstructor
+public class GoalController implements GoalControllerDocs {
+
+  private final GoalService goalService;
+
+  @Override
+  @PostMapping
+  public ResponseEntity<ApiResult<GoalResponse>> createGoal(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody GoalCreateRequest request) {
+    return ResponseEntity.ok(ApiResult.ok(goalService.createGoal(userId, request)));
+  }
+
+  @Override
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResult<Void>> deleteGoal(
+      @AuthenticationPrincipal Long userId, @PathVariable Long id) {
+    goalService.deleteGoal(userId, id);
+    return ResponseEntity.ok(ApiResult.ok());
+  }
+
+  @Override
+  @GetMapping
+  public ResponseEntity<ApiResult<GoalPageResponse>> getGoals(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) Integer year) {
+    return ResponseEntity.ok(ApiResult.ok(goalService.getGoals(userId, cursor, size, year)));
+  }
+}

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -1,0 +1,467 @@
+package plana.replan.domain.goal.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import plana.replan.domain.goal.dto.GoalCreateRequest;
+import plana.replan.domain.goal.dto.GoalPageResponse;
+import plana.replan.domain.goal.dto.GoalResponse;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "Goal", description = "목표(Goal) 관련 API. 모든 요청에 JWT 인증 필수.")
+public interface GoalControllerDocs {
+
+  @Operation(
+      summary = "목표 생성",
+      description =
+          """
+          새로운 목표를 생성합니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | String | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | String | `application/json` |
+
+          ---
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | String | 목표 제목. 공백만 있으면 유효성 오류 | `"토익 900점 달성"` |
+          | dueDate | ❌ 선택 | LocalDateTime | 목표 기한. ISO 8601 형식 | `"2025-12-31T00:00:00"` |
+          | reference | ❌ 선택 | String | 참고 자료 (URL 또는 자유 텍스트) | `"https://toeic.ets.org"` |
+
+          ---
+
+          ### 주의사항
+          - `title`이 없거나 공백이면 400 반환
+          - `dueDate`를 전달하지 않으면 null로 저장됨
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "목표 생성 성공",
+        content =
+            @Content(
+                schema = @Schema(implementation = GoalResponse.class),
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "id": 42,
+                                "title": "토익 900점 달성",
+                                "dueDate": "2025-12-31T00:00:00",
+                                "reference": "https://toeic.ets.org",
+                                "updatedAt": "2025-05-07T12:00:00"
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "요청 데이터 유효성 오류 (title 누락 또는 공백)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "INVALID_INPUT",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "USER_NOT_FOUND",
+                                "message": "유저를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<GoalResponse>> createGoal(
+      @AuthenticationPrincipal Long userId, @RequestBody GoalCreateRequest request);
+
+  @Operation(
+      summary = "목표 삭제",
+      description =
+          """
+          지정한 목표를 삭제합니다 (소프트 삭제 — DB에서 완전히 지워지지 않고 deleted_at이 기록됩니다).
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | String | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          ---
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | id | ✅ 필수 | Long | 삭제할 목표의 ID | `42` |
+
+          ---
+
+          ### 주의사항
+          - 본인 소유의 목표만 삭제 가능. 다른 유저의 목표 삭제 시도 시 403 반환
+          - 삭제된 목표는 이후 조회 API에서 반환되지 않음
+          - 이미 삭제된 목표 ID로 요청 시 404 반환
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @Parameter(name = "id", description = "삭제할 목표 ID", example = "42", required = true)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "목표 삭제 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": null,
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "403",
+        description = "본인 소유의 목표가 아님",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 403,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "GOAL_ACCESS_DENIED",
+                                "message": "본인의 목표만 삭제할 수 있습니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "404",
+        description = "목표를 찾을 수 없음 (존재하지 않거나 이미 삭제됨)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "GOAL_NOT_FOUND",
+                                "message": "목표를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<Void>> deleteGoal(
+      @AuthenticationPrincipal Long userId, @PathVariable Long id);
+
+  @Operation(
+      summary = "목표 목록 조회 (커서 기반 무한스크롤)",
+      description =
+          """
+          목표 목록을 최신순(id 내림차순)으로 반환합니다. 커서 기반 페이지네이션으로 무한스크롤을 구현합니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | String | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          ---
+
+          ### Query Parameters
+
+          | 파라미터명 | 필수 여부 | 타입 | 기본값 | 설명 | 예시 |
+          |-----------|-----------|------|--------|------|------|
+          | cursor | ❌ 선택 | Long | 없음 (첫 페이지) | 이전 응답의 `nextCursor` 값. 없으면 첫 번째 페이지 반환 | `37` |
+          | size | ❌ 선택 | int | `10` | 한 번에 가져올 목표 수 | `10` |
+          | year | ❌ 선택 | int | 없음 (전체) | 조회할 연도 (`dueDate` 기준). 없으면 전체 목표 반환 | `2025` |
+
+          ---
+
+          ### Response Elements
+
+          | 필드명 | 타입 | 설명 |
+          |--------|------|------|
+          | goals | List\\<GoalResponse\\> | 목표 목록 |
+          | goals[].id | Long | 목표 ID |
+          | goals[].title | String | 목표 제목 |
+          | goals[].dueDate | LocalDateTime | 목표 기한 (null 가능) |
+          | goals[].reference | String | 참고 자료 (null 가능) |
+          | goals[].updatedAt | LocalDateTime | 마지막 수정 시간 |
+          | nextCursor | Long | 다음 페이지 요청 시 cursor로 사용할 값. **마지막 페이지이면 null** |
+          | hasNext | boolean | 다음 페이지 존재 여부. false이면 더 이상 데이터 없음 |
+
+          ---
+
+          ### 무한스크롤 구현 방법
+
+          **Step 1. 첫 번째 요청** — cursor 없이 호출
+          ```
+          GET /api/goals?size=10
+          GET /api/goals?year=2025&size=10
+          ```
+
+          **Step 2. 다음 페이지 요청** — 응답의 `nextCursor`를 cursor에 전달
+          ```
+          GET /api/goals?cursor=37&size=10
+          GET /api/goals?year=2025&cursor=37&size=10
+          ```
+
+          **Step 3. 종료 조건** — 응답의 `hasNext`가 `false`이거나 `nextCursor`가 `null`이면 마지막 페이지
+
+          ---
+
+          ### 주의사항
+          - `cursor`는 **마지막으로 받은 목표의 id** (응답의 `nextCursor` 값 그대로 사용)
+          - `year` 파라미터가 없으면 `dueDate`가 null인 목표도 포함되어 반환됨
+          - `year` 파라미터를 사용하면 해당 연도에 `dueDate`가 설정된 목표만 반환 (`dueDate`가 null인 목표는 제외)
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @Parameters({
+    @Parameter(name = "cursor", description = "이전 응답의 nextCursor 값. 없으면 첫 페이지.", example = "37"),
+    @Parameter(name = "size", description = "한 번에 가져올 목표 수. 기본값 10.", example = "10"),
+    @Parameter(name = "year", description = "조회할 연도 (dueDate 기준). 없으면 전체 조회.", example = "2025")
+  })
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content =
+            @Content(
+                schema = @Schema(implementation = GoalPageResponse.class),
+                examples = {
+                  @ExampleObject(
+                      name = "중간 페이지 (hasNext=true)",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "goals": [
+                                {
+                                  "id": 42,
+                                  "title": "토익 900점 달성",
+                                  "dueDate": "2025-12-31T00:00:00",
+                                  "reference": "https://toeic.ets.org",
+                                  "updatedAt": "2025-05-07T12:00:00"
+                                },
+                                {
+                                  "id": 38,
+                                  "title": "운동 습관 만들기",
+                                  "dueDate": "2025-06-30T00:00:00",
+                                  "reference": null,
+                                  "updatedAt": "2025-05-01T09:00:00"
+                                }
+                              ],
+                              "nextCursor": 38,
+                              "hasNext": true
+                            },
+                            "error": null
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "마지막 페이지 (hasNext=false)",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "goals": [
+                                {
+                                  "id": 12,
+                                  "title": "독서 50권",
+                                  "dueDate": null,
+                                  "reference": null,
+                                  "updatedAt": "2025-01-10T08:00:00"
+                                }
+                              ],
+                              "nextCursor": null,
+                              "hasNext": false
+                            },
+                            "error": null
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<GoalPageResponse>> getGoals(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) Integer year);
+}

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -73,8 +73,7 @@ public interface GoalControllerDocs {
                                 "id": 42,
                                 "title": "토익 900점 달성",
                                 "dueDate": "2025-12-31T00:00:00",
-                                "reference": "https://toeic.ets.org",
-                                "updatedAt": "2025-05-07T12:00:00"
+                                "reference": "https://toeic.ets.org"
                               },
                               "error": null
                             }
@@ -324,7 +323,6 @@ public interface GoalControllerDocs {
           | goals[].title | String | 목표 제목 |
           | goals[].dueDate | LocalDateTime | 목표 기한 (null 가능) |
           | goals[].reference | String | 참고 자료 (null 가능) |
-          | goals[].updatedAt | LocalDateTime | 마지막 수정 시간 |
           | nextCursor | Long | 다음 페이지 요청 시 cursor로 사용할 값. **마지막 페이지이면 null** |
           | hasNext | boolean | 다음 페이지 존재 여부. false이면 더 이상 데이터 없음 |
 
@@ -380,15 +378,13 @@ public interface GoalControllerDocs {
                                   "id": 42,
                                   "title": "토익 900점 달성",
                                   "dueDate": "2025-12-31T00:00:00",
-                                  "reference": "https://toeic.ets.org",
-                                  "updatedAt": "2025-05-07T12:00:00"
+                                  "reference": "https://toeic.ets.org"
                                 },
                                 {
                                   "id": 38,
                                   "title": "운동 습관 만들기",
                                   "dueDate": "2025-06-30T00:00:00",
-                                  "reference": null,
-                                  "updatedAt": "2025-05-01T09:00:00"
+                                  "reference": null
                                 }
                               ],
                               "nextCursor": 38,
@@ -410,8 +406,7 @@ public interface GoalControllerDocs {
                                   "id": 12,
                                   "title": "독서 50권",
                                   "dueDate": null,
-                                  "reference": null,
-                                  "updatedAt": "2025-01-10T08:00:00"
+                                  "reference": null
                                 }
                               ],
                               "nextCursor": null,

--- a/src/main/java/plana/replan/domain/goal/dto/GoalCreateRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/GoalCreateRequest.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.goal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+@Schema(description = "목표 생성 요청")
+public record GoalCreateRequest(
+    @Schema(
+            description = "목표 제목",
+            example = "토익 900점 달성",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+    @Schema(description = "목표 기한 (ISO 8601 형식)", example = "2025-12-31T00:00:00")
+        LocalDateTime dueDate,
+    @Schema(description = "참고 자료 (URL 또는 메모)", example = "https://toeic.ets.org")
+        String reference) {}

--- a/src/main/java/plana/replan/domain/goal/dto/GoalPageResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/GoalPageResponse.java
@@ -1,0 +1,11 @@
+package plana.replan.domain.goal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "목표 목록 페이지 응답")
+public record GoalPageResponse(
+    @Schema(description = "목표 목록") List<GoalResponse> goals,
+    @Schema(description = "다음 페이지 요청 시 사용할 cursor. null이면 마지막 페이지.", example = "25")
+        Long nextCursor,
+    @Schema(description = "다음 페이지 존재 여부", example = "true") boolean hasNext) {}

--- a/src/main/java/plana/replan/domain/goal/dto/GoalResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/GoalResponse.java
@@ -1,0 +1,19 @@
+package plana.replan.domain.goal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import plana.replan.domain.goal.entity.Goal;
+
+@Schema(description = "목표 단건 응답")
+public record GoalResponse(
+    @Schema(description = "목표 ID", example = "42") Long id,
+    @Schema(description = "목표 제목", example = "토익 900점 달성") String title,
+    @Schema(description = "목표 기한", example = "2025-12-31T00:00:00") LocalDateTime dueDate,
+    @Schema(description = "참고 자료", example = "https://toeic.ets.org") String reference,
+    @Schema(description = "마지막 수정 시간", example = "2025-05-07T12:00:00") LocalDateTime updatedAt) {
+
+  public static GoalResponse from(Goal goal) {
+    return new GoalResponse(
+        goal.getId(), goal.getTitle(), goal.getDueDate(), goal.getReference(), goal.getUpdatedAt());
+  }
+}

--- a/src/main/java/plana/replan/domain/goal/dto/GoalResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/GoalResponse.java
@@ -9,11 +9,9 @@ public record GoalResponse(
     @Schema(description = "목표 ID", example = "42") Long id,
     @Schema(description = "목표 제목", example = "토익 900점 달성") String title,
     @Schema(description = "목표 기한", example = "2025-12-31T00:00:00") LocalDateTime dueDate,
-    @Schema(description = "참고 자료", example = "https://toeic.ets.org") String reference,
-    @Schema(description = "마지막 수정 시간", example = "2025-05-07T12:00:00") LocalDateTime updatedAt) {
+    @Schema(description = "참고 자료", example = "https://toeic.ets.org") String reference) {
 
   public static GoalResponse from(Goal goal) {
-    return new GoalResponse(
-        goal.getId(), goal.getTitle(), goal.getDueDate(), goal.getReference(), goal.getUpdatedAt());
+    return new GoalResponse(goal.getId(), goal.getTitle(), goal.getDueDate(), goal.getReference());
   }
 }

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -1,0 +1,15 @@
+package plana.replan.domain.goal.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum GoalErrorCode implements ErrorCode {
+  GOAL_NOT_FOUND(404, "목표를 찾을 수 없습니다."),
+  GOAL_ACCESS_DENIED(403, "본인의 목표만 삭제할 수 있습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
@@ -1,0 +1,29 @@
+package plana.replan.domain.goal.repository;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.user.entity.User;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+  List<Goal> findByUserOrderByIdDesc(User user, Pageable pageable);
+
+  List<Goal> findByUserAndIdLessThanOrderByIdDesc(User user, Long cursor, Pageable pageable);
+
+  @Query(
+      "SELECT g FROM Goal g WHERE g.user = :user AND FUNCTION('YEAR', g.dueDate) = :year ORDER BY g.id DESC")
+  List<Goal> findByUserAndYear(
+      @Param("user") User user, @Param("year") int year, Pageable pageable);
+
+  @Query(
+      "SELECT g FROM Goal g WHERE g.user = :user AND FUNCTION('YEAR', g.dueDate) = :year AND g.id < :cursor ORDER BY g.id DESC")
+  List<Goal> findByUserAndYearAndIdLessThan(
+      @Param("user") User user,
+      @Param("year") int year,
+      @Param("cursor") Long cursor,
+      Pageable pageable);
+}

--- a/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
@@ -15,12 +15,12 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
   List<Goal> findByUserAndIdLessThanOrderByIdDesc(User user, Long cursor, Pageable pageable);
 
   @Query(
-      "SELECT g FROM Goal g WHERE g.user = :user AND FUNCTION('YEAR', g.dueDate) = :year ORDER BY g.id DESC")
+      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year ORDER BY g.id DESC")
   List<Goal> findByUserAndYear(
       @Param("user") User user, @Param("year") int year, Pageable pageable);
 
   @Query(
-      "SELECT g FROM Goal g WHERE g.user = :user AND FUNCTION('YEAR', g.dueDate) = :year AND g.id < :cursor ORDER BY g.id DESC")
+      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year AND g.id < :cursor ORDER BY g.id DESC")
   List<Goal> findByUserAndYearAndIdLessThan(
       @Param("user") User user,
       @Param("year") int year,

--- a/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/plana/replan/domain/goal/repository/GoalRepository.java
@@ -10,18 +10,18 @@ import plana.replan.domain.user.entity.User;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
 
-  List<Goal> findByUserOrderByIdDesc(User user, Pageable pageable);
+  List<Goal> findByUserOrderByIdAsc(User user, Pageable pageable);
 
-  List<Goal> findByUserAndIdLessThanOrderByIdDesc(User user, Long cursor, Pageable pageable);
+  List<Goal> findByUserAndIdGreaterThanOrderByIdAsc(User user, Long cursor, Pageable pageable);
 
   @Query(
-      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year ORDER BY g.id DESC")
+      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year ORDER BY g.id ASC")
   List<Goal> findByUserAndYear(
       @Param("user") User user, @Param("year") int year, Pageable pageable);
 
   @Query(
-      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year AND g.id < :cursor ORDER BY g.id DESC")
-  List<Goal> findByUserAndYearAndIdLessThan(
+      "SELECT g FROM Goal g WHERE g.user = :user AND EXTRACT(YEAR FROM g.dueDate) = :year AND g.id > :cursor ORDER BY g.id ASC")
+  List<Goal> findByUserAndYearAndIdGreaterThan(
       @Param("user") User user,
       @Param("year") int year,
       @Param("cursor") Long cursor,

--- a/src/main/java/plana/replan/domain/goal/service/GoalService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalService.java
@@ -1,0 +1,81 @@
+package plana.replan.domain.goal.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.goal.dto.GoalCreateRequest;
+import plana.replan.domain.goal.dto.GoalPageResponse;
+import plana.replan.domain.goal.dto.GoalResponse;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.repository.GoalRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class GoalService {
+
+  private final GoalRepository goalRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public GoalResponse createGoal(Long userId, GoalCreateRequest request) {
+    User user = findUser(userId);
+    Goal goal =
+        Goal.builder()
+            .title(request.title())
+            .dueDate(request.dueDate())
+            .reference(request.reference())
+            .user(user)
+            .build();
+    return GoalResponse.from(goalRepository.save(goal));
+  }
+
+  @Transactional
+  public void deleteGoal(Long userId, Long goalId) {
+    Goal goal =
+        goalRepository
+            .findById(goalId)
+            .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
+    if (!goal.getUser().getId().equals(userId)) {
+      throw new CustomException(GoalErrorCode.GOAL_ACCESS_DENIED);
+    }
+    goal.softDelete();
+  }
+
+  @Transactional(readOnly = true)
+  public GoalPageResponse getGoals(Long userId, Long cursor, int size, Integer year) {
+    User user = findUser(userId);
+    PageRequest pageable = PageRequest.of(0, size + 1);
+
+    List<Goal> goals;
+    if (year != null) {
+      goals =
+          cursor == null
+              ? goalRepository.findByUserAndYear(user, year, pageable)
+              : goalRepository.findByUserAndYearAndIdLessThan(user, year, cursor, pageable);
+    } else {
+      goals =
+          cursor == null
+              ? goalRepository.findByUserOrderByIdDesc(user, pageable)
+              : goalRepository.findByUserAndIdLessThanOrderByIdDesc(user, cursor, pageable);
+    }
+
+    boolean hasNext = goals.size() > size;
+    List<GoalResponse> content = goals.stream().limit(size).map(GoalResponse::from).toList();
+    Long nextCursor = hasNext ? content.get(content.size() - 1).id() : null;
+
+    return new GoalPageResponse(content, nextCursor, hasNext);
+  }
+
+  private User findUser(Long userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/src/main/java/plana/replan/domain/goal/service/GoalService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalService.java
@@ -62,12 +62,12 @@ public class GoalService {
       goals =
           cursor == null
               ? goalRepository.findByUserAndYear(user, year, pageable)
-              : goalRepository.findByUserAndYearAndIdLessThan(user, year, cursor, pageable);
+              : goalRepository.findByUserAndYearAndIdGreaterThan(user, year, cursor, pageable);
     } else {
       goals =
           cursor == null
-              ? goalRepository.findByUserOrderByIdDesc(user, pageable)
-              : goalRepository.findByUserAndIdLessThanOrderByIdDesc(user, cursor, pageable);
+              ? goalRepository.findByUserOrderByIdAsc(user, pageable)
+              : goalRepository.findByUserAndIdGreaterThanOrderByIdAsc(user, cursor, pageable);
     }
 
     boolean hasNext = goals.size() > size;

--- a/src/main/java/plana/replan/domain/goal/service/GoalService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalService.java
@@ -15,6 +15,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +51,9 @@ public class GoalService {
 
   @Transactional(readOnly = true)
   public GoalPageResponse getGoals(Long userId, Long cursor, int size, Integer year) {
+    if (size < 1 || size > 100) {
+      throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+    }
     User user = findUser(userId);
     PageRequest pageable = PageRequest.of(0, size + 1);
 

--- a/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
+++ b/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
@@ -1,0 +1,217 @@
+package plana.replan.domain.goal.controller;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import plana.replan.domain.goal.dto.GoalPageResponse;
+import plana.replan.domain.goal.dto.GoalResponse;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.service.GoalService;
+import plana.replan.global.config.SecurityConfig;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtUtil;
+
+@WebMvcTest(GoalController.class)
+@Import(SecurityConfig.class)
+class GoalControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GoalService goalService;
+  @MockitoBean private JwtUtil jwtUtil;
+
+  private UsernamePasswordAuthenticationToken authToken(Long userId) {
+    return new UsernamePasswordAuthenticationToken(
+        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+
+  // ========== POST /api/goals ==========
+
+  @Test
+  void 목표_생성_성공() throws Exception {
+    GoalResponse mockResponse =
+        new GoalResponse(
+            42L,
+            "토익 900점 달성",
+            LocalDateTime.of(2025, 12, 31, 0, 0),
+            "https://toeic.ets.org",
+            LocalDateTime.of(2025, 5, 7, 12, 0));
+    given(goalService.createGoal(any(), any())).willReturn(mockResponse);
+
+    mockMvc
+        .perform(
+            post("/api/goals")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "title": "토익 900점 달성",
+                      "dueDate": "2025-12-31T00:00:00",
+                      "reference": "https://toeic.ets.org"
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.id").value(42))
+        .andExpect(jsonPath("$.data.title").value("토익 900점 달성"))
+        .andExpect(jsonPath("$.data.reference").value("https://toeic.ets.org"))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  void 목표_생성_title_없으면_400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/goals")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "title": ""
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").exists());
+  }
+
+  @Test
+  void 목표_생성_인증_없으면_401() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "title": "토익 900점 달성"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  // ========== DELETE /api/goals/{id} ==========
+
+  @Test
+  void 목표_삭제_성공() throws Exception {
+    willDoNothing().given(goalService).deleteGoal(any(), any());
+
+    mockMvc
+        .perform(delete("/api/goals/42").with(authentication(authToken(1L))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data").value(nullValue()))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  void 목표_삭제_목표_없으면_404() throws Exception {
+    willThrow(new CustomException(GoalErrorCode.GOAL_NOT_FOUND))
+        .given(goalService)
+        .deleteGoal(any(), any());
+
+    mockMvc
+        .perform(delete("/api/goals/999").with(authentication(authToken(1L))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("GOAL_NOT_FOUND"));
+  }
+
+  @Test
+  void 목표_삭제_타인_목표_403() throws Exception {
+    willThrow(new CustomException(GoalErrorCode.GOAL_ACCESS_DENIED))
+        .given(goalService)
+        .deleteGoal(any(), any());
+
+    mockMvc
+        .perform(delete("/api/goals/42").with(authentication(authToken(2L))))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.status").value(403))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("GOAL_ACCESS_DENIED"));
+  }
+
+  @Test
+  void 목표_삭제_인증_없으면_401() throws Exception {
+    mockMvc
+        .perform(delete("/api/goals/42"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  // ========== GET /api/goals ==========
+
+  @Test
+  void 목표_조회_성공_기본() throws Exception {
+    GoalResponse goal = new GoalResponse(42L, "토익 900점", null, null, LocalDateTime.now());
+    GoalPageResponse mockResponse = new GoalPageResponse(List.of(goal), null, false);
+    given(goalService.getGoals(any(), any(), anyInt(), any())).willReturn(mockResponse);
+
+    mockMvc
+        .perform(get("/api/goals").with(authentication(authToken(1L))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.goals[0].id").value(42))
+        .andExpect(jsonPath("$.data.goals[0].title").value("토익 900점"))
+        .andExpect(jsonPath("$.data.hasNext").value(false))
+        .andExpect(jsonPath("$.data.nextCursor").value(nullValue()));
+  }
+
+  @Test
+  void 목표_조회_성공_커서와_연도_파라미터() throws Exception {
+    GoalPageResponse mockResponse = new GoalPageResponse(List.of(), null, false);
+    given(goalService.getGoals(any(), anyLong(), anyInt(), anyInt())).willReturn(mockResponse);
+
+    mockMvc
+        .perform(
+            get("/api/goals")
+                .param("cursor", "37")
+                .param("size", "5")
+                .param("year", "2025")
+                .with(authentication(authToken(1L))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(200));
+  }
+
+  @Test
+  void 목표_조회_인증_없으면_401() throws Exception {
+    mockMvc
+        .perform(get("/api/goals"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+}

--- a/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
+++ b/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
@@ -53,11 +53,7 @@ class GoalControllerTest {
   void 목표_생성_성공() throws Exception {
     GoalResponse mockResponse =
         new GoalResponse(
-            42L,
-            "토익 900점 달성",
-            LocalDateTime.of(2025, 12, 31, 0, 0),
-            "https://toeic.ets.org",
-            LocalDateTime.of(2025, 5, 7, 12, 0));
+            42L, "토익 900점 달성", LocalDateTime.of(2025, 12, 31, 0, 0), "https://toeic.ets.org");
     given(goalService.createGoal(any(), any())).willReturn(mockResponse);
 
     mockMvc
@@ -175,7 +171,7 @@ class GoalControllerTest {
 
   @Test
   void 목표_조회_성공_기본() throws Exception {
-    GoalResponse goal = new GoalResponse(42L, "토익 900점", null, null, LocalDateTime.now());
+    GoalResponse goal = new GoalResponse(42L, "토익 900점", null, null);
     GoalPageResponse mockResponse = new GoalPageResponse(List.of(goal), null, false);
     given(goalService.getGoals(any(), any(), anyInt(), any())).willReturn(mockResponse);
 

--- a/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
@@ -1,0 +1,267 @@
+package plana.replan.domain.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+import plana.replan.domain.goal.dto.GoalCreateRequest;
+import plana.replan.domain.goal.dto.GoalPageResponse;
+import plana.replan.domain.goal.dto.GoalResponse;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.repository.GoalRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GoalServiceTest {
+
+  @Mock private GoalRepository goalRepository;
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private GoalService goalService;
+
+  // ========== createGoal ==========
+
+  @Test
+  void 목표_생성_성공() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal savedGoal = mock(Goal.class);
+    given(savedGoal.getId()).willReturn(42L);
+    given(savedGoal.getTitle()).willReturn("토익 900점 달성");
+    given(savedGoal.getDueDate()).willReturn(LocalDateTime.of(2025, 12, 31, 0, 0));
+    given(savedGoal.getReference()).willReturn("https://toeic.ets.org");
+    given(savedGoal.getUpdatedAt()).willReturn(LocalDateTime.of(2025, 5, 7, 12, 0));
+    given(goalRepository.save(any())).willReturn(savedGoal);
+
+    GoalCreateRequest request =
+        new GoalCreateRequest(
+            "토익 900점 달성", LocalDateTime.of(2025, 12, 31, 0, 0), "https://toeic.ets.org");
+
+    GoalResponse response = goalService.createGoal(1L, request);
+
+    assertThat(response.id()).isEqualTo(42L);
+    assertThat(response.title()).isEqualTo("토익 900점 달성");
+    assertThat(response.reference()).isEqualTo("https://toeic.ets.org");
+    verify(goalRepository).save(any());
+  }
+
+  @Test
+  void 목표_생성_성공_선택필드_없이() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal savedGoal = mock(Goal.class);
+    given(savedGoal.getId()).willReturn(1L);
+    given(savedGoal.getTitle()).willReturn("독서 50권");
+    given(savedGoal.getDueDate()).willReturn(null);
+    given(savedGoal.getReference()).willReturn(null);
+    given(savedGoal.getUpdatedAt()).willReturn(LocalDateTime.now());
+    given(goalRepository.save(any())).willReturn(savedGoal);
+
+    GoalCreateRequest request = new GoalCreateRequest("독서 50권", null, null);
+
+    GoalResponse response = goalService.createGoal(1L, request);
+
+    assertThat(response.title()).isEqualTo("독서 50권");
+    assertThat(response.dueDate()).isNull();
+    assertThat(response.reference()).isNull();
+  }
+
+  @Test
+  void 목표_생성_유저_없음_404() {
+    given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> goalService.createGoal(999L, new GoalCreateRequest("제목", null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  // ========== deleteGoal ==========
+
+  @Test
+  void 목표_삭제_성공() {
+    User owner = mock(User.class);
+    given(owner.getId()).willReturn(1L);
+
+    Goal goal = mock(Goal.class);
+    given(goal.getUser()).willReturn(owner);
+    given(goalRepository.findById(42L)).willReturn(Optional.of(goal));
+
+    goalService.deleteGoal(1L, 42L);
+
+    verify(goal).softDelete();
+  }
+
+  @Test
+  void 목표_삭제_목표_없음_404() {
+    given(goalRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> goalService.deleteGoal(1L, 999L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GoalErrorCode.GOAL_NOT_FOUND));
+  }
+
+  @Test
+  void 목표_삭제_타인_목표_403() {
+    User owner = mock(User.class);
+    given(owner.getId()).willReturn(2L);
+
+    Goal goal = mock(Goal.class);
+    given(goal.getUser()).willReturn(owner);
+    given(goalRepository.findById(42L)).willReturn(Optional.of(goal));
+
+    assertThatThrownBy(() -> goalService.deleteGoal(1L, 42L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GoalErrorCode.GOAL_ACCESS_DENIED));
+  }
+
+  // ========== getGoals ==========
+
+  @Test
+  void 목표_조회_첫_페이지_커서없음() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal goal = mockGoal(10L, "운동 습관", null, null);
+    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class)))
+        .willReturn(List.of(goal));
+
+    GoalPageResponse response = goalService.getGoals(1L, null, 10, null);
+
+    assertThat(response.goals()).hasSize(1);
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursor()).isNull();
+  }
+
+  @Test
+  void 목표_조회_커서_있는_페이지() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal goal = mockGoal(5L, "독서", null, null);
+    given(
+            goalRepository.findByUserAndIdLessThanOrderByIdDesc(
+                any(), any(Long.class), any(Pageable.class)))
+        .willReturn(List.of(goal));
+
+    GoalPageResponse response = goalService.getGoals(1L, 10L, 10, null);
+
+    assertThat(response.goals()).hasSize(1);
+    assertThat(response.hasNext()).isFalse();
+  }
+
+  @Test
+  void 목표_조회_연도_필터_첫_페이지() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal goal = mockGoal(10L, "토익", LocalDateTime.of(2025, 6, 1, 0, 0), null);
+    given(goalRepository.findByUserAndYear(any(), any(Integer.class), any(Pageable.class)))
+        .willReturn(List.of(goal));
+
+    GoalPageResponse response = goalService.getGoals(1L, null, 10, 2025);
+
+    assertThat(response.goals()).hasSize(1);
+  }
+
+  @Test
+  void 목표_조회_연도_필터_커서_있는_페이지() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    Goal goal = mockGoal(5L, "토익", LocalDateTime.of(2025, 6, 1, 0, 0), null);
+    given(
+            goalRepository.findByUserAndYearAndIdLessThan(
+                any(), any(Integer.class), any(Long.class), any(Pageable.class)))
+        .willReturn(List.of(goal));
+
+    GoalPageResponse response = goalService.getGoals(1L, 10L, 10, 2025);
+
+    assertThat(response.goals()).hasSize(1);
+  }
+
+  @Test
+  void 목표_조회_다음_페이지_있음() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    List<Goal> goals =
+        List.of(
+            mockGoal(10L, "목표1", null, null),
+            mockGoal(9L, "목표2", null, null),
+            mockGoal(8L, "목표3", null, null));
+    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class))).willReturn(goals);
+
+    GoalPageResponse response = goalService.getGoals(1L, null, 2, null);
+
+    assertThat(response.goals()).hasSize(2);
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.nextCursor()).isEqualTo(9L);
+  }
+
+  @Test
+  void 목표_조회_마지막_페이지() {
+    User user = mock(User.class);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    List<Goal> goals = List.of(mockGoal(10L, "목표1", null, null), mockGoal(9L, "목표2", null, null));
+    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class))).willReturn(goals);
+
+    GoalPageResponse response = goalService.getGoals(1L, null, 10, null);
+
+    assertThat(response.goals()).hasSize(2);
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursor()).isNull();
+  }
+
+  @Test
+  void 목표_조회_유저_없음_404() {
+    given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> goalService.getGoals(999L, null, 10, null))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  private Goal mockGoal(Long id, String title, LocalDateTime dueDate, String reference) {
+    Goal goal = mock(Goal.class);
+    given(goal.getId()).willReturn(id);
+    given(goal.getTitle()).willReturn(title);
+    given(goal.getDueDate()).willReturn(dueDate);
+    given(goal.getReference()).willReturn(reference);
+    given(goal.getUpdatedAt()).willReturn(LocalDateTime.now());
+    return goal;
+  }
+}

--- a/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
@@ -51,7 +51,6 @@ class GoalServiceTest {
     given(savedGoal.getTitle()).willReturn("토익 900점 달성");
     given(savedGoal.getDueDate()).willReturn(LocalDateTime.of(2025, 12, 31, 0, 0));
     given(savedGoal.getReference()).willReturn("https://toeic.ets.org");
-    given(savedGoal.getUpdatedAt()).willReturn(LocalDateTime.of(2025, 5, 7, 12, 0));
     given(goalRepository.save(any())).willReturn(savedGoal);
 
     GoalCreateRequest request =
@@ -76,7 +75,6 @@ class GoalServiceTest {
     given(savedGoal.getTitle()).willReturn("독서 50권");
     given(savedGoal.getDueDate()).willReturn(null);
     given(savedGoal.getReference()).willReturn(null);
-    given(savedGoal.getUpdatedAt()).willReturn(LocalDateTime.now());
     given(goalRepository.save(any())).willReturn(savedGoal);
 
     GoalCreateRequest request = new GoalCreateRequest("독서 50권", null, null);
@@ -153,7 +151,7 @@ class GoalServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
     Goal goal = mockGoal(10L, "운동 습관", null, null);
-    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class)))
+    given(goalRepository.findByUserOrderByIdAsc(any(), any(Pageable.class)))
         .willReturn(List.of(goal));
 
     GoalPageResponse response = goalService.getGoals(1L, null, 10, null);
@@ -170,7 +168,7 @@ class GoalServiceTest {
 
     Goal goal = mockGoal(5L, "독서", null, null);
     given(
-            goalRepository.findByUserAndIdLessThanOrderByIdDesc(
+            goalRepository.findByUserAndIdGreaterThanOrderByIdAsc(
                 any(), any(Long.class), any(Pageable.class)))
         .willReturn(List.of(goal));
 
@@ -201,7 +199,7 @@ class GoalServiceTest {
 
     Goal goal = mockGoal(5L, "토익", LocalDateTime.of(2025, 6, 1, 0, 0), null);
     given(
-            goalRepository.findByUserAndYearAndIdLessThan(
+            goalRepository.findByUserAndYearAndIdGreaterThan(
                 any(), any(Integer.class), any(Long.class), any(Pageable.class)))
         .willReturn(List.of(goal));
 
@@ -220,7 +218,7 @@ class GoalServiceTest {
             mockGoal(10L, "목표1", null, null),
             mockGoal(9L, "목표2", null, null),
             mockGoal(8L, "목표3", null, null));
-    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class))).willReturn(goals);
+    given(goalRepository.findByUserOrderByIdAsc(any(), any(Pageable.class))).willReturn(goals);
 
     GoalPageResponse response = goalService.getGoals(1L, null, 2, null);
 
@@ -235,7 +233,7 @@ class GoalServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
     List<Goal> goals = List.of(mockGoal(10L, "목표1", null, null), mockGoal(9L, "목표2", null, null));
-    given(goalRepository.findByUserOrderByIdDesc(any(), any(Pageable.class))).willReturn(goals);
+    given(goalRepository.findByUserOrderByIdAsc(any(), any(Pageable.class))).willReturn(goals);
 
     GoalPageResponse response = goalService.getGoals(1L, null, 10, null);
 
@@ -282,7 +280,6 @@ class GoalServiceTest {
     given(goal.getTitle()).willReturn(title);
     given(goal.getDueDate()).willReturn(dueDate);
     given(goal.getReference()).willReturn(reference);
-    given(goal.getUpdatedAt()).willReturn(LocalDateTime.now());
     return goal;
   }
 }

--- a/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
@@ -28,6 +28,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -253,6 +254,26 @@ class GoalServiceTest {
             e ->
                 assertThat(((CustomException) e).getErrorCode())
                     .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  @Test
+  void 목표_조회_size_0이면_400() {
+    assertThatThrownBy(() -> goalService.getGoals(1L, null, 0, null))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GlobalErrorCode.INVALID_INPUT));
+  }
+
+  @Test
+  void 목표_조회_size_101이면_400() {
+    assertThatThrownBy(() -> goalService.getGoals(1L, null, 101, null))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GlobalErrorCode.INVALID_INPUT));
   }
 
   private Goal mockGoal(Long id, String title, LocalDateTime dueDate, String reference) {


### PR DESCRIPTION
## Summary
- `POST /api/goals` — 목표 생성
- `DELETE /api/goals/{id}` — 목표 삭제 (소프트 삭제)
- `GET /api/goals` — 목표 목록 조회 (커서 기반 무한스크롤, 연도 필터 지원)

## 변경 사항
- `GoalRepository`: 커서 기반 페이지네이션 쿼리 (id DESC)
- `GoalService`: 생성/삭제/조회 비즈니스 로직
- `GoalControllerDocs`: Swagger 어노테이션 전용 인터페이스 (Controller와 분리)
- `GoalController`: HTTP 매핑 + 메서드 구현만 담당
- DTO: `GoalCreateRequest`, `GoalResponse`, `GoalPageResponse` (@Schema 적용)
- `GoalErrorCode`: GOAL_NOT_FOUND(404), GOAL_ACCESS_DENIED(403)
- `CLAUDE.md`: Swagger 작성 규칙 추가

## 무한스크롤 방식
커서 기반 페이지네이션 (Keyset Pagination)
- `cursor` = 마지막으로 받은 목표의 id (응답의 `nextCursor` 그대로 전달)
- `hasNext=false` 또는 `nextCursor=null`이면 마지막 페이지

## Test plan
- [ ] `POST /api/goals` — 목표 생성 성공 (200)
- [ ] `POST /api/goals` — title 누락 시 400
- [ ] `DELETE /api/goals/{id}` — 본인 목표 삭제 성공 (200)
- [ ] `DELETE /api/goals/{id}` — 타인 목표 삭제 시 403
- [ ] `DELETE /api/goals/{id}` — 존재하지 않는 id 삭제 시 404
- [ ] `GET /api/goals` — 첫 페이지 조회 (cursor 없음)
- [ ] `GET /api/goals?cursor=37` — 다음 페이지 조회
- [ ] `GET /api/goals?year=2025` — 연도 필터 조회
- [ ] 마지막 페이지에서 `hasNext=false`, `nextCursor=null` 확인

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 목표 관리 API 추가: 목표 생성, 삭제, 조회 기능 제공
  * 커서 기반 페이지네이션 및 연도별 필터링을 통한 목표 목록 조회 지원

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/76)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->