### PR TITLE
refactor: 태그 삭제 시 연관 todo·루틴 tag_id null 처리

### DIFF
--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -1,6 +1,15 @@
 package plana.replan.domain.routine.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.tag.entity.Tag;
 
-public interface RoutineRepository extends JpaRepository<Routine, Long> {}
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+
+  @Modifying
+  @Query("UPDATE Routine r SET r.tag = null WHERE r.tag = :tag AND r.deletedAt IS NULL")
+  void clearTagFromRoutines(@Param("tag") Tag tag);
+}

--- a/src/main/java/plana/replan/domain/tag/service/TagService.java
+++ b/src/main/java/plana/replan/domain/tag/service/TagService.java
@@ -3,12 +3,14 @@ package plana.replan.domain.tag.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.dto.TagCreateRequestDto;
 import plana.replan.domain.tag.dto.TagResponseDto;
 import plana.replan.domain.tag.dto.TagUpdateRequestDto;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
@@ -21,6 +23,8 @@ public class TagService {
 
   private final TagRepository tagRepository;
   private final UserRepository userRepository;
+  private final TodoRepository todoRepository;
+  private final RoutineRepository routineRepository;
 
   @Transactional
   public TagResponseDto createTag(Long userId, TagCreateRequestDto request) {
@@ -77,6 +81,8 @@ public class TagService {
       throw new CustomException(TagErrorCode.TAG_NOT_FOUND);
     }
 
+    todoRepository.clearTagFromTodos(tag);
+    routineRepository.clearTagFromRoutines(tag);
     tag.softDelete();
   }
 }

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -3,13 +3,19 @@ package plana.replan.domain.todo.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.todo.entity.Todo;
 import plana.replan.domain.user.entity.User;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+  @Modifying
+  @Query("UPDATE Todo t SET t.tag = null WHERE t.tag = :tag AND t.deletedAt IS NULL")
+  void clearTagFromTodos(@Param("tag") Tag tag);
 
   boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
 

--- a/src/test/java/plana/replan/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/plana/replan/domain/tag/service/TagServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.dto.TagCreateRequestDto;
 import plana.replan.domain.tag.dto.TagResponseDto;
 import plana.replan.domain.tag.dto.TagUpdateRequestDto;
@@ -23,6 +24,7 @@ import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.entity.TagColor;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;
@@ -36,6 +38,8 @@ class TagServiceTest {
 
   @Mock private TagRepository tagRepository;
   @Mock private UserRepository userRepository;
+  @Mock private TodoRepository todoRepository;
+  @Mock private RoutineRepository routineRepository;
 
   @InjectMocks private TagService tagService;
 
@@ -288,7 +292,7 @@ class TagServiceTest {
   }
 
   @Test
-  @DisplayName("deleteTag - 성공: soft delete 처리")
+  @DisplayName("deleteTag - 성공: 연관 todo·루틴 tag null 처리 후 soft delete")
   void deleteTag_success() {
     User user = testUser();
     Tag tag = testTag(1L, user);
@@ -296,6 +300,8 @@ class TagServiceTest {
 
     tagService.deleteTag(1L, 1L);
 
+    verify(todoRepository).clearTagFromTodos(tag);
+    verify(routineRepository).clearTagFromRoutines(tag);
     assertThat(ReflectionTestUtils.getField(tag, "deletedAt")).isNotNull();
   }
 }


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #


## 변경 사항
-태그 삭제 시 연관 todo와 루틴의 tag_id를 null 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 태그 삭제 시 관련된 모든 항목들에서 해당 태그의 참조가 자동으로 제거되어 데이터 정합성이 개선되었습니다.

* **테스트**
  * 태그 삭제 시 정리 작업이 올바르게 수행되는지 검증하는 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->