### PR TITLE
Feat: ToDo 생성

### DIFF
--- a/src/main/java/plana/replan/ReplanApplication.java
+++ b/src/main/java/plana/replan/ReplanApplication.java
@@ -2,8 +2,10 @@ package plana.replan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ReplanApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -1,0 +1,31 @@
+package plana.replan.domain.routine.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.service.RoutineService;
+import plana.replan.global.common.ApiResult;
+
+@RestController
+@RequestMapping("/api/routines")
+@RequiredArgsConstructor
+public class RoutineController implements RoutineControllerDocs {
+
+  private final RoutineService routineService;
+
+  @Override
+  @PostMapping
+  public ResponseEntity<ApiResult<RoutineResponseDto>> createRoutine(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody RoutineCreateRequestDto request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResult.ok(routineService.createRoutine(userId, request)));
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -1,0 +1,251 @@
+package plana.replan.domain.routine.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "Routine", description = "루틴 관련 API. 모든 요청에 JWT 인증 필수.")
+public interface RoutineControllerDocs {
+
+  @Operation(
+      summary = "루틴 생성",
+      description =
+          """
+          새로운 루틴을 생성합니다. 루틴 타입에 따라 반복 날짜 규칙이 달라집니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          ---
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 루틴 제목 | `"영어 단어 외우기"` |
+          | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
+          | dueDate | ❌ 선택 | string | 반복 마감일 (ISO 8601 형식). 이 날짜까지 반복 | `"2025-12-31T00:00:00"` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요 | `21` |
+          | tagId | ❌ 선택 | integer | 태그 ID | `1` |
+          | goalId | ❌ 선택 | integer | 목표 ID | `2` |
+
+          > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
+
+          ---
+
+          ### routineDate 규칙
+
+          | routineType | routineDate 의미 | 유효 범위 |
+          |-------------|-----------------|-----------|
+          | `DAILY` | 사용 안 함 (무시) | — |
+          | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
+          | `MONTHLY` | 반복할 일자 | 1 ~ 31 |
+
+          **WEEKLY 예시**: 월+수+금 → 1+4+16 = **21**
+
+          ---
+
+          ### 주의사항
+          - `WEEKLY` 또는 `MONTHLY` 타입에서 `routineDate`가 유효 범위를 벗어나면 400 반환
+          - `tagId`가 제공된 경우 해당 태그가 존재하지 않으면 404 반환
+          - `goalId`가 제공된 경우 해당 목표가 존재하지 않으면 404 반환
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "루틴 생성 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 201,
+                              "success": true,
+                              "data": {
+                                "routineId": 1,
+                                "title": "영어 단어 외우기",
+                                "dueDate": "2025-12-31T00:00:00",
+                                "routineType": "WEEKLY",
+                                "routineDate": 21,
+                                "tagId": 1,
+                                "goalId": 2
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title/routineType 누락, 또는 routineDate 범위 오류)",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "title 누락",
+                      value =
+                          """
+                          {
+                            "status": 400,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "INVALID_INPUT",
+                              "message": "제목은 필수입니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "routineDate 범위 오류",
+                      value =
+                          """
+                          {
+                            "status": 400,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "ROUTINE_INVALID_DATE",
+                              "message": "유효하지 않은 반복 날짜입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저, 태그 또는 목표를 찾을 수 없음",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "태그 없음",
+                      value =
+                          """
+                          {
+                            "status": 404,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "TAG_NOT_FOUND",
+                              "message": "태그를 찾을 수 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "목표 없음",
+                      value =
+                          """
+                          {
+                            "status": 404,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "GOAL_NOT_FOUND",
+                              "message": "목표를 찾을 수 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<RoutineResponseDto>> createRoutine(
+      @AuthenticationPrincipal Long userId,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples = {
+                        @ExampleObject(
+                            name = "WEEKLY — 전체 필드",
+                            value =
+                                """
+                                {
+                                  "title": "영어 단어 외우기",
+                                  "dueDate": "2025-12-31T00:00:00",
+                                  "routineType": "WEEKLY",
+                                  "routineDate": 21,
+                                  "tagId": 1,
+                                  "goalId": 2
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "DAILY — 필수 필드만",
+                            summary = "DAILY는 routineDate 불필요",
+                            value =
+                                """
+                                {
+                                  "title": "아침 스트레칭",
+                                  "routineType": "DAILY"
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "MONTHLY — 매월 15일",
+                            value =
+                                """
+                                {
+                                  "title": "월간 회고",
+                                  "dueDate": "2025-12-31T00:00:00",
+                                  "routineType": "MONTHLY",
+                                  "routineDate": 15
+                                }
+                                """)
+                      }))
+          @RequestBody
+          RoutineCreateRequestDto request);
+}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
@@ -1,0 +1,31 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import plana.replan.domain.routine.entity.RoutineType;
+
+@Schema(description = "루틴 생성 요청")
+public record RoutineCreateRequestDto(
+    @Schema(
+            description = "루틴 제목",
+            example = "영어 단어 외우기",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+    @Schema(description = "반복 마감일 (ISO 8601 형식)", example = "2025-12-31T00:00:00")
+        LocalDateTime dueDate,
+    @Schema(
+            description = "반복 유형 (DAILY / WEEKLY / MONTHLY)",
+            example = "WEEKLY",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "반복 유형은 필수입니다.")
+        RoutineType routineType,
+    @Schema(
+            description =
+                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요.",
+            example = "21")
+        Integer routineDate,
+    @Schema(description = "태그 ID", example = "1") Long tagId,
+    @Schema(description = "목표 ID", example = "2") Long goalId) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -1,0 +1,31 @@
+package plana.replan.domain.routine.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineType;
+
+@Getter
+@AllArgsConstructor
+public class RoutineResponseDto {
+
+  private Long routineId;
+  private String title;
+  private LocalDateTime dueDate;
+  private RoutineType routineType;
+  private Integer routineDate;
+  private Long tagId;
+  private Long goalId;
+
+  public static RoutineResponseDto from(Routine routine) {
+    return new RoutineResponseDto(
+        routine.getId(),
+        routine.getTitle(),
+        routine.getDueDate(),
+        routine.getRoutineType(),
+        routine.getRoutineDate(),
+        routine.getTag() != null ? routine.getTag().getId() : null,
+        routine.getGoal() != null ? routine.getGoal().getId() : null);
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/entity/Routine.java
+++ b/src/main/java/plana/replan/domain/routine/entity/Routine.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.user.entity.User;
 import plana.replan.global.entity.BaseTimeEntity;
 
@@ -41,6 +42,10 @@ public class Routine extends BaseTimeEntity {
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_id")
+  private Tag tag;
+
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "goal_id")
   private Goal goal;
 
@@ -51,12 +56,14 @@ public class Routine extends BaseTimeEntity {
       RoutineType routineType,
       Integer routineDate,
       User user,
+      Tag tag,
       Goal goal) {
     this.title = Objects.requireNonNull(title, "제목은 필수입니다.");
     this.user = Objects.requireNonNull(user, "유저는 필수입니다.");
     this.dueDate = dueDate;
     this.routineType = routineType;
     this.routineDate = routineDate;
+    this.tag = tag;
     this.goal = goal;
   }
 }

--- a/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
+++ b/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.routine.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoutineErrorCode implements ErrorCode {
+  ROUTINE_INVALID_DATE(400, "유효하지 않은 반복 날짜입니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -1,0 +1,6 @@
+package plana.replan.domain.routine.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.routine.entity.Routine;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {}

--- a/src/main/java/plana/replan/domain/routine/scheduler/RoutineTodoScheduler.java
+++ b/src/main/java/plana/replan/domain/routine/scheduler/RoutineTodoScheduler.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.routine.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import plana.replan.domain.routine.service.RoutineService;
+
+@Component
+@RequiredArgsConstructor
+public class RoutineTodoScheduler {
+
+  private final RoutineService routineService;
+
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void generateDailyTodos() {
+    routineService.generateDailyTodos();
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -1,8 +1,8 @@
 package plana.replan.domain.routine.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,8 +30,7 @@ import plana.replan.global.exception.CustomException;
 @RequiredArgsConstructor
 public class RoutineService {
 
-  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
+  private final Clock clock;
   private final RoutineRepository routineRepository;
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
@@ -89,7 +88,7 @@ public class RoutineService {
   }
 
   private boolean isTodayMatch(Routine routine) {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     return switch (routine.getRoutineType()) {
       case DAILY -> true;
       case WEEKLY -> {
@@ -102,7 +101,7 @@ public class RoutineService {
   }
 
   private void createTodoFromRoutine(Routine routine) {
-    LocalDateTime todayStart = LocalDate.now(KST).atStartOfDay();
+    LocalDateTime todayStart = LocalDate.now(clock).atStartOfDay();
     if (todoRepository.existsByRoutineAndDueDateBetween(
         routine, todayStart, todayStart.plusDays(1))) {
       return;

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -62,13 +62,15 @@ public class RoutineService {
               .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
     }
 
+    Integer routineDate = request.routineType() == RoutineType.DAILY ? null : request.routineDate();
+
     Routine routine =
         routineRepository.save(
             Routine.builder()
                 .title(request.title())
                 .dueDate(request.dueDate())
                 .routineType(request.routineType())
-                .routineDate(request.routineDate())
+                .routineDate(routineDate)
                 .user(user)
                 .tag(tag)
                 .goal(goal)

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -1,0 +1,82 @@
+package plana.replan.domain.routine.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.repository.GoalRepository;
+import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineService {
+
+  private final RoutineRepository routineRepository;
+  private final UserRepository userRepository;
+  private final TagRepository tagRepository;
+  private final GoalRepository goalRepository;
+
+  @Transactional
+  public RoutineResponseDto createRoutine(Long userId, RoutineCreateRequestDto request) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    validateRoutineDate(request.routineType(), request.routineDate());
+
+    Tag tag = null;
+    if (request.tagId() != null) {
+      tag =
+          tagRepository
+              .findById(request.tagId())
+              .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
+    }
+
+    Goal goal = null;
+    if (request.goalId() != null) {
+      goal =
+          goalRepository
+              .findById(request.goalId())
+              .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
+    }
+
+    Routine routine =
+        Routine.builder()
+            .title(request.title())
+            .dueDate(request.dueDate())
+            .routineType(request.routineType())
+            .routineDate(request.routineDate())
+            .user(user)
+            .tag(tag)
+            .goal(goal)
+            .build();
+
+    return RoutineResponseDto.from(routineRepository.save(routine));
+  }
+
+  private void validateRoutineDate(RoutineType routineType, Integer routineDate) {
+    if (routineType == RoutineType.WEEKLY) {
+      if (routineDate == null || routineDate < 1 || routineDate > 127) {
+        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
+      }
+    } else if (routineType == RoutineType.MONTHLY) {
+      if (routineDate == null || routineDate < 1 || routineDate > 31) {
+        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
+      }
+    }
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -1,5 +1,9 @@
 package plana.replan.domain.routine.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +19,8 @@ import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
@@ -24,10 +30,13 @@ import plana.replan.global.exception.CustomException;
 @RequiredArgsConstructor
 public class RoutineService {
 
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
   private final RoutineRepository routineRepository;
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
   private final GoalRepository goalRepository;
+  private final TodoRepository todoRepository;
 
   @Transactional
   public RoutineResponseDto createRoutine(Long userId, RoutineCreateRequestDto request) {
@@ -55,17 +64,59 @@ public class RoutineService {
     }
 
     Routine routine =
-        Routine.builder()
-            .title(request.title())
-            .dueDate(request.dueDate())
-            .routineType(request.routineType())
-            .routineDate(request.routineDate())
-            .user(user)
-            .tag(tag)
-            .goal(goal)
-            .build();
+        routineRepository.save(
+            Routine.builder()
+                .title(request.title())
+                .dueDate(request.dueDate())
+                .routineType(request.routineType())
+                .routineDate(request.routineDate())
+                .user(user)
+                .tag(tag)
+                .goal(goal)
+                .build());
 
-    return RoutineResponseDto.from(routineRepository.save(routine));
+    if (isTodayMatch(routine)) {
+      createTodoFromRoutine(routine);
+    }
+
+    return RoutineResponseDto.from(routine);
+  }
+
+  @Transactional
+  public void generateDailyTodos() {
+    List<Routine> routines = routineRepository.findAll();
+    routines.stream().filter(this::isTodayMatch).forEach(this::createTodoFromRoutine);
+  }
+
+  private boolean isTodayMatch(Routine routine) {
+    LocalDate today = LocalDate.now(KST);
+    return switch (routine.getRoutineType()) {
+      case DAILY -> true;
+      case WEEKLY -> {
+        int dayBit = 1 << (today.getDayOfWeek().getValue() - 1);
+        yield routine.getRoutineDate() != null && (routine.getRoutineDate() & dayBit) != 0;
+      }
+      case MONTHLY -> routine.getRoutineDate() != null
+          && routine.getRoutineDate() == today.getDayOfMonth();
+    };
+  }
+
+  private void createTodoFromRoutine(Routine routine) {
+    LocalDateTime todayStart = LocalDate.now(KST).atStartOfDay();
+    if (todoRepository.existsByRoutineAndDueDateBetween(
+        routine, todayStart, todayStart.plusDays(1))) {
+      return;
+    }
+    todoRepository.save(
+        Todo.builder()
+            .title(routine.getTitle())
+            .dueDate(todayStart)
+            .isPinned(false)
+            .user(routine.getUser())
+            .tag(routine.getTag())
+            .goal(routine.getGoal())
+            .routine(routine)
+            .build());
   }
 
   private void validateRoutineDate(RoutineType routineType, Integer routineDate) {

--- a/src/main/java/plana/replan/domain/tag/exception/TagErrorCode.java
+++ b/src/main/java/plana/replan/domain/tag/exception/TagErrorCode.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.tag.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum TagErrorCode implements ErrorCode {
+  TAG_NOT_FOUND(404, "태그를 찾을 수 없습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
+++ b/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
@@ -1,0 +1,6 @@
+package plana.replan.domain.tag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.tag.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {}

--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -1,0 +1,99 @@
+package plana.replan.domain.todo.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.todo.dto.TodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.service.TodoService;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "Todo", description = "투두 관련 API")
+@RestController
+@RequestMapping("/api/todos")
+@RequiredArgsConstructor
+public class TodoController {
+
+  private final TodoService todoService;
+
+  @Operation(
+      summary = "투두 생성",
+      description =
+          """
+                    **호출 주체**: AccessToken을 보유한 인증 사용자
+
+                    **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+                    **비즈니스 로직**
+                    1. JwtFilter에서 AccessToken 검증 후 userId를 SecurityContext에 저장
+                    2. @AuthenticationPrincipal 로 userId 주입
+                    3. title(필수), due_date(선택), tag_id(선택)를 받아 투두 생성
+                    4. tag_id가 주어진 경우 태그 존재 여부 확인 후 연결
+
+                    **참고**: tag_id가 제공된 경우 해당 태그가 존재하지 않으면 404 반환
+                    """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "투두 생성 성공"),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title 누락)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                                  {
+                                    "status": 400,
+                                    "success": false,
+                                    "data": null,
+                                    "error": {
+                                      "code": "VALIDATION_ERROR",
+                                      "message": "제목은 필수입니다.",
+                                      "detail": null
+                                    }
+                                  }
+                                  """))),
+    @ApiResponse(responseCode = "401", description = "AccessToken 없음 또는 유효하지 않은 토큰"),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저 또는 태그를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                                  {
+                                    "status": 404,
+                                    "success": false,
+                                    "data": null,
+                                    "error": {
+                                      "code": "TAG_NOT_FOUND",
+                                      "message": "태그를 찾을 수 없습니다.",
+                                      "detail": null
+                                    }
+                                  }
+                                  """)))
+  })
+  @PostMapping("/create")
+  public ResponseEntity<ApiResult<TodoResponseDto>> createTodo(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequestDto request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResult.ok(todoService.createTodo(userId, request)));
+  }
+}

--- a/src/main/java/plana/replan/domain/todo/dto/TodoCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoCreateRequestDto.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.todo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoCreateRequestDto {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  private LocalDateTime dueDate;
+
+  private Long tagId;
+}

--- a/src/main/java/plana/replan/domain/todo/dto/TodoResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoResponseDto.java
@@ -1,0 +1,26 @@
+package plana.replan.domain.todo.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import plana.replan.domain.todo.entity.Todo;
+
+@Getter
+@AllArgsConstructor
+public class TodoResponseDto {
+
+  private Long todoId;
+  private String title;
+  private LocalDateTime dueDate;
+  private boolean isCompleted;
+  private Long tagId;
+
+  public static TodoResponseDto from(Todo todo) {
+    return new TodoResponseDto(
+        todo.getId(),
+        todo.getTitle(),
+        todo.getDueDate(),
+        todo.isCompleted(),
+        todo.getTag() != null ? todo.getTag().getId() : null);
+  }
+}

--- a/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.todo.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum TodoErrorCode implements ErrorCode {
+  TODO_NOT_FOUND(404, "투두를 찾을 수 없습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -1,6 +1,11 @@
 package plana.replan.domain.todo.repository;
 
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.todo.entity.Todo;
 
-public interface TodoRepository extends JpaRepository<Todo, Long> {}
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+  boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -1,0 +1,6 @@
+package plana.replan.domain.todo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.todo.entity.Todo;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {}

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -1,0 +1,56 @@
+package plana.replan.domain.todo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.dto.TodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+
+  private final TodoRepository todoRepository;
+  private final UserRepository userRepository;
+  private final TagRepository tagRepository;
+
+  @Transactional
+  public TodoResponseDto createTodo(Long userId, TodoCreateRequestDto request) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    Tag tag = null;
+    if (request.getTagId() != null) {
+      tag =
+          tagRepository
+              .findById(request.getTagId())
+              .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
+    }
+
+    Todo todo =
+        Todo.builder()
+            .title(request.getTitle())
+            .dueDate(request.getDueDate())
+            .isPinned(false)
+            .user(user)
+            .tag(tag)
+            .build();
+
+    todoRepository.save(todo);
+    return TodoResponseDto.from(todo);
+  }
+}

--- a/src/main/java/plana/replan/global/config/ClockConfig.java
+++ b/src/main/java/plana/replan/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package plana.replan.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.system(ZoneId.of("Asia/Seoul"));
+  }
+}

--- a/src/main/resources/db/migration/V3__add_tag_id_to_routine.sql
+++ b/src/main/resources/db/migration/V3__add_tag_id_to_routine.sql
@@ -1,2 +1,2 @@
 ALTER TABLE routine
-    ADD COLUMN tag_id BIGINT REFERENCES tag (id);
+    ADD COLUMN tag_id BIGINT REFERENCES tag (id) ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V3__add_tag_id_to_routine.sql
+++ b/src/main/resources/db/migration/V3__add_tag_id_to_routine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE routine
+    ADD COLUMN tag_id BIGINT REFERENCES tag (id);

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -1,0 +1,295 @@
+package plana.replan.domain.routine.controller;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.service.RoutineService;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.global.config.SecurityConfig;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtUtil;
+
+@WebMvcTest(RoutineController.class)
+@Import(SecurityConfig.class)
+class RoutineControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private RoutineService routineService;
+
+  @MockitoBean private JwtUtil jwtUtil;
+
+  private UsernamePasswordAuthenticationToken authToken(Long userId) {
+    return new UsernamePasswordAuthenticationToken(
+        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+
+  @Test
+  @DisplayName("인증 없이 루틴 생성 호출: Security가 차단, 401 반환")
+  void createRoutine_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "루틴", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("DAILY 루틴 생성 성공: status=201, 필수 필드 검증")
+  void createRoutine_daily_success() throws Exception {
+    given(routineService.createRoutine(any(), any()))
+        .willReturn(
+            new RoutineResponseDto(1L, "아침 스트레칭", null, RoutineType.DAILY, null, null, null));
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "아침 스트레칭", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.routineId").value(1))
+        .andExpect(jsonPath("$.data.title").value("아침 스트레칭"))
+        .andExpect(jsonPath("$.data.routineType").value("DAILY"))
+        .andExpect(jsonPath("$.data.routineDate").value(nullValue()))
+        .andExpect(jsonPath("$.data.tagId").value(nullValue()))
+        .andExpect(jsonPath("$.data.goalId").value(nullValue()))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("WEEKLY 루틴 생성 성공 (전체 필드): routineDate=21, tagId/goalId 포함")
+  void createRoutine_weekly_success_fullFields() throws Exception {
+    LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
+    given(routineService.createRoutine(any(), any()))
+        .willReturn(
+            new RoutineResponseDto(2L, "영어 단어", dueDate, RoutineType.WEEKLY, 21, 5L, 2L));
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "title": "영어 단어",
+                      "dueDate": "2025-12-31T00:00:00",
+                      "routineType": "WEEKLY",
+                      "routineDate": 21,
+                      "tagId": 5,
+                      "goalId": 2
+                    }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.routineId").value(2))
+        .andExpect(jsonPath("$.data.routineType").value("WEEKLY"))
+        .andExpect(jsonPath("$.data.routineDate").value(21))
+        .andExpect(jsonPath("$.data.tagId").value(5))
+        .andExpect(jsonPath("$.data.goalId").value(2))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("MONTHLY 루틴 생성 성공: routineDate=15")
+  void createRoutine_monthly_success() throws Exception {
+    given(routineService.createRoutine(any(), any()))
+        .willReturn(
+            new RoutineResponseDto(3L, "월간 회고", null, RoutineType.MONTHLY, 15, null, null));
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "월간 회고", "routineType": "MONTHLY", "routineDate": 15 }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.routineType").value("MONTHLY"))
+        .andExpect(jsonPath("$.data.routineDate").value(15));
+  }
+
+  @Test
+  @DisplayName("title 누락: status=400, error.code=INVALID_INPUT")
+  void createRoutine_missingTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("title 빈 문자열: status=400, error.code=INVALID_INPUT")
+  void createRoutine_blankTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("routineType 누락: status=400, error.code=INVALID_INPUT")
+  void createRoutine_missingRoutineType() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "루틴" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("routineType에 잘못된 값: JSON 파싱 실패, status=400, error.code=INVALID_INPUT")
+  void createRoutine_invalidRoutineType() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "루틴", "routineType": "INVALID_TYPE" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("routineDate 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
+  void createRoutine_invalidRoutineDate() throws Exception {
+    willThrow(new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE))
+        .given(routineService)
+        .createRoutine(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "루틴", "routineType": "WEEKLY", "routineDate": 128 }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("ROUTINE_INVALID_DATE"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 tagId: status=404, error.code=TAG_NOT_FOUND")
+  void createRoutine_tagNotFound() throws Exception {
+    willThrow(new CustomException(TagErrorCode.TAG_NOT_FOUND))
+        .given(routineService)
+        .createRoutine(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "루틴", "routineType": "DAILY", "tagId": 999 }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("TAG_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 goalId: status=404, error.code=GOAL_NOT_FOUND")
+  void createRoutine_goalNotFound() throws Exception {
+    willThrow(new CustomException(GoalErrorCode.GOAL_NOT_FOUND))
+        .given(routineService)
+        .createRoutine(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "루틴", "routineType": "DAILY", "goalId": 999 }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("GOAL_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("userId가 DB에 없는 경우: status=404, error.code=USER_NOT_FOUND")
+  void createRoutine_userNotFound() throws Exception {
+    willThrow(new CustomException(UserErrorCode.USER_NOT_FOUND))
+        .given(routineService)
+        .createRoutine(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/routines")
+                .with(authentication(authToken(999L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "루틴", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("USER_NOT_FOUND"));
+  }
+}

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -54,7 +54,8 @@ class RoutineControllerTest {
         .perform(
             post("/api/routines")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                .content(
+                    """
                     { "title": "루틴", "routineType": "DAILY" }
                     """))
         .andExpect(status().isUnauthorized())
@@ -95,8 +96,7 @@ class RoutineControllerTest {
   void createRoutine_weekly_success_fullFields() throws Exception {
     LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
     given(routineService.createRoutine(any(), any()))
-        .willReturn(
-            new RoutineResponseDto(2L, "영어 단어", dueDate, RoutineType.WEEKLY, 21, 5L, 2L));
+        .willReturn(new RoutineResponseDto(2L, "영어 단어", dueDate, RoutineType.WEEKLY, 21, 5L, 2L));
 
     mockMvc
         .perform(
@@ -128,8 +128,7 @@ class RoutineControllerTest {
   @DisplayName("MONTHLY 루틴 생성 성공: routineDate=15")
   void createRoutine_monthly_success() throws Exception {
     given(routineService.createRoutine(any(), any()))
-        .willReturn(
-            new RoutineResponseDto(3L, "월간 회고", null, RoutineType.MONTHLY, 15, null, null));
+        .willReturn(new RoutineResponseDto(3L, "월간 회고", null, RoutineType.MONTHLY, 15, null, null));
 
     mockMvc
         .perform(
@@ -153,7 +152,8 @@ class RoutineControllerTest {
             post("/api/routines")
                 .with(authentication(authToken(1L)))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                .content(
+                    """
                     { "routineType": "DAILY" }
                     """))
         .andExpect(status().isBadRequest())

--- a/src/test/java/plana/replan/domain/routine/scheduler/RoutineTodoSchedulerTest.java
+++ b/src/test/java/plana/replan/domain/routine/scheduler/RoutineTodoSchedulerTest.java
@@ -1,0 +1,25 @@
+package plana.replan.domain.routine.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import plana.replan.domain.routine.service.RoutineService;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineTodoSchedulerTest {
+
+  @Mock private RoutineService routineService;
+
+  @InjectMocks private RoutineTodoScheduler scheduler;
+
+  @Test
+  void 자정_스케줄러_실행시_generateDailyTodos_호출됨() {
+    scheduler.generateDailyTodos();
+
+    verify(routineService).generateDailyTodos();
+  }
+}

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -31,6 +31,7 @@ import plana.replan.domain.tag.repository.TagRepository;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;
+import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
@@ -42,6 +43,7 @@ class RoutineServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private TagRepository tagRepository;
   @Mock private GoalRepository goalRepository;
+  @Mock private TodoRepository todoRepository;
 
   @InjectMocks private RoutineService routineService;
 
@@ -193,8 +195,7 @@ class RoutineServiceTest {
     assertThatThrownBy(
             () ->
                 routineService.createRoutine(
-                    1L,
-                    new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 0, null, null)))
+                    1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 0, null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -316,8 +317,7 @@ class RoutineServiceTest {
             () ->
                 routineService.createRoutine(
                     1L,
-                    new RoutineCreateRequestDto(
-                        "루틴", null, RoutineType.DAILY, null, 999L, null)))
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.DAILY, null, 999L, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -336,8 +336,7 @@ class RoutineServiceTest {
             () ->
                 routineService.createRoutine(
                     1L,
-                    new RoutineCreateRequestDto(
-                        "루틴", null, RoutineType.DAILY, null, null, 999L)))
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.DAILY, null, null, 999L)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -4,11 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,10 +34,11 @@ import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.entity.TagColor;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;
-import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
@@ -39,6 +46,11 @@ import plana.replan.global.exception.CustomException;
 @ExtendWith(MockitoExtension.class)
 class RoutineServiceTest {
 
+  // 2024-01-15: Monday(DayOfWeek=1, bit=1), day of month=15
+  private static final LocalDate TEST_DATE = LocalDate.of(2024, 1, 15);
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  @Mock private Clock clock;
   @Mock private RoutineRepository routineRepository;
   @Mock private UserRepository userRepository;
   @Mock private TagRepository tagRepository;
@@ -46,6 +58,13 @@ class RoutineServiceTest {
   @Mock private TodoRepository todoRepository;
 
   @InjectMocks private RoutineService routineService;
+
+  @BeforeEach
+  void setUpClock() {
+    // 예외 발생 테스트에서는 clock이 호출되지 않으므로 lenient 처리
+    lenient().when(clock.instant()).thenReturn(TEST_DATE.atStartOfDay(KST).toInstant());
+    lenient().when(clock.getZone()).thenReturn(KST);
+  }
 
   private User testUser() {
     User user =
@@ -344,5 +363,148 @@ class RoutineServiceTest {
                     .isEqualTo(GoalErrorCode.GOAL_NOT_FOUND));
 
     verify(routineRepository, never()).save(any());
+  }
+
+  // ========== Todo 즉시 생성 (createRoutine) ==========
+
+  @Test
+  void 루틴_생성_DAILY_Todo_즉시_생성됨() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("아침 스트레칭", null, RoutineType.DAILY, null, null, null));
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_오늘_요일_포함_Todo_생성됨() {
+    // TEST_DATE = Monday(bit=1). routineDate=1 → Monday만 포함 → 일치
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 1, null, null));
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_오늘_요일_미포함_Todo_생성_안됨() {
+    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 포함 → 불일치
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 2, null, null));
+
+    verify(todoRepository, never()).save(any(Todo.class));
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_오늘_날짜_일치_Todo_생성됨() {
+    // TEST_DATE = 15일. routineDate=15 → 일치
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 15, null, null));
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_오늘_날짜_불일치_Todo_생성_안됨() {
+    // TEST_DATE = 15일. routineDate=16 → 불일치
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 16, null, null));
+
+    verify(todoRepository, never()).save(any(Todo.class));
+  }
+
+  @Test
+  void 루틴_생성_오늘_이미_Todo_존재시_중복_생성_안됨() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
+
+    routineService.createRoutine(
+        1L, new RoutineCreateRequestDto("아침 스트레칭", null, RoutineType.DAILY, null, null, null));
+
+    verify(todoRepository, never()).save(any(Todo.class));
+  }
+
+  // ========== generateDailyTodos (배치) ==========
+
+  private Routine buildRoutine(RoutineType type, Integer routineDate) {
+    return Routine.builder()
+        .title("테스트 루틴")
+        .routineType(type)
+        .routineDate(routineDate)
+        .user(testUser())
+        .build();
+  }
+
+  @Test
+  void generateDailyTodos_DAILY_루틴_Todo_생성됨() {
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.DAILY, null)));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_WEEKLY_오늘_요일_포함_Todo_생성됨() {
+    // TEST_DATE = Monday(bit=1). routineDate=1 → 일치
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.WEEKLY, 1)));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_WEEKLY_오늘_요일_미포함_Todo_생성_안됨() {
+    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 → 불일치
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.WEEKLY, 2)));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).save(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_MONTHLY_오늘_날짜_일치_Todo_생성됨() {
+    // TEST_DATE = 15일. routineDate=15 → 일치
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.MONTHLY, 15)));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_MONTHLY_오늘_날짜_불일치_Todo_생성_안됨() {
+    // TEST_DATE = 15일. routineDate=16 → 불일치
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.MONTHLY, 16)));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).save(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_이미_오늘_Todo_존재시_중복_생성_안됨() {
+    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.DAILY, null)));
+    given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).save(any(Todo.class));
   }
 }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -1,0 +1,349 @@
+package plana.replan.domain.routine.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.repository.GoalRepository;
+import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.entity.TagColor;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineServiceTest {
+
+  @Mock private RoutineRepository routineRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private TagRepository tagRepository;
+  @Mock private GoalRepository goalRepository;
+
+  @InjectMocks private RoutineService routineService;
+
+  private User testUser() {
+    User user =
+        User.builder()
+            .email("test@test.com")
+            .nickname("테스트")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(user, "id", 1L);
+    return user;
+  }
+
+  private Tag testTag(Long id) {
+    Tag tag = Tag.builder().title("업무").color(TagColor.BLUE).user(testUser()).build();
+    ReflectionTestUtils.setField(tag, "id", id);
+    return tag;
+  }
+
+  private Goal testGoal(Long id) {
+    Goal goal = Goal.builder().title("목표").user(testUser()).build();
+    ReflectionTestUtils.setField(goal, "id", id);
+    return goal;
+  }
+
+  // ========== 유저 없음 ==========
+
+  @Test
+  void 루틴_생성_유저_없음_404() {
+    given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    999L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.DAILY, null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+    verify(routineRepository, never()).save(any());
+  }
+
+  // ========== DAILY ==========
+
+  @Test
+  void 루틴_생성_DAILY_성공_선택필드_없음() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("아침 스트레칭", null, RoutineType.DAILY, null, null, null));
+
+    assertThat(result.getTitle()).isEqualTo("아침 스트레칭");
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
+    assertThat(result.getRoutineDate()).isNull();
+    assertThat(result.getTagId()).isNull();
+    assertThat(result.getGoalId()).isNull();
+    assertThat(result.getDueDate()).isNull();
+  }
+
+  @Test
+  void 루틴_생성_DAILY_routineDate_무시됨() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // DAILY에서 routineDate=999를 넘겨도 검증 없이 저장됨
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("루틴", null, RoutineType.DAILY, 999, null, null));
+
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
+    assertThat(result.getRoutineDate()).isEqualTo(999);
+  }
+
+  // ========== WEEKLY ==========
+
+  @Test
+  void 루틴_생성_WEEKLY_성공_전체필드() {
+    LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(tagRepository.findById(5L)).willReturn(Optional.of(testTag(5L)));
+    given(goalRepository.findById(2L)).willReturn(Optional.of(testGoal(2L)));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("영어 단어", dueDate, RoutineType.WEEKLY, 21, 5L, 2L));
+
+    assertThat(result.getTitle()).isEqualTo("영어 단어");
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
+    assertThat(result.getRoutineDate()).isEqualTo(21);
+    assertThat(result.getDueDate()).isEqualTo(dueDate);
+    assertThat(result.getTagId()).isEqualTo(5L);
+    assertThat(result.getGoalId()).isEqualTo(2L);
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_routineDate_경계값_1_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 1, null, null));
+
+    assertThat(result.getRoutineDate()).isEqualTo(1);
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_routineDate_경계값_127_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 127, null, null));
+
+    assertThat(result.getRoutineDate()).isEqualTo(127);
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_routineDate_null이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+
+    verify(routineRepository, never()).save(any());
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_routineDate_0이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 0, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  @Test
+  void 루틴_생성_WEEKLY_routineDate_128이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 128, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  // ========== MONTHLY ==========
+
+  @Test
+  void 루틴_생성_MONTHLY_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("월간 회고", null, RoutineType.MONTHLY, 15, null, null));
+
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.MONTHLY);
+    assertThat(result.getRoutineDate()).isEqualTo(15);
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_경계값_1_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 1, null, null));
+
+    assertThat(result.getRoutineDate()).isEqualTo(1);
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_경계값_31_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 31, null, null));
+
+    assertThat(result.getRoutineDate()).isEqualTo(31);
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_null이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_0이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 0, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_32이면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 32, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  // ========== tag / goal 없음 ==========
+
+  @Test
+  void 루틴_생성_존재하지_않는_tagId_404() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(tagRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto(
+                        "루틴", null, RoutineType.DAILY, null, 999L, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TagErrorCode.TAG_NOT_FOUND));
+
+    verify(routineRepository, never()).save(any());
+  }
+
+  @Test
+  void 루틴_생성_존재하지_않는_goalId_404() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(goalRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto(
+                        "루틴", null, RoutineType.DAILY, null, null, 999L)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GoalErrorCode.GOAL_NOT_FOUND));
+
+    verify(routineRepository, never()).save(any());
+  }
+}

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -134,13 +134,13 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // DAILY에서 routineDate=999를 넘겨도 검증 없이 저장됨
+    // DAILY에서 routineDate=999를 넘겨도 null로 정규화되어 저장됨
     RoutineResponseDto result =
         routineService.createRoutine(
             1L, new RoutineCreateRequestDto("루틴", null, RoutineType.DAILY, 999, null, null));
 
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
-    assertThat(result.getRoutineDate()).isEqualTo(999);
+    assertThat(result.getRoutineDate()).isNull();
   }
 
   // ========== WEEKLY ==========

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -1,0 +1,186 @@
+package plana.replan.domain.todo.controller;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.service.TodoService;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.global.config.SecurityConfig;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.jwt.JwtUtil;
+
+@WebMvcTest(TodoController.class)
+@Import(SecurityConfig.class)
+class TodoControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private TodoService todoService;
+
+  @MockitoBean private JwtUtil jwtUtil;
+
+  private UsernamePasswordAuthenticationToken authToken(Long userId) {
+    return new UsernamePasswordAuthenticationToken(
+        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+
+  @Test
+  @DisplayName("인증 없이 투두 생성 호출: Security가 차단, 401 반환")
+  void createTodo_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "테스트 투두" }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("투두 생성 성공 (tagId 없음): status=201, success=true, data 필드 검증")
+  void createTodo_success_withoutTag() throws Exception {
+    given(todoService.createTodo(any(), any()))
+        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, null));
+
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "테스트 투두" }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.todoId").value(1))
+        .andExpect(jsonPath("$.data.title").value("테스트 투두"))
+        .andExpect(jsonPath("$.data.dueDate").value(nullValue()))
+        .andExpect(jsonPath("$.data.tagId").value(nullValue()))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("투두 생성 성공 (tagId 있음): status=201, data.tagId 포함")
+  void createTodo_success_withTag() throws Exception {
+    given(todoService.createTodo(any(), any()))
+        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, 5L));
+
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "테스트 투두", "tagId": 5 }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value(200))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.tagId").value(5))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("title 누락: status=400, error.code=INVALID_INPUT")
+  void createTodo_missingTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("title 빈 문자열: status=400, error.code=INVALID_INPUT")
+  void createTodo_blankTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 tagId: status=404, error.code=TAG_NOT_FOUND")
+  void createTodo_tagNotFound() throws Exception {
+    willThrow(new CustomException(TagErrorCode.TAG_NOT_FOUND))
+        .given(todoService)
+        .createTodo(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "테스트 투두", "tagId": 999 }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("TAG_NOT_FOUND"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("userId가 DB에 없는 경우: status=404, error.code=USER_NOT_FOUND")
+  void createTodo_userNotFound() throws Exception {
+    willThrow(new CustomException(UserErrorCode.USER_NOT_FOUND))
+        .given(todoService)
+        .createTodo(any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/todos/create")
+                .with(authentication(authToken(999L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "테스트 투두" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("USER_NOT_FOUND"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+}

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1,0 +1,147 @@
+package plana.replan.domain.todo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.entity.TagColor;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.dto.TodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+  @Mock private TodoRepository todoRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private TagRepository tagRepository;
+
+  @InjectMocks private TodoService todoService;
+
+  private User testUser() {
+    User user =
+        User.builder()
+            .email("test@test.com")
+            .nickname("테스트")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(user, "id", 1L);
+    return user;
+  }
+
+  private Tag testTag(Long id) {
+    Tag tag = Tag.builder().title("업무").color(TagColor.BLUE).user(testUser()).build();
+    ReflectionTestUtils.setField(tag, "id", id);
+    return tag;
+  }
+
+  private TodoCreateRequestDto request(String title, LocalDateTime dueDate, Long tagId) {
+    TodoCreateRequestDto dto = new TodoCreateRequestDto();
+    ReflectionTestUtils.setField(dto, "title", title);
+    ReflectionTestUtils.setField(dto, "dueDate", dueDate);
+    ReflectionTestUtils.setField(dto, "tagId", tagId);
+    return dto;
+  }
+
+  @Test
+  @DisplayName("userId null: USER_NOT_FOUND 예외, save 미호출")
+  void createTodo_nullUserId_throws() {
+    assertThatThrownBy(() -> todoService.createTodo(null, request("제목", null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("userId가 DB에 없음: USER_NOT_FOUND 예외, save 미호출")
+  void createTodo_userNotFound_throws() {
+    given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.createTodo(1L, request("제목", null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("tagId가 DB에 없음: TAG_NOT_FOUND 예외, save 미호출")
+  void createTodo_tagNotFound_throws() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(tagRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.createTodo(1L, request("제목", null, 99L)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TagErrorCode.TAG_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("성공 (tagId 없음): 올바른 DTO 반환, isPinned=false, tagId=null, tagRepository 미호출")
+  void createTodo_success_withoutTag() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    TodoResponseDto result = todoService.createTodo(1L, request("제목", null, null));
+
+    assertThat(result.getTitle()).isEqualTo("제목");
+    assertThat(result.getDueDate()).isNull();
+    assertThat(result.getTagId()).isNull();
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).save(captor.capture());
+    assertThat(ReflectionTestUtils.getField(captor.getValue(), "isPinned")).isEqualTo(false);
+
+    verify(tagRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("성공 (tagId 있음): 올바른 DTO 반환, dueDate 포함, tagId 포함")
+  void createTodo_success_withTag() {
+    LocalDateTime dueDate = LocalDateTime.of(2026, 5, 10, 12, 30);
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(tagRepository.findById(5L)).willReturn(Optional.of(testTag(5L)));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    TodoResponseDto result = todoService.createTodo(1L, request("제목", dueDate, 5L));
+
+    assertThat(result.getTitle()).isEqualTo("제목");
+    assertThat(result.getDueDate()).isEqualTo(dueDate);
+    assertThat(result.getTagId()).isEqualTo(5L);
+  }
+}


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
 #67


## 변경 사항
- todo 생성 api
- Routine 생성 api
- routine 생성 시 해당하는 TODO 바로 생성
- 매일 자정에 배치 작업으로 ROUTINE을 보고 TODO 생성   

## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일, 주간, 월간 반복 루틴 생성 API 추가
  * 매일 자정에 루틴으로부터 자동 할 일 생성 스케줄러 추가
  * 할 일 생성 API 추가
  * 루틴과 할 일에 태그, 목표 연결 지원
  
* **개선 사항**
  * 루틴 날짜 유효성 검증으로 잘못된 입력값 처리
  * 포괄적인 오류 처리 및 사용자 피드백 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/104)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->