### PR TITLE
[Feat] 하위투두 API 및 테스트 코드

### DIFF
--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -5,12 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.SubTodoUpdateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.service.TodoService;
@@ -39,5 +42,26 @@ public class TodoController implements TodoControllerDocs {
       @Valid @RequestBody SubTodoCreateRequestDto request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResult.ok(todoService.createSubTodo(userId, parentId, request)));
+  }
+
+  @Override
+  @PutMapping("/{parentId}/sub-todos/{subTodoId}")
+  public ResponseEntity<ApiResult<TodoResponseDto>> updateSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long parentId,
+      @PathVariable Long subTodoId,
+      @Valid @RequestBody SubTodoUpdateRequestDto request) {
+    return ResponseEntity.ok(
+        ApiResult.ok(todoService.updateSubTodo(userId, parentId, subTodoId, request)));
+  }
+
+  @Override
+  @DeleteMapping("/{parentId}/sub-todos/{subTodoId}")
+  public ResponseEntity<Void> deleteSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long parentId,
+      @PathVariable Long subTodoId) {
+    todoService.deleteSubTodo(userId, parentId, subTodoId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -1,99 +1,43 @@
 package plana.replan.domain.todo.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.service.TodoService;
 import plana.replan.global.common.ApiResult;
 
-@Tag(name = "Todo", description = "투두 관련 API")
 @RestController
 @RequestMapping("/api/todos")
 @RequiredArgsConstructor
-public class TodoController {
+public class TodoController implements TodoControllerDocs {
 
   private final TodoService todoService;
 
-  @Operation(
-      summary = "투두 생성",
-      description =
-          """
-                    **호출 주체**: AccessToken을 보유한 인증 사용자
-
-                    **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
-
-                    **비즈니스 로직**
-                    1. JwtFilter에서 AccessToken 검증 후 userId를 SecurityContext에 저장
-                    2. @AuthenticationPrincipal 로 userId 주입
-                    3. title(필수), due_date(선택), tag_id(선택)를 받아 투두 생성
-                    4. tag_id가 주어진 경우 태그 존재 여부 확인 후 연결
-
-                    **참고**: tag_id가 제공된 경우 해당 태그가 존재하지 않으면 404 반환
-                    """,
-      security = @SecurityRequirement(name = "Bearer Authentication"))
-  @ApiResponses({
-    @ApiResponse(responseCode = "201", description = "투두 생성 성공"),
-    @ApiResponse(
-        responseCode = "400",
-        description = "입력값 오류 (title 누락)",
-        content =
-            @Content(
-                examples =
-                    @ExampleObject(
-                        value =
-                            """
-                                  {
-                                    "status": 400,
-                                    "success": false,
-                                    "data": null,
-                                    "error": {
-                                      "code": "VALIDATION_ERROR",
-                                      "message": "제목은 필수입니다.",
-                                      "detail": null
-                                    }
-                                  }
-                                  """))),
-    @ApiResponse(responseCode = "401", description = "AccessToken 없음 또는 유효하지 않은 토큰"),
-    @ApiResponse(
-        responseCode = "404",
-        description = "유저 또는 태그를 찾을 수 없음",
-        content =
-            @Content(
-                examples =
-                    @ExampleObject(
-                        value =
-                            """
-                                  {
-                                    "status": 404,
-                                    "success": false,
-                                    "data": null,
-                                    "error": {
-                                      "code": "TAG_NOT_FOUND",
-                                      "message": "태그를 찾을 수 없습니다.",
-                                      "detail": null
-                                    }
-                                  }
-                                  """)))
-  })
+  @Override
   @PostMapping("/create")
   public ResponseEntity<ApiResult<TodoResponseDto>> createTodo(
       @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequestDto request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResult.ok(todoService.createTodo(userId, request)));
+  }
+
+  @Override
+  @PostMapping("/{parentId}/sub-todos")
+  public ResponseEntity<ApiResult<TodoResponseDto>> createSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long parentId,
+      @Valid @RequestBody SubTodoCreateRequestDto request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResult.ok(todoService.createSubTodo(userId, parentId, request)));
   }
 }

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.SubTodoUpdateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.global.common.ApiResult;
@@ -224,4 +225,240 @@ public interface TodoControllerDocs {
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "상위 투두 ID", example = "42") @PathVariable Long parentId,
       @Valid @RequestBody SubTodoCreateRequestDto request);
