### PR TITLE
refactor: goal 도메인 DTO 리네이밍 및 투두 추천 API 개선

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalController.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalController.java
@@ -6,13 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
-import plana.replan.domain.goal.dto.create.GoalCreateRequestDto;
-import plana.replan.domain.goal.dto.list.GoalsByDateResponseDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequestDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponseDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementRequestDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
+import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
+import plana.replan.domain.goal.dto.refine.GoalRefinementRequest;
+import plana.replan.domain.goal.dto.refine.GoalRefinementResponse;
 import plana.replan.domain.goal.service.GoalAiService;
 import plana.replan.domain.goal.service.GoalService;
 import plana.replan.global.common.ApiResult;
@@ -27,8 +27,8 @@ public class GoalController implements GoalControllerDocs {
 
   @Override
   @PostMapping
-  public ResponseEntity<ApiResult<GoalSingleResponseDto>> createGoal(
-      @AuthenticationPrincipal Long userId, @Valid @RequestBody GoalCreateRequestDto request) {
+  public ResponseEntity<ApiResult<GoalSingleResponse>> createGoal(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody GoalCreateRequest request) {
     return ResponseEntity.ok(ApiResult.ok(goalService.createGoal(userId, request)));
   }
 
@@ -42,7 +42,7 @@ public class GoalController implements GoalControllerDocs {
 
   @Override
   @GetMapping
-  public ResponseEntity<ApiResult<List<GoalsByDateResponseDto>>> getGoals(
+  public ResponseEntity<ApiResult<List<GoalsByDateResponse>>> getGoals(
       @AuthenticationPrincipal Long userId,
       @RequestParam(required = false) Integer year,
       @RequestParam(required = false) Integer month) {
@@ -51,16 +51,15 @@ public class GoalController implements GoalControllerDocs {
 
   @Override
   @PostMapping("/ai/refine")
-  public ResponseEntity<ApiResult<GoalRefinementResponseDto>> refineGoal(
-      @AuthenticationPrincipal Long userId, @Valid @RequestBody GoalRefinementRequestDto request) {
+  public ResponseEntity<ApiResult<GoalRefinementResponse>> refineGoal(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody GoalRefinementRequest request) {
     return ResponseEntity.ok(ApiResult.ok(goalAiService.refineGoal(request)));
   }
 
   @Override
   @PostMapping("/ai/todo-recommendations")
-  public ResponseEntity<ApiResult<TodoRecommendationResponseDto>> recommendTodos(
-      @AuthenticationPrincipal Long userId,
-      @Valid @RequestBody TodoRecommendationRequestDto request) {
+  public ResponseEntity<ApiResult<TodoRecommendationResponse>> recommendTodos(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoRecommendationRequest request) {
     return ResponseEntity.ok(ApiResult.ok(goalAiService.recommendTodos(request)));
   }
 }

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -17,13 +17,13 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
-import plana.replan.domain.goal.dto.create.GoalCreateRequestDto;
-import plana.replan.domain.goal.dto.list.GoalsByDateResponseDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequestDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponseDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementRequestDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
+import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
+import plana.replan.domain.goal.dto.refine.GoalRefinementRequest;
+import plana.replan.domain.goal.dto.refine.GoalRefinementResponse;
 import plana.replan.global.common.ApiResult;
 
 @Tag(name = "Goal", description = "목표(Goal) 관련 API. 모든 요청에 JWT 인증 필수.")
@@ -70,7 +70,7 @@ public interface GoalControllerDocs {
         description = "목표 생성 성공",
         content =
             @Content(
-                schema = @Schema(implementation = GoalSingleResponseDto.class),
+                schema = @Schema(implementation = GoalSingleResponse.class),
                 examples =
                     @ExampleObject(
                         value =
@@ -165,7 +165,7 @@ public interface GoalControllerDocs {
                             }
                             """)))
   })
-  ResponseEntity<ApiResult<GoalSingleResponseDto>> createGoal(
+  ResponseEntity<ApiResult<GoalSingleResponse>> createGoal(
       @AuthenticationPrincipal Long userId,
       @io.swagger.v3.oas.annotations.parameters.RequestBody(
               content =
@@ -204,7 +204,7 @@ public interface GoalControllerDocs {
                                 """)
                       }))
           @RequestBody
-          GoalCreateRequestDto request);
+          GoalCreateRequest request);
 
   @Operation(
       summary = "목표 삭제",
@@ -516,7 +516,7 @@ public interface GoalControllerDocs {
                           """)
                 }))
   })
-  ResponseEntity<ApiResult<List<GoalsByDateResponseDto>>> getGoals(
+  ResponseEntity<ApiResult<List<GoalsByDateResponse>>> getGoals(
       @AuthenticationPrincipal Long userId,
       @RequestParam(required = false) Integer year,
       @RequestParam(required = false) Integer month);
@@ -676,7 +676,7 @@ public interface GoalControllerDocs {
                           """)
                 }))
   })
