### PR TITLE
fix: CORS 허용 출처에 localhost:5173 추가

### DIFF
--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration config = new CorsConfiguration();
     config.addAllowedOrigin("http://localhost:3000");
+    config.addAllowedOrigin("http://localhost:5173");
     config.addAllowedOrigin("https://re-plan-fe.vercel.app");
     config.addAllowedMethod("*");
     config.addAllowedHeader("*");


### PR DESCRIPTION
## 작업 내용

- `SecurityConfig`의 CORS 허용 출처에 `http://localhost:5173` 추가

## 변경된 파일
- `SecurityConfig.java`