+
+  @Operation(
+      summary = "하위 투두 수정",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          **Path Variables**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | parentId | ✅ 필수 | integer | 상위 투두 ID | `42` |
+          | subTodoId | ✅ 필수 | integer | 수정할 하위 투두 ID | `43` |
+
+          **Request Body**
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 하위 투두 제목 | `"개념 정리하기 (수정)"` |
+
+          **비즈니스 로직**
+          1. subTodoId로 하위 투두 조회
+          2. 하위 투두가 요청 유저 소유인지 검증
+          3. 하위 투두의 parent가 parentId와 일치하는지 검증
+          4. 제목 수정 후 수정된 투두 반환
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "하위 투두 수정 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "todoId": 43,
+                                "title": "개념 정리하기 (수정)",
+                                "dueDate": null,
+                                "isCompleted": false,
+                                "tagId": null,
+                                "parentId": 42
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title 누락)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "INVALID_INPUT",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "하위 투두를 찾을 수 없음 (존재하지 않거나 본인 소유가 아니거나 parentId 불일치)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TODO_NOT_FOUND",
+                                "message": "투두를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<TodoResponseDto>> updateSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "상위 투두 ID", example = "42") @PathVariable Long parentId,
+      @Parameter(description = "수정할 하위 투두 ID", example = "43") @PathVariable Long subTodoId,
+      @Valid @RequestBody SubTodoUpdateRequestDto request);
+
+  @Operation(
+      summary = "하위 투두 삭제",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          **Path Variables**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | parentId | ✅ 필수 | integer | 상위 투두 ID | `42` |
+          | subTodoId | ✅ 필수 | integer | 삭제할 하위 투두 ID | `43` |
+
+          **비즈니스 로직**
+          1. subTodoId로 하위 투두 조회
+          2. 하위 투두가 요청 유저 소유인지 검증
+          3. 하위 투두의 parent가 parentId와 일치하는지 검증
+          4. soft delete 처리 (deleted_at 설정)
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "204", description = "하위 투두 삭제 성공"),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "하위 투두를 찾을 수 없음 (존재하지 않거나 본인 소유가 아니거나 parentId 불일치)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TODO_NOT_FOUND",
+                                "message": "투두를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<Void> deleteSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "상위 투두 ID", example = "42") @PathVariable Long parentId,
+      @Parameter(description = "삭제할 하위 투두 ID", example = "43") @PathVariable Long subTodoId);
 }

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -1,0 +1,227 @@
+package plana.replan.domain.todo.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "Todo", description = "투두 관련 API")
+public interface TodoControllerDocs {
+
+  @Operation(
+      summary = "투두 생성",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          **비즈니스 로직**
+          1. JwtFilter에서 AccessToken 검증 후 userId를 SecurityContext에 저장
+          2. @AuthenticationPrincipal 로 userId 주입
+          3. title(필수), due_date(선택), tag_id(선택)를 받아 투두 생성
+          4. tag_id가 주어진 경우 태그 존재 여부 확인 후 연결
+
+          **참고**: tag_id가 제공된 경우 해당 태그가 존재하지 않으면 404 반환
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "201", description = "투두 생성 성공"),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title 누락)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "VALIDATION_ERROR",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(responseCode = "401", description = "AccessToken 없음 또는 유효하지 않은 토큰"),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저 또는 태그를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TAG_NOT_FOUND",
+                                "message": "태그를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<TodoResponseDto>> createTodo(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoCreateRequestDto request);
+
+  @Operation(
+      summary = "하위 투두 생성",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          **Path Variable**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | parentId | ✅ 필수 | integer | 상위 투두 ID | `42` |
+
+          **Request Body**
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 하위 투두 제목 | `"개념 정리하기"` |
+
+          **비즈니스 로직**
+          1. parentId로 상위 투두 조회
+          2. 상위 투두가 요청 유저 소유인지 검증
+          3. 하위 투두 생성 후 parentId 포함 응답 반환
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "하위 투두 생성 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "todoId": 43,
+                                "title": "개념 정리하기",
+                                "dueDate": null,
+                                "isCompleted": false,
+                                "tagId": null,
+                                "parentId": 42
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title 누락)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "INVALID_INPUT",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "상위 투두를 찾을 수 없음 (존재하지 않거나 본인 소유가 아닌 경우)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TODO_NOT_FOUND",
+                                "message": "투두를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<TodoResponseDto>> createSubTodo(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "상위 투두 ID", example = "42") @PathVariable Long parentId,
+      @Valid @RequestBody SubTodoCreateRequestDto request);
+}

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -55,7 +55,7 @@ public interface TodoControllerDocs {
                               "success": false,
                               "data": null,
                               "error": {
-                                "code": "VALIDATION_ERROR",
+                                "code": "INVALID_INPUT",
                                 "message": "제목은 필수입니다.",
                                 "detail": null
                               }

--- a/src/main/java/plana/replan/domain/todo/dto/SubTodoCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/SubTodoCreateRequestDto.java
@@ -1,0 +1,13 @@
+package plana.replan.domain.todo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SubTodoCreateRequestDto {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+}

--- a/src/main/java/plana/replan/domain/todo/dto/SubTodoUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/SubTodoUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package plana.replan.domain.todo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "하위 투두 수정 요청")
+public class SubTodoUpdateRequestDto {
+
+  @Schema(
+      description = "하위 투두 제목",
+      example = "개념 정리하기 (수정)",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+}

--- a/src/main/java/plana/replan/domain/todo/dto/TodoResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoResponseDto.java
@@ -14,6 +14,7 @@ public class TodoResponseDto {
   private LocalDateTime dueDate;
   private boolean isCompleted;
   private Long tagId;
+  private Long parentId;
 
   public static TodoResponseDto from(Todo todo) {
     return new TodoResponseDto(
@@ -21,6 +22,7 @@ public class TodoResponseDto {
         todo.getTitle(),
         todo.getDueDate(),
         todo.isCompleted(),
-        todo.getTag() != null ? todo.getTag().getId() : null);
+        todo.getTag() != null ? todo.getTag().getId() : null,
+        todo.getParent() != null ? todo.getParent().getId() : null);
   }
 }

--- a/src/main/java/plana/replan/domain/todo/entity/Todo.java
+++ b/src/main/java/plana/replan/domain/todo/entity/Todo.java
@@ -71,6 +71,10 @@ public class Todo extends BaseTimeEntity {
   @OneToOne(mappedBy = "todo", fetch = FetchType.LAZY)
   private FailureReason failureReason;
 
+  public void updateTitle(String title) {
+    this.title = Objects.requireNonNull(title, "제목은 필수입니다.");
+  }
+
   @Builder
   public Todo(
       String title,

--- a/src/main/java/plana/replan/domain/todo/entity/Todo.java
+++ b/src/main/java/plana/replan/domain/todo/entity/Todo.java
@@ -80,7 +80,8 @@ public class Todo extends BaseTimeEntity {
       User user,
       Tag tag,
       Goal goal,
-      Routine routine) {
+      Routine routine,
+      Todo parent) {
     this.title = Objects.requireNonNull(title, "제목은 필수입니다.");
     this.user = Objects.requireNonNull(user, "유저는 필수입니다.");
     this.dueDate = dueDate;
@@ -89,5 +90,6 @@ public class Todo extends BaseTimeEntity {
     this.tag = tag;
     this.goal = goal;
     this.routine = routine;
+    this.parent = parent;
   }
 }

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -7,6 +7,7 @@ import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.SubTodoUpdateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.entity.Todo;
@@ -81,5 +82,49 @@ public class TodoService {
 
     todoRepository.save(subTodo);
     return TodoResponseDto.from(subTodo);
+  }
+
+  @Transactional
+  public TodoResponseDto updateSubTodo(
+      Long userId, Long parentId, Long subTodoId, SubTodoUpdateRequestDto request) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    Todo subTodo =
+        todoRepository
+            .findById(subTodoId)
+            .orElseThrow(() -> new CustomException(TodoErrorCode.TODO_NOT_FOUND));
+
+    if (!subTodo.getUser().getId().equals(userId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    if (subTodo.getParent() == null || !subTodo.getParent().getId().equals(parentId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    subTodo.updateTitle(request.getTitle());
+    return TodoResponseDto.from(subTodo);
+  }
+
+  @Transactional
+  public void deleteSubTodo(Long userId, Long parentId, Long subTodoId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    Todo subTodo =
+        todoRepository
+            .findById(subTodoId)
+            .orElseThrow(() -> new CustomException(TodoErrorCode.TODO_NOT_FOUND));
+
+    if (!subTodo.getUser().getId().equals(userId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    if (subTodo.getParent() == null || !subTodo.getParent().getId().equals(parentId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    subTodo.softDelete();
   }
 }

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -6,9 +6,11 @@ import org.springframework.transaction.annotation.Transactional;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.exception.TodoErrorCode;
 import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
@@ -52,5 +54,32 @@ public class TodoService {
 
     todoRepository.save(todo);
     return TodoResponseDto.from(todo);
+  }
+
+  @Transactional
+  public TodoResponseDto createSubTodo(
+      Long userId, Long parentId, SubTodoCreateRequestDto request) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    Todo parent =
+        todoRepository
+            .findById(parentId)
+            .orElseThrow(() -> new CustomException(TodoErrorCode.TODO_NOT_FOUND));
+
+    if (!parent.getUser().getId().equals(userId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    Todo subTodo =
+        Todo.builder().title(request.getTitle()).user(user).parent(parent).isPinned(false).build();
+
+    todoRepository.save(subTodo);
+    return TodoResponseDto.from(subTodo);
   }
 }

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.exception.TodoErrorCode;
 import plana.replan.domain.todo.service.TodoService;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.global.config.SecurityConfig;
@@ -182,5 +183,73 @@ class TodoControllerTest {
         .andExpect(jsonPath("$.success").value(false))
         .andExpect(jsonPath("$.error.code").value("USER_NOT_FOUND"))
         .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("인증 없이 하위 투두 생성 호출: Security가 차단, 401 반환")
+  void createSubTodo_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/10/sub-todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "하위 투두" }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("하위 투두 생성 성공: status=201, parentId 포함")
+  void createSubTodo_success() throws Exception {
+    given(todoService.createSubTodo(any(), any(), any()))
+        .willReturn(new TodoResponseDto(43L, "하위 투두", null, false, null, 10L));
+
+    mockMvc
+        .perform(
+            post("/api/todos/10/sub-todos")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "하위 투두" }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.todoId").value(43))
+        .andExpect(jsonPath("$.data.title").value("하위 투두"))
+        .andExpect(jsonPath("$.data.parentId").value(10))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("title 누락: status=400, error.code=INVALID_INPUT")
+  void createSubTodo_missingTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/10/sub-todos")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 parentId: status=404, error.code=TODO_NOT_FOUND")
+  void createSubTodo_parentNotFound() throws Exception {
+    willThrow(new CustomException(TodoErrorCode.TODO_NOT_FOUND))
+        .given(todoService)
+        .createSubTodo(any(), any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/todos/999/sub-todos")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "하위 투두" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("TODO_NOT_FOUND"));
   }
 }

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -235,6 +235,42 @@ class TodoControllerTest {
   }
 
   @Test
+  @DisplayName("title 빈 문자열: status=400, error.code=INVALID_INPUT")
+  void createSubTodo_blankTitle() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/todos/10/sub-todos")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("userId가 DB에 없는 경우: status=404, error.code=USER_NOT_FOUND")
+  void createSubTodo_userNotFound() throws Exception {
+    willThrow(new CustomException(UserErrorCode.USER_NOT_FOUND))
+        .given(todoService)
+        .createSubTodo(any(), any(), any());
+
+    mockMvc
+        .perform(
+            post("/api/todos/10/sub-todos")
+                .with(authentication(authToken(999L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "하위 투두" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("USER_NOT_FOUND"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
   @DisplayName("존재하지 않는 parentId: status=404, error.code=TODO_NOT_FOUND")
   void createSubTodo_parentNotFound() throws Exception {
     willThrow(new CustomException(TodoErrorCode.TODO_NOT_FOUND))

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -3,9 +3,12 @@ package plana.replan.domain.todo.controller;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -285,6 +288,110 @@ class TodoControllerTest {
                 .content("""
                     { "title": "하위 투두" }
                     """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("TODO_NOT_FOUND"));
+  }
+
+  // ── updateSubTodo ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("인증 없이 하위 투두 수정 호출: 401 반환")
+  void updateSubTodo_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/todos/10/sub-todos/43")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "수정 제목" }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("하위 투두 수정 성공: status=200, 수정된 title 반환")
+  void updateSubTodo_success() throws Exception {
+    given(todoService.updateSubTodo(any(), any(), any(), any()))
+        .willReturn(new TodoResponseDto(43L, "수정 제목", null, false, null, 10L));
+
+    mockMvc
+        .perform(
+            put("/api/todos/10/sub-todos/43")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "수정 제목" }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.todoId").value(43))
+        .andExpect(jsonPath("$.data.title").value("수정 제목"))
+        .andExpect(jsonPath("$.data.parentId").value(10))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("title 누락 (수정): status=400, error.code=INVALID_INPUT")
+  void updateSubTodo_missingTitle() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/todos/10/sub-todos/43")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않거나 본인 소유가 아닌 하위 투두 수정: status=404, error.code=TODO_NOT_FOUND")
+  void updateSubTodo_notFound() throws Exception {
+    willThrow(new CustomException(TodoErrorCode.TODO_NOT_FOUND))
+        .given(todoService)
+        .updateSubTodo(any(), any(), any(), any());
+
+    mockMvc
+        .perform(
+            put("/api/todos/10/sub-todos/999")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "title": "수정 제목" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("TODO_NOT_FOUND"));
+  }
+
+  // ── deleteSubTodo ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("인증 없이 하위 투두 삭제 호출: 401 반환")
+  void deleteSubTodo_unauthenticated() throws Exception {
+    mockMvc
+        .perform(delete("/api/todos/10/sub-todos/43"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("하위 투두 삭제 성공: status=204, 응답 바디 없음")
+  void deleteSubTodo_success() throws Exception {
+    willDoNothing().given(todoService).deleteSubTodo(any(), any(), any());
+
+    mockMvc
+        .perform(delete("/api/todos/10/sub-todos/43").with(authentication(authToken(1L))))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("존재하지 않거나 본인 소유가 아닌 하위 투두 삭제: status=404, error.code=TODO_NOT_FOUND")
+  void deleteSubTodo_notFound() throws Exception {
+    willThrow(new CustomException(TodoErrorCode.TODO_NOT_FOUND))
+        .given(todoService)
+        .deleteSubTodo(any(), any(), any());
+
+    mockMvc
+        .perform(delete("/api/todos/10/sub-todos/999").with(authentication(authToken(1L))))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("TODO_NOT_FOUND"));
   }

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -63,7 +63,7 @@ class TodoControllerTest {
   @DisplayName("투두 생성 성공 (tagId 없음): status=201, success=true, data 필드 검증")
   void createTodo_success_withoutTag() throws Exception {
     given(todoService.createTodo(any(), any()))
-        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, null));
+        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, null, null));
 
     mockMvc
         .perform(
@@ -87,7 +87,7 @@ class TodoControllerTest {
   @DisplayName("투두 생성 성공 (tagId 있음): status=201, data.tagId 포함")
   void createTodo_success_withTag() throws Exception {
     given(todoService.createTodo(any(), any()))
-        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, 5L));
+        .willReturn(new TodoResponseDto(1L, "테스트 투두", null, false, 5L, null));
 
     mockMvc
         .perform(

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -245,4 +245,27 @@ class TodoServiceTest {
     assertThat(result.getParentId()).isEqualTo(10L);
     assertThat(result.getTagId()).isNull();
   }
+
+  @Test
+  @DisplayName("성공: 저장되는 엔티티에 parent 연결, isPinned=false, tag/goal/routine null")
+  void createSubTodo_success_entityProperties() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    given(todoRepository.findById(10L)).willReturn(Optional.of(parent));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    todoService.createSubTodo(1L, 10L, subRequest("하위 투두"));
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).save(captor.capture());
+    Todo saved = captor.getValue();
+
+    assertThat(ReflectionTestUtils.getField(saved, "isPinned")).isEqualTo(false);
+    assertThat(ReflectionTestUtils.getField(saved, "parent")).isSameAs(parent);
+    assertThat(ReflectionTestUtils.getField(saved, "tag")).isNull();
+    assertThat(ReflectionTestUtils.getField(saved, "goal")).isNull();
+    assertThat(ReflectionTestUtils.getField(saved, "routine")).isNull();
+  }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -21,9 +21,11 @@ import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.entity.TagColor;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.exception.TodoErrorCode;
 import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
@@ -143,5 +145,104 @@ class TodoServiceTest {
     assertThat(result.getTitle()).isEqualTo("제목");
     assertThat(result.getDueDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
+  }
+
+  private SubTodoCreateRequestDto subRequest(String title) {
+    SubTodoCreateRequestDto dto = new SubTodoCreateRequestDto();
+    ReflectionTestUtils.setField(dto, "title", title);
+    return dto;
+  }
+
+  private Todo testTodo(Long id, User user) {
+    Todo todo = Todo.builder().title("부모 투두").user(user).isPinned(false).build();
+    ReflectionTestUtils.setField(todo, "id", id);
+    return todo;
+  }
+
+  @Test
+  @DisplayName("userId null: USER_NOT_FOUND 예외, save 미호출")
+  void createSubTodo_nullUserId_throws() {
+    assertThatThrownBy(() -> todoService.createSubTodo(null, 1L, subRequest("하위 투두")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("userId가 DB에 없음: USER_NOT_FOUND 예외, save 미호출")
+  void createSubTodo_userNotFound_throws() {
+    given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.createSubTodo(1L, 10L, subRequest("하위 투두")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("parentId가 DB에 없음: TODO_NOT_FOUND 예외, save 미호출")
+  void createSubTodo_parentNotFound_throws() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(todoRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.createSubTodo(1L, 99L, subRequest("하위 투두")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("parent 투두가 다른 유저 소유: TODO_NOT_FOUND 예외, save 미호출")
+  void createSubTodo_parentOwnedByOtherUser_throws() {
+    User otherUser =
+        User.builder()
+            .email("other@test.com")
+            .nickname("타인")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(otherUser, "id", 2L);
+
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Todo parentOwnedByOther = testTodo(10L, otherUser);
+    given(todoRepository.findById(10L)).willReturn(Optional.of(parentOwnedByOther));
+
+    assertThatThrownBy(() -> todoService.createSubTodo(1L, 10L, subRequest("하위 투두")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+
+    verify(todoRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("성공: 하위 투두 생성, parentId 포함된 DTO 반환")
+  void createSubTodo_success() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    given(todoRepository.findById(10L)).willReturn(Optional.of(parent));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    TodoResponseDto result = todoService.createSubTodo(1L, 10L, subRequest("하위 투두"));
+
+    assertThat(result.getTitle()).isEqualTo("하위 투두");
+    assertThat(result.getParentId()).isEqualTo(10L);
+    assertThat(result.getTagId()).isNull();
   }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -22,6 +22,7 @@ import plana.replan.domain.tag.entity.TagColor;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.SubTodoUpdateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoResponseDto;
 import plana.replan.domain.todo.entity.Todo;
@@ -246,6 +247,12 @@ class TodoServiceTest {
     assertThat(result.getTagId()).isNull();
   }
 
+  private SubTodoUpdateRequestDto updateRequest(String title) {
+    SubTodoUpdateRequestDto dto = new SubTodoUpdateRequestDto();
+    ReflectionTestUtils.setField(dto, "title", title);
+    return dto;
+  }
+
   @Test
   @DisplayName("성공: 저장되는 엔티티에 parent 연결, isPinned=false, tag/goal/routine null")
   void createSubTodo_success_entityProperties() {
@@ -267,5 +274,180 @@ class TodoServiceTest {
     assertThat(ReflectionTestUtils.getField(saved, "tag")).isNull();
     assertThat(ReflectionTestUtils.getField(saved, "goal")).isNull();
     assertThat(ReflectionTestUtils.getField(saved, "routine")).isNull();
+  }
+
+  // ── updateSubTodo ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("updateSubTodo - userId null: USER_NOT_FOUND 예외")
+  void updateSubTodo_nullUserId_throws() {
+    assertThatThrownBy(() -> todoService.updateSubTodo(null, 10L, 43L, updateRequest("수정 제목")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("updateSubTodo - subTodoId가 DB에 없음: TODO_NOT_FOUND 예외")
+  void updateSubTodo_subTodoNotFound_throws() {
+    given(todoRepository.findById(43L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.updateSubTodo(1L, 10L, 43L, updateRequest("수정 제목")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("updateSubTodo - 다른 유저 소유 하위 투두: TODO_NOT_FOUND 예외")
+  void updateSubTodo_ownedByOtherUser_throws() {
+    User otherUser =
+        User.builder()
+            .email("other@test.com")
+            .nickname("타인")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(otherUser, "id", 2L);
+
+    User owner = testUser();
+    Todo parent = testTodo(10L, owner);
+    Todo subTodo =
+        Todo.builder().title("하위 투두").user(otherUser).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    assertThatThrownBy(() -> todoService.updateSubTodo(1L, 10L, 43L, updateRequest("수정 제목")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("updateSubTodo - parentId 불일치: TODO_NOT_FOUND 예외")
+  void updateSubTodo_parentMismatch_throws() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+    Todo subTodo = Todo.builder().title("하위 투두").user(user).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    assertThatThrownBy(() -> todoService.updateSubTodo(1L, 99L, 43L, updateRequest("수정 제목")))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("updateSubTodo - 성공: 수정된 제목 포함 DTO 반환")
+  void updateSubTodo_success() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+    Todo subTodo = Todo.builder().title("원래 제목").user(user).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    TodoResponseDto result = todoService.updateSubTodo(1L, 10L, 43L, updateRequest("수정 제목"));
+
+    assertThat(result.getTitle()).isEqualTo("수정 제목");
+    assertThat(result.getParentId()).isEqualTo(10L);
+  }
+
+  // ── deleteSubTodo ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("deleteSubTodo - userId null: USER_NOT_FOUND 예외")
+  void deleteSubTodo_nullUserId_throws() {
+    assertThatThrownBy(() -> todoService.deleteSubTodo(null, 10L, 43L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("deleteSubTodo - subTodoId가 DB에 없음: TODO_NOT_FOUND 예외")
+  void deleteSubTodo_subTodoNotFound_throws() {
+    given(todoRepository.findById(43L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.deleteSubTodo(1L, 10L, 43L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("deleteSubTodo - 다른 유저 소유 하위 투두: TODO_NOT_FOUND 예외")
+  void deleteSubTodo_ownedByOtherUser_throws() {
+    User otherUser =
+        User.builder()
+            .email("other@test.com")
+            .nickname("타인")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(otherUser, "id", 2L);
+
+    User owner = testUser();
+    Todo parent = testTodo(10L, owner);
+    Todo subTodo =
+        Todo.builder().title("하위 투두").user(otherUser).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    assertThatThrownBy(() -> todoService.deleteSubTodo(1L, 10L, 43L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("deleteSubTodo - parentId 불일치: TODO_NOT_FOUND 예외")
+  void deleteSubTodo_parentMismatch_throws() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+    Todo subTodo = Todo.builder().title("하위 투두").user(user).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    assertThatThrownBy(() -> todoService.deleteSubTodo(1L, 99L, 43L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("deleteSubTodo - 성공: soft delete 처리 (deletedAt 설정)")
+  void deleteSubTodo_success() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+    Todo subTodo = Todo.builder().title("하위 투두").user(user).parent(parent).isPinned(false).build();
+    ReflectionTestUtils.setField(subTodo, "id", 43L);
+
+    given(todoRepository.findById(43L)).willReturn(Optional.of(subTodo));
+
+    todoService.deleteSubTodo(1L, 10L, 43L);
+
+    assertThat(ReflectionTestUtils.getField(subTodo, "deletedAt")).isNotNull();
   }
 }


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타

## 변경 사항
> 하위 투두 생성 및 수정, 삭제 관련 API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 기존 투두 내에 하위 투두를 생성할 수 있는 새로운 기능이 추가되었습니다.
  * 투두 응답 데이터에 상위 투두의 ID 정보가 포함되도록 개선되었습니다.

* **개선 사항**
  * API 문서가 더욱 명확하게 정리되었습니다.

* **테스트**
  * 하위 투두 생성 기능에 대한 포괄적인 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->