### PR TITLE
V0.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+jar {
+    enabled = false
+}
+
 hibernate {
     enhancement {
         enableLazyInitialization = true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,3 +1,5 @@
+debug: true
+
 spring:
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## 변경 사항
>  plain JAR 문제: ./gradlew build가 bootJar(100MB)와 plain JAR(110KB) 두 개를 생성하는데, Dockerfile의 COPY *.jar app.jar가 불명확하게 동작 → plain JAR이 배포되면 Flyway 없음
- build.gradle에 jar { enabled = false } 추가로 plain JAR 생성 자체를 막아서 해결