-  ResponseEntity<ApiResult<GoalRefinementResponseDto>> refineGoal(
+  ResponseEntity<ApiResult<GoalRefinementResponse>> refineGoal(
       @AuthenticationPrincipal Long userId,
       @io.swagger.v3.oas.annotations.parameters.RequestBody(
               content =
@@ -716,7 +716,7 @@ public interface GoalControllerDocs {
                       }))
           @Valid
           @RequestBody
-          GoalRefinementRequestDto request);
+          GoalRefinementRequest request);
 
   @Operation(
       summary = "AI 투두 추천",
@@ -741,10 +741,13 @@ public interface GoalControllerDocs {
           | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
           |--------|-----------|------|------|------|
           | goal | ✅ 필수 | string | 목표 | `"토익 900점 달성"` |
-          | deadline | ✅ 필수 | string | 마감기한 | `"2025-08-25"` |
-          | currentLevel | ✅ 필수 | string | 현재 수준 | `"토익 600점"` |
-          | availableTime | ✅ 필수 | string | 투자 가능 시간 | `"평일 1시간·주말 4시간"` |
-          | notes | ✅ 필수 | string | 특이사항 (교재·루틴·전략 포함 권장) | `"해커스 보카·RC·LC 활용"` |
+          | deadlineDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식) | `"2025-08-25"` |
+          | deadlineTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식) | `"08:00"` |
+          | currentLevel | ❌ 선택 | string | 현재 수준 | `"토익 600점"` |
+          | availableTime | ❌ 선택 | string | 투자 가능 시간 | `"평일 1시간·주말 4시간"` |
+          | notes | ❌ 선택 | string | 특이사항 (교재·루틴·전략 포함 권장) | `"해커스 보카·RC·LC 활용"` |
+
+          > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
 
           ---
 
