### PR TITLE
fix: flyway-core를 spring-boot-starter-flyway로 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.4.1'
     implementation platform('software.amazon.awssdk:bom:2.43.1')
     implementation 'software.amazon.awssdk:s3'
-    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.flywaydb:flyway-database-postgresql'
 
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,5 +1,3 @@
-debug: true
-
 spring:
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타



## 변경 사항
> Spring Boot 4.0에서 flyway-core만 직접 추가하면 FlywayAutoConfiguration이 auto-configuration imports 파일에 등록되지 않아 Flyway가 실행되지 않는 문제. spring-boot-starter-flyway를 사용하면 Spring Boot의 자동 구성 메커니즘을 통해 FlywayAutoConfiguration이 정상적으로 등록된다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 마이그레이션 라이브러리 의존성을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/101)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->