### PR TITLE
v0.10.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 ## 필수 규칙
 
+### 작업 시작 절차
+모든 신규 작업은 다음 순서로 시작한다.
+
+1. `git checkout develop && git pull` — develop 브랜치 최신화
+2. GitHub 이슈 생성 — 반드시 `.github/ISSUE_TEMPLATE/이슈-템플릿.md` 템플릿 구조(`Issue?`, `Details`, `References`)를 그대로 사용한다.
+3. `git checkout -b {type}/{issueNumber}-{slug}` — 이슈 번호를 포함한 브랜치를 develop 기준으로 생성하고 체크아웃
+4. 위 절차를 완료한 뒤에야 코드 작업을 시작한다.
+
 ### 빌드 & 테스트
 **매 작업 완료 후 반드시 빌드(테스트 포함)를 실행해야 한다.**
 

--- a/src/main/java/plana/replan/domain/tag/controller/TagController.java
+++ b/src/main/java/plana/replan/domain/tag/controller/TagController.java
@@ -1,11 +1,13 @@
 package plana.replan.domain.tag.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -24,6 +26,13 @@ import plana.replan.global.common.ApiResult;
 public class TagController implements TagControllerDocs {
 
   private final TagService tagService;
+
+  @Override
+  @GetMapping
+  public ResponseEntity<ApiResult<List<TagResponseDto>>> getTags(
+      @AuthenticationPrincipal Long userId) {
+    return ResponseEntity.ok(ApiResult.ok(tagService.getTags(userId)));
+  }
 
   @Override
   @PostMapping

--- a/src/main/java/plana/replan/domain/tag/controller/TagControllerDocs.java
+++ b/src/main/java/plana/replan/domain/tag/controller/TagControllerDocs.java
@@ -22,6 +22,118 @@ import plana.replan.global.common.ApiResult;
 public interface TagControllerDocs {
 
   @Operation(
+      summary = "태그 목록 조회",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          로그인 사용자가 보유한 모든 태그를 최신 생성순(createdAt 내림차순, 동일 시각이면 id 내림차순)으로 반환합니다.
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          **Response Elements**
+
+          | 필드명 | 타입 | 설명 |
+          |--------|------|------|
+          | tagId | integer | 태그 ID |
+          | title | string | 태그 이름 |
+          | color | string | 태그 색상 (RED/ORANGE/YELLOW/GREEN/BLUE/PURPLE/PINK/GRAY). 색상이 지정되지 않은 경우 null |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "태그 목록 조회 성공",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "태그 목록",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": [
+                              {
+                                "tagId": 3,
+                                "title": "업무",
+                                "color": "RED"
+                              },
+                              {
+                                "tagId": 2,
+                                "title": "독서",
+                                "color": null
+                              },
+                              {
+                                "tagId": 1,
+                                "title": "영어",
+                                "color": "BLUE"
+                              }
+                            ],
+                            "error": null
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "빈 목록",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": [],
+                            "error": null
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<java.util.List<TagResponseDto>>> getTags(
+      @AuthenticationPrincipal Long userId);
+
+  @Operation(
       summary = "태그 생성",
       description =
           """

--- a/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
+++ b/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
@@ -1,6 +1,11 @@
 package plana.replan.domain.tag.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.user.entity.User;
 
-public interface TagRepository extends JpaRepository<Tag, Long> {}
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+  List<Tag> findAllByUserOrderByCreatedAtDescIdDesc(User user);
+}

--- a/src/main/java/plana/replan/domain/tag/service/TagService.java
+++ b/src/main/java/plana/replan/domain/tag/service/TagService.java
@@ -1,5 +1,6 @@
 package plana.replan.domain.tag.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,21 @@ public class TagService {
   private final UserRepository userRepository;
   private final TodoRepository todoRepository;
   private final RoutineRepository routineRepository;
+
+  @Transactional(readOnly = true)
+  public List<TagResponseDto> getTags(Long userId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    return tagRepository.findAllByUserOrderByCreatedAtDescIdDesc(user).stream()
+        .map(TagResponseDto::from)
+        .toList();
+  }
 
   @Transactional
   public TagResponseDto createTag(Long userId, TagCreateRequestDto request) {


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 문서 관련
- [ ] 기타


## Related Issues
close #128


## 변경 사항
### 기능 추가
- **태그 목록 조회 API (`GET /api/tags`)**
  - 로그인 유저가 보유한 모든 태그를 최신 생성순(`createdAt DESC`, 동일 시각이면 `id DESC`)으로 반환
  - 응답: `ApiResult<List<TagResponseDto>>` (`tagId`, `title`, `color`)
  - soft delete 된 태그는 자동 제외(`@SQLRestriction`)
  - Swagger 문서화 추가(Headers / Response Elements 표, 200·401 예시)

### 문서
- **CLAUDE.md "작업 시작 절차" 규칙 추가**
  - 모든 신규 작업은 `git checkout develop && git pull` → 이슈 템플릿 기반 이슈 생성 → `git checkout -b {type}/{issueNumber}-{slug}` 순서로 시작
  - 위 절차를 완료한 뒤에야 코드 작업 시작


## 테스트 결과
- `./gradlew build` 통과 (테스트 포함)
- 수동 확인 항목
  - [x] Swagger UI 에서 `GET /api/tags` 문서 노출 및 예시 정상 표시
  - [x] 태그 생성 후 목록 조회 시 최신순 정렬 확인
  - [x] 다른 유저 태그가 섞이지 않는지 확인
  - [ ] soft delete 된 태그가 목록에서 빠지는지 확인