@@ -752,6 +755,7 @@ public interface GoalControllerDocs {
 
           | 필드명 | 타입 | 설명 |
           |--------|------|------|
+          | overallReason | string | 전체 추천에 대한 총평 |
           | todos | array | 추천 투두 목록 |
           | todos[].type | string | `ONE_TIME` (일회형) 또는 `RECURRING` (반복형) |
           | todos[].title | string | 투두 제목 |
@@ -783,6 +787,7 @@ public interface GoalControllerDocs {
                               "status": 200,
                               "success": true,
                               "data": {
+                                "overallReason": "해커스 교재를 기반으로 단어 암기와 RC 강의 수강을 병행하고, 마감 D-1에 최종 점검을 배치했습니다. 하루 투자시간의 50%를 초과하지 않도록 분량을 조정했습니다.",
                                 "todos": [
                                   {
                                     "type": "RECURRING",
@@ -895,26 +900,37 @@ public interface GoalControllerDocs {
                           """)
                 }))
   })
-  ResponseEntity<ApiResult<TodoRecommendationResponseDto>> recommendTodos(
+  ResponseEntity<ApiResult<TodoRecommendationResponse>> recommendTodos(
       @AuthenticationPrincipal Long userId,
       @io.swagger.v3.oas.annotations.parameters.RequestBody(
               content =
                   @Content(
                       mediaType = "application/json",
-                      examples =
-                          @ExampleObject(
-                              name = "정제된 값으로 요청",
-                              value =
-                                  """
-                                  {
-                                    "goal": "토익 900점 달성 (LC 450·RC 450 이상)",
-                                    "deadline": "2025-08-25",
-                                    "currentLevel": "토익 600점 (LC 310·RC 290 추정)",
-                                    "availableTime": "평일 1시간·주말 4시간 (주 약 13시간)",
-                                    "notes": "해커스 보카·RC·LC 활용. 주 1회 모의고사. 매주 오답 노트 정리."
-                                  }
-                                  """)))
+                      examples = {
+                        @ExampleObject(
+                            name = "전체 필드 포함",
+                            value =
+                                """
+                                {
+                                  "goal": "토익 900점 달성 (LC 450·RC 450 이상)",
+                                  "deadlineDate": "2025-08-25",
+                                  "deadlineTime": "08:00",
+                                  "currentLevel": "토익 600점 (LC 310·RC 290 추정)",
+                                  "availableTime": "평일 1시간·주말 4시간 (주 약 13시간)",
+                                  "notes": "해커스 보카·RC·LC 활용. 주 1회 모의고사. 매주 오답 노트 정리."
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "필수 필드만 (선택 필드 생략)",
+                            summary = "goal만 필수. 나머지는 생략하면 미입력으로 처리됩니다.",
+                            value =
+                                """
+                                {
+                                  "goal": "토익 900점 달성 (LC 450·RC 450 이상)"
+                                }
+                                """)
+                      }))
           @Valid
           @RequestBody
-          TodoRecommendationRequestDto request);
+          TodoRecommendationRequest request);
 }

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -755,15 +755,13 @@ public interface GoalControllerDocs {
 
           | 필드명 | 타입 | 설명 |
           |--------|------|------|
-          | overallReason | string | 전체 추천에 대한 총평 |
+          | overallReason | string | 전체 추천 총평. 교재·강의가 포함된 경우 저자/출판사/링크 또는 강사/플랫폼/링크 포함 |
           | todos | array | 추천 투두 목록 |
           | todos[].type | string | `ONE_TIME` (일회형) 또는 `RECURRING` (반복형) |
           | todos[].title | string | 투두 제목 |
           | todos[].dueDate | string | 마감일 (ISO 8601). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
           | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자. DAILY·ONE_TIME: null |
-          | todos[].reason | string | AI가 이 투두를 생성한 이유 |
-          | todos[].source | string | 강의면 플랫폼명, 책이면 저자명. 없으면 null |
 
           ---
 
@@ -787,34 +785,28 @@ public interface GoalControllerDocs {
                               "status": 200,
                               "success": true,
                               "data": {
-                                "overallReason": "해커스 교재를 기반으로 단어 암기와 RC 강의 수강을 병행하고, 마감 D-1에 최종 점검을 배치했습니다. 하루 투자시간의 50%를 초과하지 않도록 분량을 조정했습니다.",
+                                "overallReason": "단어 암기와 RC 강의 수강을 병행하고 마감 D-1에 최종 점검을 배치했습니다. 하루 투자시간의 50%를 초과하지 않도록 분량을 조정했습니다. 사용 교재: 해커스 토익 기출 VOCA (저자: 해커스어학연구소 / 출판사: 해커스어학원 / 링크: https://www.yes24.com/product/goods/97469327), 해커스 토익 실전 1000제 RC (저자: 해커스어학연구소 / 출판사: 해커스어학원 / 링크: https://www.yes24.com/product/goods/74369738).",
                                 "todos": [
                                   {
                                     "type": "RECURRING",
                                     "title": "해커스 보카 30단어 암기 및 복습",
                                     "dueDate": "2025-08-25T00:00:00",
                                     "routineType": "DAILY",
-                                    "routineDate": null,
-                                    "reason": "목표 달성을 위해 매일 꾸준한 단어 암기가 필요합니다.",
-                                    "source": "해커스"
+                                    "routineDate": null
                                   },
                                   {
                                     "type": "ONE_TIME",
                                     "title": "해커스 RC 1~5강 수강",
                                     "dueDate": "2025-06-10T00:00:00",
                                     "routineType": null,
-                                    "routineDate": null,
-                                    "reason": "RC 파트의 기초 개념을 먼저 잡아야 이후 문제 풀이 효율이 높아집니다.",
-                                    "source": "해커스"
+                                    "routineDate": null
                                   },
                                   {
                                     "type": "ONE_TIME",
                                     "title": "실전 모의고사 최종 점검",
                                     "dueDate": "2025-08-24T00:00:00",
                                     "routineType": null,
-                                    "routineDate": null,
-                                    "reason": "마감 D-1일에 전체 실력을 점검하여 시험 당일 컨디션을 최적화합니다.",
-                                    "source": null
+                                    "routineDate": null
                                   }
                                 ]
                               },

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -759,7 +759,8 @@ public interface GoalControllerDocs {
           | todos | array | 추천 투두 목록 |
           | todos[].type | string | `ONE_TIME` (일회형) 또는 `RECURRING` (반복형) |
           | todos[].title | string | 투두 제목 |
-          | todos[].dueDate | string | 마감일 (ISO 8601). 없으면 null |
+          | todos[].dueDate | string | 마감 날짜 (yyyy-MM-dd 형식). 없으면 null |
+          | todos[].dueTime | string | 마감 시간 (HH:mm 형식). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
           | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자. DAILY·ONE_TIME: null |
 
@@ -790,21 +791,24 @@ public interface GoalControllerDocs {
                                   {
                                     "type": "RECURRING",
                                     "title": "해커스 보카 30단어 암기 및 복습",
-                                    "dueDate": "2025-08-25T00:00:00",
+                                    "dueDate": "2025-08-25",
+                                    "dueTime": null,
                                     "routineType": "DAILY",
                                     "routineDate": null
                                   },
                                   {
                                     "type": "ONE_TIME",
                                     "title": "해커스 RC 1~5강 수강",
-                                    "dueDate": "2025-06-10T00:00:00",
+                                    "dueDate": "2025-06-10",
+                                    "dueTime": "08:00",
                                     "routineType": null,
                                     "routineDate": null
                                   },
                                   {
                                     "type": "ONE_TIME",
                                     "title": "실전 모의고사 최종 점검",
-                                    "dueDate": "2025-08-24T00:00:00",
+                                    "dueDate": "2025-08-24",
+                                    "dueTime": null,
                                     "routineType": null,
                                     "routineDate": null
                                   }

--- a/src/main/java/plana/replan/domain/goal/dto/common/GoalSingleResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/common/GoalSingleResponse.java
@@ -5,14 +5,14 @@ import java.time.LocalDateTime;
 import plana.replan.domain.goal.entity.Goal;
 
 @Schema(description = "목표 단건 응답")
-public record GoalSingleResponseDto(
+public record GoalSingleResponse(
     @Schema(description = "목표 ID", example = "10") Long id,
     @Schema(description = "목표 제목", example = "토익 850점 달성") String title,
     @Schema(description = "마감기한 (없으면 null)", example = "2026-05-26T20:00:00") LocalDateTime dueDate,
     @Schema(description = "참고 자료 (없으면 null)", example = "https://toeic.ets.org") String reference) {
 
-  public static GoalSingleResponseDto from(Goal goal) {
-    return new GoalSingleResponseDto(
+  public static GoalSingleResponse from(Goal goal) {
+    return new GoalSingleResponse(
         goal.getId(), goal.getTitle(), goal.getDueDate(), goal.getReference());
   }
 }

--- a/src/main/java/plana/replan/domain/goal/dto/create/GoalCreateRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/GoalCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 
 @Schema(description = "목표 생성 요청")
-public record GoalCreateRequestDto(
+public record GoalCreateRequest(
     @Schema(
             description = "목표 제목",
             example = "토익 900점 달성",

--- a/src/main/java/plana/replan/domain/goal/dto/list/GoalsByDateResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/list/GoalsByDateResponse.java
@@ -3,9 +3,9 @@ package plana.replan.domain.goal.dto.list;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
 
 @Schema(description = "날짜별 목표 묶음")
-public record GoalsByDateResponseDto(
+public record GoalsByDateResponse(
     @Schema(description = "생성 날짜 (yyyy-MM-dd)", example = "2026-05-04") LocalDate date,
-    @Schema(description = "해당 날짜에 생성된 목표 목록") List<GoalSingleResponseDto> goals) {}
+    @Schema(description = "해당 날짜에 생성된 목표 목록") List<GoalSingleResponse> goals) {}

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -3,7 +3,7 @@ package plana.replan.domain.goal.dto.recommend;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "AI 추천 투두 항목")
-public record RecommendedTodoDto(
+public record RecommendedTodo(
     @Schema(
             description = "투두 유형. ONE_TIME: 일회형, RECURRING: 반복형",
             example = "RECURRING",

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -26,8 +26,4 @@ public record RecommendedTodo(
                 "반복 날짜 (RECURRING만 사용). WEEKLY: 요일 bitmask (월=1,화=2,수=4,목=8,금=16,토=32,일=64). MONTHLY: 일자(1~31). DAILY: null.",
             example = "62",
             nullable = true)
-        Integer routineDate,
-    @Schema(description = "AI가 이 투두를 생성한 이유", example = "목표 달성을 위해 매일 꾸준한 단어 암기가 필요합니다.")
-        String reason,
-    @Schema(description = "출처 정보. 강의면 플랫폼명, 책이면 저자명. 해당 없으면 null", example = "인프런", nullable = true)
-        String source) {}
+        Integer routineDate) {}

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -11,10 +11,12 @@ public record RecommendedTodo(
         String type,
     @Schema(description = "투두 제목", example = "해커스 보카 30단어 암기") String title,
     @Schema(
-            description = "마감일 (ISO 8601 형식). 없으면 null",
-            example = "2025-08-25T00:00:00",
+            description = "마감 날짜 (yyyy-MM-dd 형식). 없으면 null",
+            example = "2025-08-25",
             nullable = true)
         String dueDate,
+    @Schema(description = "마감 시간 (HH:mm 형식). 없으면 null", example = "08:00", nullable = true)
+        String dueTime,
     @Schema(
             description = "반복 유형 (RECURRING만 사용). DAILY·WEEKLY·MONTHLY",
             example = "WEEKLY",

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "AI 투두 추천 요청 (정제된 값을 입력 권장)")
-public record TodoRecommendationRequestDto(
+public record TodoRecommendationRequest(
     @Schema(
             description = "목표",
             example = "토익 900점 달성 (LC 450·RC 450 이상)",
@@ -12,26 +12,27 @@ public record TodoRecommendationRequestDto(
         @NotBlank(message = "목표는 필수입니다.")
         String goal,
     @Schema(
-            description = "마감기한",
+            description = "마감 날짜 (yyyy-MM-dd 형식)",
             example = "2025-08-25",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "마감기한은 필수입니다.")
-        String deadline,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String deadlineDate,
+    @Schema(
+            description = "마감 시간 (HH:mm 형식)",
+            example = "08:00",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String deadlineTime,
     @Schema(
             description = "현재 수준",
             example = "토익 600점 (LC 310·RC 290 추정)",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "현재 수준은 필수입니다.")
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String currentLevel,
     @Schema(
             description = "투자 가능 시간",
             example = "평일 1시간·주말 4시간 (주 약 13시간)",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "투자 가능 시간은 필수입니다.")
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String availableTime,
     @Schema(
             description = "특이사항",
             example = "해커스 보카·RC·LC 활용. 주 1회 모의고사. 매주 오답 노트 정리.",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "특이사항은 필수입니다.")
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String notes) {}

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationResponse.java
@@ -1,0 +1,9 @@
+package plana.replan.domain.goal.dto.recommend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "AI 투두 추천 결과")
+public record TodoRecommendationResponse(
+    @Schema(description = "전체 추천에 대한 총평") String overallReason,
+    @Schema(description = "추천 투두 목록") List<RecommendedTodo> todos) {}

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationResponseDto.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/TodoRecommendationResponseDto.java
@@ -1,8 +1,0 @@
-package plana.replan.domain.goal.dto.recommend;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-
-@Schema(description = "AI 투두 추천 결과")
-public record TodoRecommendationResponseDto(
-    @Schema(description = "추천 투두 목록") List<RecommendedTodoDto> todos) {}

--- a/src/main/java/plana/replan/domain/goal/dto/refine/GoalRefinementRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/refine/GoalRefinementRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "AI 목표 정제 요청")
-public record GoalRefinementRequestDto(
+public record GoalRefinementRequest(
     @Schema(
             description = "목표 (자연어)",
             example = "토익 900점",

--- a/src/main/java/plana/replan/domain/goal/dto/refine/GoalRefinementResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/refine/GoalRefinementResponse.java
@@ -3,7 +3,7 @@ package plana.replan.domain.goal.dto.refine;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "AI 목표 정제 결과")
-public record GoalRefinementResponseDto(
+public record GoalRefinementResponse(
     @Schema(description = "정제된 목표") RefinedField goal,
     @Schema(description = "정제된 마감기한") RefinedDeadline deadline,
     @Schema(description = "정제된 현재 수준") RefinedField currentLevel,

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -168,22 +168,25 @@ public class GoalAiService {
            예) "인프런 - 한입 리액트 13강 컴포넌트 만들기 수강" (검색으로 확인된 실제 제목)
         4. 1회 투두 분량은 하루 투자시간의 50%%를 초과하지 않는다
         5. 교재·강의가 없으면 notes에 제공된 정보만으로 투두 생성 (새 교재·강의 검색·추천 금지)
-        6. source 필드: 강의면 플랫폼명(인프런, freeCodeCamp, 해커스 등), 책이면 저자명, 해당 없으면 null
-        7. RECURRING 투두는 매번 내용이 동일한 작업만 해당 (예: 매일 단어 암기, 매일 운동)
-        8. 인강 수강처럼 매번 다른 내용을 학습하는 것은 ONE_TIME 투두 여러 개로 생성
-        9. 이론 나열 금지. '수기 복습', '문제 풀이', '오답 노트' 등 아웃풋 태스크 반드시 중간에 배치
-        10. 마감 D-1~2는 진도 금지. '최종 점검', '백지 복습' 등 마무리 태스크만 배치
-        11. WEEKLY routineDate는 bitmask: 월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64
-        12. MONTHLY routineDate는 일자(1~31)
-        13. DAILY는 routineDate 불필요 (null)
-        14. dueDate는 yyyy-MM-ddT00:00:00 형식 또는 null
-        15. type은 "ONE_TIME" 또는 "RECURRING"만 허용
-        16. routineType은 "DAILY", "WEEKLY", "MONTHLY" 중 하나 (ONE_TIME이면 null)
-        17. reason 포함 모든 텍스트는 "~합니다", "~했습니다" 등 서술형으로 작성. "~하세요", "~하시기 바랍니다" 등 조언·명령형 말투 절대 금지
-        18. overallReason: 이 추천 전체에 대한 총평. 어떤 기준으로 투두를 구성했는지, 핵심 전략이 무엇인지 2~3문장 서술체로 작성
+        6. RECURRING 투두는 매번 내용이 동일한 작업만 해당 (예: 매일 단어 암기, 매일 운동)
+        7. 인강 수강처럼 매번 다른 내용을 학습하는 것은 ONE_TIME 투두 여러 개로 생성
+        8. 이론 나열 금지. '수기 복습', '문제 풀이', '오답 노트' 등 아웃풋 태스크 반드시 중간에 배치
+        9. 마감 D-1~2는 진도 금지. '최종 점검', '백지 복습' 등 마무리 태스크만 배치
+        10. WEEKLY routineDate는 bitmask: 월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64
+        11. MONTHLY routineDate는 일자(1~31)
+        12. DAILY는 routineDate 불필요 (null)
+        13. dueDate는 yyyy-MM-ddT00:00:00 형식 또는 null
+        14. type은 "ONE_TIME" 또는 "RECURRING"만 허용
+        15. routineType은 "DAILY", "WEEKLY", "MONTHLY" 중 하나 (ONE_TIME이면 null)
+        16. overallReason: 이 추천 전체에 대한 총평을 서술체("~합니다", "~했습니다")로 작성. 조언·명령형("~하세요") 절대 금지.
+            - 어떤 기준으로 투두를 구성했는지, 핵심 전략이 무엇인지 서술
+            - 교재·강의가 포함된 경우 각 항목마다 아래 형식으로 출처 정보를 포함:
+              · 책: "교재명 (저자: OOO / 출판사: OOO / 링크: https://...)"
+              · 강의: "강의명 (강사: OOO / 플랫폼: OOO / 링크: https://...)"
+            - 링크는 Google Search로 확인된 실제 URL만 사용. 확인 불가 시 링크 생략
 
         반드시 아래 JSON만 출력하세요 (다른 설명 없이):
-        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"routineType":null,"routineDate":null,"reason":"","source":null}]}
+        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"routineType":null,"routineDate":null}]}
         """
         .formatted(
             req.goal(),
@@ -225,13 +228,7 @@ public class GoalAiService {
             throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
           }
         }
-        String reason = node.path("reason").asText(null);
-        String source =
-            node.path("source").isNull() || node.path("source").isMissingNode()
-                ? null
-                : node.path("source").asText(null);
-        todos.add(
-            new RecommendedTodo(type, title, dueDate, routineType, routineDate, reason, source));
+        todos.add(new RecommendedTodo(type, title, dueDate, routineType, routineDate));
       }
       return new TodoRecommendationResponse(overallReason, todos);
     } catch (Exception e) {

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -175,7 +175,7 @@ public class GoalAiService {
         10. WEEKLY routineDate는 bitmask: 월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64
         11. MONTHLY routineDate는 일자(1~31)
         12. DAILY는 routineDate 불필요 (null)
-        13. dueDate는 yyyy-MM-ddT00:00:00 형식 또는 null
+        13. dueDate는 yyyy-MM-dd 형식 또는 null, dueTime은 HH:mm 형식 또는 null
         14. type은 "ONE_TIME" 또는 "RECURRING"만 허용
         15. routineType은 "DAILY", "WEEKLY", "MONTHLY" 중 하나 (ONE_TIME이면 null)
         16. overallReason: 이 추천 전체에 대한 총평을 서술체("~합니다", "~했습니다")로 작성. 조언·명령형("~하세요") 절대 금지.
@@ -186,7 +186,7 @@ public class GoalAiService {
             - 링크는 Google Search로 확인된 실제 URL만 사용. 확인 불가 시 링크 생략
 
         반드시 아래 JSON만 출력하세요 (다른 설명 없이):
-        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"routineType":null,"routineDate":null}]}
+        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"dueTime":null,"routineType":null,"routineDate":null}]}
         """
         .formatted(
             req.goal(),
@@ -215,6 +215,7 @@ public class GoalAiService {
         String type = node.path("type").asText();
         String title = node.path("title").asText();
         String dueDate = node.path("dueDate").isNull() ? null : node.path("dueDate").asText(null);
+        String dueTime = node.path("dueTime").isNull() ? null : node.path("dueTime").asText(null);
         String routineType =
             node.path("routineType").isNull() ? null : node.path("routineType").asText(null);
         Integer routineDate = null;
@@ -228,7 +229,7 @@ public class GoalAiService {
             throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
           }
         }
-        todos.add(new RecommendedTodo(type, title, dueDate, routineType, routineDate));
+        todos.add(new RecommendedTodo(type, title, dueDate, dueTime, routineType, routineDate));
       }
       return new TodoRecommendationResponse(overallReason, todos);
     } catch (Exception e) {

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -14,11 +14,11 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
-import plana.replan.domain.goal.dto.recommend.RecommendedTodoDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequestDto;
-import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponseDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementRequestDto;
-import plana.replan.domain.goal.dto.refine.GoalRefinementResponseDto;
+import plana.replan.domain.goal.dto.recommend.RecommendedTodo;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
+import plana.replan.domain.goal.dto.refine.GoalRefinementRequest;
+import plana.replan.domain.goal.dto.refine.GoalRefinementResponse;
 import plana.replan.domain.goal.dto.refine.RefinedDeadline;
 import plana.replan.domain.goal.dto.refine.RefinedField;
 import plana.replan.domain.goal.dto.refine.RefinedNoteItem;
@@ -40,14 +40,14 @@ public class GoalAiService {
   @Value("${gemini.api-key}")
   private String apiKey;
 
-  public GoalRefinementResponseDto refineGoal(GoalRefinementRequestDto request) {
+  public GoalRefinementResponse refineGoal(GoalRefinementRequest request) {
     String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
     String prompt = buildRefinePrompt(request, today);
     String raw = callGemini(prompt);
     return parseRefineResponse(raw);
   }
 
-  private String buildRefinePrompt(GoalRefinementRequestDto req, String today) {
+  private String buildRefinePrompt(GoalRefinementRequest req, String today) {
     return """
         당신은 목표 달성 플래닝 전문가입니다.
         사용자가 제공한 목표 초안을 분석하고, 투두 리스트 생성에 최적화되도록 정제하세요.
@@ -91,7 +91,7 @@ public class GoalAiService {
             today);
   }
 
-  private GoalRefinementResponseDto parseRefineResponse(String raw) {
+  private GoalRefinementResponse parseRefineResponse(String raw) {
     try {
       String json = extractJson(raw);
       JsonNode root = objectMapper.readTree(json);
@@ -123,20 +123,21 @@ public class GoalAiService {
       }
       RefinedNotes notes = new RefinedNotes(noteItems, notesNode.path("reason").asText());
 
-      return new GoalRefinementResponseDto(goal, deadline, currentLevel, availableTime, notes);
+      return new GoalRefinementResponse(goal, deadline, currentLevel, availableTime, notes);
     } catch (Exception e) {
       log.error("Gemini refine 응답 파싱 실패: {}", raw, e);
       throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
     }
   }
 
-  public TodoRecommendationResponseDto recommendTodos(TodoRecommendationRequestDto request) {
+  public TodoRecommendationResponse recommendTodos(TodoRecommendationRequest request) {
     String prompt = buildRecommendPrompt(request);
     String raw = callGemini(prompt);
     return parseRecommendResponse(raw);
   }
 
-  private String buildRecommendPrompt(TodoRecommendationRequestDto req) {
+  private String buildRecommendPrompt(TodoRecommendationRequest req) {
+    String deadlineInfo = buildDeadlineInfo(req.deadlineDate(), req.deadlineTime());
     return """
         당신은 목표 달성 플래닝 전문가입니다.
 
@@ -179,21 +180,34 @@ public class GoalAiService {
         15. type은 "ONE_TIME" 또는 "RECURRING"만 허용
         16. routineType은 "DAILY", "WEEKLY", "MONTHLY" 중 하나 (ONE_TIME이면 null)
         17. reason 포함 모든 텍스트는 "~합니다", "~했습니다" 등 서술형으로 작성. "~하세요", "~하시기 바랍니다" 등 조언·명령형 말투 절대 금지
+        18. overallReason: 이 추천 전체에 대한 총평. 어떤 기준으로 투두를 구성했는지, 핵심 전략이 무엇인지 2~3문장 서술체로 작성
 
         반드시 아래 JSON만 출력하세요 (다른 설명 없이):
-        {"todos":[{"type":"","title":"","dueDate":null,"routineType":null,"routineDate":null,"reason":"","source":null}]}
+        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"routineType":null,"routineDate":null,"reason":"","source":null}]}
         """
         .formatted(
-            req.goal(), req.deadline(), req.currentLevel(), req.availableTime(), req.notes());
+            req.goal(),
+            deadlineInfo,
+            req.currentLevel() != null ? req.currentLevel() : "미입력",
+            req.availableTime() != null ? req.availableTime() : "미입력",
+            req.notes() != null ? req.notes() : "미입력");
   }
 
-  private TodoRecommendationResponseDto parseRecommendResponse(String raw) {
+  private String buildDeadlineInfo(String deadlineDate, String deadlineTime) {
+    if (deadlineDate == null && deadlineTime == null) return "미입력";
+    if (deadlineDate != null && deadlineTime != null) return deadlineDate + " " + deadlineTime;
+    if (deadlineDate != null) return deadlineDate;
+    return deadlineTime;
+  }
+
+  private TodoRecommendationResponse parseRecommendResponse(String raw) {
     try {
       String json = extractJson(raw);
       JsonNode root = objectMapper.readTree(json);
+      String overallReason = root.path("overallReason").asText(null);
       JsonNode todosNode = root.path("todos");
 
-      List<RecommendedTodoDto> todos = new ArrayList<>();
+      List<RecommendedTodo> todos = new ArrayList<>();
       for (JsonNode node : todosNode) {
         String type = node.path("type").asText();
         String title = node.path("title").asText();
@@ -217,9 +231,9 @@ public class GoalAiService {
                 ? null
                 : node.path("source").asText(null);
         todos.add(
-            new RecommendedTodoDto(type, title, dueDate, routineType, routineDate, reason, source));
+            new RecommendedTodo(type, title, dueDate, routineType, routineDate, reason, source));
       }
-      return new TodoRecommendationResponseDto(todos);
+      return new TodoRecommendationResponse(overallReason, todos);
     } catch (Exception e) {
       log.error("Gemini recommend 응답 파싱 실패: {}", raw, e);
       throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);

--- a/src/main/java/plana/replan/domain/goal/service/GoalService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalService.java
@@ -9,9 +9,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
-import plana.replan.domain.goal.dto.create.GoalCreateRequestDto;
-import plana.replan.domain.goal.dto.list.GoalsByDateResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
+import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.entity.Goal;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
@@ -28,7 +28,7 @@ public class GoalService {
   private final UserRepository userRepository;
 
   @Transactional
-  public GoalSingleResponseDto createGoal(Long userId, GoalCreateRequestDto request) {
+  public GoalSingleResponse createGoal(Long userId, GoalCreateRequest request) {
     User user = findUser(userId);
     Goal goal =
         Goal.builder()
@@ -37,7 +37,7 @@ public class GoalService {
             .reference(request.reference())
             .user(user)
             .build();
-    return GoalSingleResponseDto.from(goalRepository.save(goal));
+    return GoalSingleResponse.from(goalRepository.save(goal));
   }
 
   @Transactional
@@ -53,7 +53,7 @@ public class GoalService {
   }
 
   @Transactional(readOnly = true)
-  public List<GoalsByDateResponseDto> getGoals(Long userId, Integer year, Integer month) {
+  public List<GoalsByDateResponse> getGoals(Long userId, Integer year, Integer month) {
     if (year == null && month != null) {
       throw new CustomException(GoalErrorCode.GOAL_INVALID_FILTER);
     }
@@ -80,11 +80,11 @@ public class GoalService {
     return byDate.entrySet().stream()
         .map(
             e ->
-                new GoalsByDateResponseDto(
+                new GoalsByDateResponse(
                     e.getKey(),
                     e.getValue().stream()
                         .sorted(Comparator.comparing(Goal::getId))
-                        .map(GoalSingleResponseDto::from)
+                        .map(GoalSingleResponse::from)
                         .toList()))
         .toList();
   }

--- a/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
+++ b/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
@@ -24,8 +24,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
-import plana.replan.domain.goal.dto.list.GoalsByDateResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
+import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.service.GoalAiService;
 import plana.replan.domain.goal.service.GoalService;
@@ -52,8 +52,8 @@ class GoalControllerTest {
 
   @Test
   void 목표_생성_성공() throws Exception {
-    GoalSingleResponseDto mockResponse =
-        new GoalSingleResponseDto(
+    GoalSingleResponse mockResponse =
+        new GoalSingleResponse(
             42L, "토익 900점 달성", LocalDateTime.of(2025, 12, 31, 0, 0), "https://toeic.ets.org");
     given(goalService.createGoal(any(), any())).willReturn(mockResponse);
 
@@ -81,7 +81,7 @@ class GoalControllerTest {
 
   @Test
   void 목표_생성_optional_필드_생략해도_200() throws Exception {
-    GoalSingleResponseDto mockResponse = new GoalSingleResponseDto(42L, "토익", null, null);
+    GoalSingleResponse mockResponse = new GoalSingleResponse(42L, "토익", null, null);
     given(goalService.createGoal(any(), any())).willReturn(mockResponse);
 
     mockMvc
@@ -194,10 +194,10 @@ class GoalControllerTest {
 
   @Test
   void 목표_조회_성공_전체() throws Exception {
-    GoalSingleResponseDto goal =
-        new GoalSingleResponseDto(10L, "토익 900점", LocalDateTime.of(2026, 5, 26, 20, 0), null);
-    GoalsByDateResponseDto dateGroup =
-        new GoalsByDateResponseDto(LocalDate.of(2026, 5, 4), List.of(goal));
+    GoalSingleResponse goal =
+        new GoalSingleResponse(10L, "토익 900점", LocalDateTime.of(2026, 5, 26, 20, 0), null);
+    GoalsByDateResponse dateGroup =
+        new GoalsByDateResponse(LocalDate.of(2026, 5, 4), List.of(goal));
     given(goalService.getGoals(any(), any(), any())).willReturn(List.of(dateGroup));
 
     mockMvc

--- a/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import plana.replan.domain.goal.dto.common.GoalSingleResponseDto;
-import plana.replan.domain.goal.dto.create.GoalCreateRequestDto;
-import plana.replan.domain.goal.dto.list.GoalsByDateResponseDto;
+import plana.replan.domain.goal.dto.common.GoalSingleResponse;
+import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.entity.Goal;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
@@ -49,11 +49,11 @@ class GoalServiceTest {
     given(savedGoal.getReference()).willReturn("https://toeic.ets.org");
     given(goalRepository.save(any())).willReturn(savedGoal);
 
-    GoalCreateRequestDto request =
-        new GoalCreateRequestDto(
+    GoalCreateRequest request =
+        new GoalCreateRequest(
             "토익 900점 달성", LocalDateTime.of(2025, 12, 31, 0, 0), "https://toeic.ets.org");
 
-    GoalSingleResponseDto response = goalService.createGoal(1L, request);
+    GoalSingleResponse response = goalService.createGoal(1L, request);
 
     assertThat(response.id()).isEqualTo(42L);
     assertThat(response.title()).isEqualTo("토익 900점 달성");
@@ -73,9 +73,9 @@ class GoalServiceTest {
     given(savedGoal.getReference()).willReturn(null);
     given(goalRepository.save(any())).willReturn(savedGoal);
 
-    GoalCreateRequestDto request = new GoalCreateRequestDto("독서 50권", null, null);
+    GoalCreateRequest request = new GoalCreateRequest("독서 50권", null, null);
 
-    GoalSingleResponseDto response = goalService.createGoal(1L, request);
+    GoalSingleResponse response = goalService.createGoal(1L, request);
 
     assertThat(response.title()).isEqualTo("독서 50권");
     assertThat(response.dueDate()).isNull();
@@ -86,8 +86,7 @@ class GoalServiceTest {
   void 목표_생성_유저_없음_404() {
     given(userRepository.findById(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(
-            () -> goalService.createGoal(999L, new GoalCreateRequestDto("제목", null, null)))
+    assertThatThrownBy(() -> goalService.createGoal(999L, new GoalCreateRequest("제목", null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -158,7 +157,7 @@ class GoalServiceTest {
     given(goalRepository.findByUserOrderByCreatedAtDescIdAsc(user))
         .willReturn(List.of(goal1, goal2));
 
-    List<GoalsByDateResponseDto> result = goalService.getGoals(1L, null, null);
+    List<GoalsByDateResponse> result = goalService.getGoals(1L, null, null);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0).date()).isEqualTo(LocalDate.of(2026, 5, 4));
@@ -179,7 +178,7 @@ class GoalServiceTest {
     given(goalRepository.findByUserOrderByCreatedAtDescIdAsc(user))
         .willReturn(List.of(goal1, goal2));
 
-    List<GoalsByDateResponseDto> result = goalService.getGoals(1L, null, null);
+    List<GoalsByDateResponse> result = goalService.getGoals(1L, null, null);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).goals().get(0).id()).isEqualTo(8L);
@@ -194,7 +193,7 @@ class GoalServiceTest {
     Goal goal = mockGoal(10L, "토익", null, null, LocalDateTime.of(2026, 5, 4, 10, 0));
     given(goalRepository.findByUserAndCreatedAtYear(user, 2026)).willReturn(List.of(goal));
 
-    List<GoalsByDateResponseDto> result = goalService.getGoals(1L, 2026, null);
+    List<GoalsByDateResponse> result = goalService.getGoals(1L, 2026, null);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).goals().get(0).title()).isEqualTo("토익");
@@ -209,7 +208,7 @@ class GoalServiceTest {
     given(goalRepository.findByUserAndCreatedAtYearAndMonth(user, 2026, 5))
         .willReturn(List.of(goal));
 
-    List<GoalsByDateResponseDto> result = goalService.getGoals(1L, 2026, 5);
+    List<GoalsByDateResponse> result = goalService.getGoals(1L, 2026, 5);
 
     assertThat(result).hasSize(1);
   }
@@ -252,7 +251,7 @@ class GoalServiceTest {
     Goal goal = mockGoal(10L, "마감없는 목표", null, null, LocalDateTime.of(2026, 5, 4, 10, 0));
     given(goalRepository.findByUserOrderByCreatedAtDescIdAsc(user)).willReturn(List.of(goal));
 
-    List<GoalsByDateResponseDto> result = goalService.getGoals(1L, null, null);
+    List<GoalsByDateResponse> result = goalService.getGoals(1L, null, null);
 
     assertThat(result.get(0).goals().get(0).dueDate()).isNull();
   }


### PR DESCRIPTION
## 작업 내용

### 1. goal 도메인 DTO 파일명 정리

DTO라는 개념은 패키지(`dto/`)로 표현하고, 개별 파일명에서 `Dto` suffix를 제거했습니다.

| 변경 전 | 변경 후 |
|--------|---------|
| `GoalSingleResponseDto` | `GoalSingleResponse` |
| `GoalCreateRequestDto` | `GoalCreateRequest` |
| `GoalsByDateResponseDto` | `GoalsByDateResponse` |
| `RecommendedTodoDto` | `RecommendedTodo` |
| `TodoRecommendationRequestDto` | `TodoRecommendationRequest` |
| `TodoRecommendationResponseDto` | `TodoRecommendationResponse` |
| `GoalRefinementRequestDto` | `GoalRefinementRequest` |
| `GoalRefinementResponseDto` | `GoalRefinementResponse` |

### 2. 투두 추천 Request 파라미터 개선

- `deadline` 단일 필드 → `deadlineDate` (yyyy-MM-dd) + `deadlineTime` (HH:mm) 분리
- `goal`만 필수, 나머지(`deadlineDate`, `deadlineTime`, `currentLevel`, `availableTime`, `notes`) 전부 선택으로 변경

### 3. 투두 추천 Response 개선

- `overallReason` 필드 추가: 전체 추천에 대한 총평. 교재·강의가 포함된 경우 저자/출판사/링크 또는 강사/플랫폼/링크를 함께 제공
- 투두별 `reason`, `source` 필드 제거: 출처 정보는 `overallReason`에 통합
- `dueDate` (ISO 8601) → `dueDate` (yyyy-MM-dd) + `dueTime` (HH:mm) 분리

### 4. AI 프롬프트 수정

- deadline 분리 입력 처리
- `overallReason`에 출처 정보 포함 지침 추가
- 불필요한 `source`, `reason` 출력 지시 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * API 응답 형식을 일관되게 정규화하여 구조 명확성 향상
  * 목표 및 일정 관련 API 응답 타입 정리

* **Bug Fixes**
  * 태그 삭제 시 연관된 할일 및 루틴의 태그 참조가 자동으로 제거되어 데이터 부정합 해결

* **Improvements**
  * 할일 추천 응답을 전체 추천 이유와 항목 목록으로 개선하여 사용성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->