### PR TITLE
feat: 목표+투두 일괄 생성 API

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalController.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalController.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import plana.replan.domain.goal.dto.common.GoalSingleResponse;
 import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateRequest;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
 import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
 import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
@@ -15,6 +17,7 @@ import plana.replan.domain.goal.dto.refine.GoalRefinementRequest;
 import plana.replan.domain.goal.dto.refine.GoalRefinementResponse;
 import plana.replan.domain.goal.service.GoalAiService;
 import plana.replan.domain.goal.service.GoalService;
+import plana.replan.domain.goal.service.GoalWithTodosService;
 import plana.replan.global.common.ApiResult;
 
 @RestController
@@ -24,6 +27,7 @@ public class GoalController implements GoalControllerDocs {
 
   private final GoalService goalService;
   private final GoalAiService goalAiService;
+  private final GoalWithTodosService goalWithTodosService;
 
   @Override
   @PostMapping
@@ -47,6 +51,14 @@ public class GoalController implements GoalControllerDocs {
       @RequestParam(required = false) Integer year,
       @RequestParam(required = false) Integer month) {
     return ResponseEntity.ok(ApiResult.ok(goalService.getGoals(userId, year, month)));
+  }
+
+  @Override
+  @PostMapping("/with-todos")
+  public ResponseEntity<ApiResult<GoalWithTodosCreateResponse>> createGoalWithTodos(
+      @AuthenticationPrincipal Long userId,
+      @Valid @RequestBody GoalWithTodosCreateRequest request) {
+    return ResponseEntity.ok(ApiResult.ok(goalWithTodosService.create(userId, request)));
   }
 
   @Override

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -53,7 +53,8 @@ public interface GoalControllerDocs {
           | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
           |--------|-----------|------|------|------|
           | title | ✅ 필수 | string | 목표 제목. 공백만 있으면 유효성 오류 | `"토익 900점 달성"` |
-          | dueDate | ❌ 선택 | string | 목표 기한 (ISO 8601 형식). 생략 가능 | `"2025-12-31T00:00:00"` |
+          | dueDate | ❌ 선택 | string | 목표 기한 날짜 (yyyy-MM-dd 형식) | `"2025-12-31"` |
+          | dueTime | ❌ 선택 | string | 목표 기한 시간 (HH:mm 형식). dueDate 없이 단독 사용 불가. | `"09:00"` |
           | reference | ❌ 선택 | string | 참고 자료 (URL 또는 자유 텍스트). 생략 가능 | `"https://toeic.ets.org"` |
 
           > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
@@ -62,7 +63,8 @@ public interface GoalControllerDocs {
 
           ### 주의사항
           - `title`이 없거나 공백이면 400 반환
-          - `dueDate`, `reference`는 생략하거나 null로 전달해도 동일하게 처리됨 (null 저장)
+          - `dueTime`만 있고 `dueDate`가 없으면 400 반환
+          - `dueDate`, `dueTime`, `reference`는 생략하거나 null로 전달해도 동일하게 처리됨 (null 저장)
           - JSON 파싱 실패(잘못된 형식, 타입 불일치 등)도 400 반환
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
@@ -180,28 +182,27 @@ public interface GoalControllerDocs {
                                 """
                                 {
                                   "title": "토익 900점 달성",
-                                  "dueDate": "2025-12-31T00:00:00",
+                                  "dueDate": "2025-12-31",
+                                  "dueTime": "09:00",
                                   "reference": "https://toeic.ets.org"
                                 }
                                 """),
                         @ExampleObject(
-                            name = "title만 (optional 생략)",
-                            summary = "dueDate, reference를 생략하면 null로 처리됨",
-                            value =
-                                """
-                                {
-                                  "title": "토익 900점 달성"
-                                }
-                                """),
-                        @ExampleObject(
-                            name = "optional null 명시",
-                            summary = "생략과 동일한 동작",
+                            name = "날짜만 (시간 생략)",
                             value =
                                 """
                                 {
                                   "title": "토익 900점 달성",
-                                  "dueDate": null,
-                                  "reference": null
+                                  "dueDate": "2025-12-31"
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "title만 (optional 생략)",
+                            summary = "dueDate, dueTime, reference를 생략하면 null로 처리됨",
+                            value =
+                                """
+                                {
+                                  "title": "토익 900점 달성"
                                 }
                                 """)
                       }))
@@ -231,7 +232,8 @@ public interface GoalControllerDocs {
           | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
           |--------|-----------|------|------|------|
           | title | ✅ 필수 | string | 목표 제목 | `"토익 900점 달성"` |
-          | dueDate | ❌ 선택 | string | 목표 기한 (ISO 8601 형식) | `"2025-12-31T00:00:00"` |
+          | dueDate | ❌ 선택 | string | 목표 기한 날짜 (yyyy-MM-dd 형식) | `"2025-12-31"` |
+          | dueTime | ❌ 선택 | string | 목표 기한 시간 (HH:mm 형식). dueDate 없이 단독 사용 불가. | `"09:00"` |
           | reference | ❌ 선택 | string | 참고 자료 (URL 또는 메모) | `"https://toeic.ets.org"` |
           | todos | ✅ 필수 | array | 생성할 투두 목록 | |
           | todos[].type | ✅ 필수 | string | `ONE_TIME` (일반형) 또는 `RECURRING` (반복형) | `"ONE_TIME"` |
@@ -372,7 +374,8 @@ public interface GoalControllerDocs {
                                 """
                                 {
                                   "title": "토익 900점 달성",
-                                  "dueDate": "2025-12-31T00:00:00",
+                                  "dueDate": "2025-12-31",
+                                  "dueTime": "09:00",
                                   "reference": "https://toeic.ets.org",
                                   "todos": [
                                     {

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import plana.replan.domain.goal.dto.common.GoalSingleResponse;
 import plana.replan.domain.goal.dto.create.GoalCreateRequest;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateRequest;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
 import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
 import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
@@ -205,6 +207,215 @@ public interface GoalControllerDocs {
                       }))
           @RequestBody
           GoalCreateRequest request);
+
+  @Operation(
+      summary = "목표+투두 일괄 생성",
+      description =
+          """
+          목표와 투두(일반형/반복형) 및 하위투두를 단일 요청으로 일괄 생성합니다.
+          투두 추천 결과를 그대로 저장할 때 사용합니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          ---
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 목표 제목 | `"토익 900점 달성"` |
+          | dueDate | ❌ 선택 | string | 목표 기한 (ISO 8601 형식) | `"2025-12-31T00:00:00"` |
+          | reference | ❌ 선택 | string | 참고 자료 (URL 또는 메모) | `"https://toeic.ets.org"` |
+          | todos | ✅ 필수 | array | 생성할 투두 목록 | |
+          | todos[].type | ✅ 필수 | string | `ONE_TIME` (일반형) 또는 `RECURRING` (반복형) | `"ONE_TIME"` |
+          | todos[].title | ✅ 필수 | string | 투두 제목 | `"단어 암기"` |
+          | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
+          | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
+          | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
+          | todos[].routineDate | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자(1~31), DAILY: null | `null` |
+          | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
+          | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
+
+          > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
+
+          ---
+
+          ### Response Elements
+
+          | 필드명 | 타입 | 설명 |
+          |--------|------|------|
+          | goalId | integer | 생성된 목표 ID |
+          | todos | array | 생성된 투두/루틴 목록 |
+          | todos[].type | string | `ONE_TIME` 또는 `RECURRING` |
+          | todos[].title | string | 투두 제목 |
+          | todos[].todoId | integer | 생성된 투두 ID. ONE_TIME만 해당. RECURRING이면 null. |
+          | todos[].routineId | integer | 생성된 루틴 ID. RECURRING만 해당. ONE_TIME이면 null. |
+
+          ---
+
+          ### 주의사항
+          - 모든 생성은 단일 트랜잭션으로 처리됩니다. 하나라도 실패하면 전체 롤백됩니다.
+          - RECURRING 투두는 오늘 날짜가 반복 조건과 일치하면 자동으로 오늘의 투두가 생성됩니다.
+          - 하위투두는 ONE_TIME 투두에만 생성할 수 있습니다.
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "일괄 생성 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "goalId": 10,
+                                "todos": [
+                                  { "type": "ONE_TIME", "title": "단어 암기", "todoId": 101, "routineId": null },
+                                  { "type": "RECURRING", "title": "리스닝 연습", "todoId": null, "routineId": 201 }
+                                ]
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "요청 데이터 유효성 오류",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "INVALID_INPUT",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": { "code": "EMPTY_TOKEN", "message": "토큰이 없습니다.", "detail": null }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": { "code": "EXPIRED_TOKEN", "message": "만료된 토큰입니다.", "detail": null }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저 또는 태그를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TAG_NOT_FOUND",
+                                "message": "태그를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<GoalWithTodosCreateResponse>> createGoalWithTodos(
+      @AuthenticationPrincipal Long userId,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples = {
+                        @ExampleObject(
+                            name = "전체 필드 포함",
+                            value =
+                                """
+                                {
+                                  "title": "토익 900점 달성",
+                                  "dueDate": "2025-12-31T00:00:00",
+                                  "reference": "https://toeic.ets.org",
+                                  "todos": [
+                                    {
+                                      "type": "ONE_TIME",
+                                      "title": "단어 암기",
+                                      "dueDate": "2025-06-01",
+                                      "dueTime": "09:00",
+                                      "routineType": null,
+                                      "routineDate": null,
+                                      "tagId": 1,
+                                      "subTodos": ["챕터 1", "챕터 2"]
+                                    },
+                                    {
+                                      "type": "RECURRING",
+                                      "title": "리스닝 연습",
+                                      "dueDate": null,
+                                      "dueTime": null,
+                                      "routineType": "DAILY",
+                                      "routineDate": null,
+                                      "tagId": null,
+                                      "subTodos": []
+                                    }
+                                  ]
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "필수 필드만 (선택 필드 생략)",
+                            value =
+                                """
+                                {
+                                  "title": "토익 900점 달성",
+                                  "todos": [
+                                    {
+                                      "type": "ONE_TIME",
+                                      "title": "단어 암기",
+                                      "subTodos": []
+                                    }
+                                  ]
+                                }
+                                """)
+                      }))
+          @RequestBody
+          GoalWithTodosCreateRequest request);
 
   @Operation(
       summary = "목표 삭제",

--- a/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
@@ -1,0 +1,21 @@
+package plana.replan.domain.goal.dto.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "생성된 투두 항목")
+public record CreatedTodoItem(
+    @Schema(description = "투두 유형 (ONE_TIME / RECURRING)", example = "ONE_TIME") String type,
+    @Schema(description = "투두 제목", example = "단어 암기") String title,
+    @Schema(description = "생성된 투두 ID. ONE_TIME만 해당. RECURRING이면 null.", example = "101")
+        Long todoId,
+    @Schema(description = "생성된 루틴 ID. RECURRING만 해당. ONE_TIME이면 null.", example = "null")
+        Long routineId) {
+
+  public static CreatedTodoItem ofTodo(Long todoId, String title) {
+    return new CreatedTodoItem("ONE_TIME", title, todoId, null);
+  }
+
+  public static CreatedTodoItem ofRoutine(Long routineId, String title) {
+    return new CreatedTodoItem("RECURRING", title, null, routineId);
+  }
+}

--- a/src/main/java/plana/replan/domain/goal/dto/create/GoalCreateRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/GoalCreateRequest.java
@@ -2,7 +2,6 @@ package plana.replan.domain.goal.dto.create;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDateTime;
 
 @Schema(description = "목표 생성 요청")
 public record GoalCreateRequest(
@@ -12,7 +11,8 @@ public record GoalCreateRequest(
             requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "제목은 필수입니다.")
         String title,
-    @Schema(description = "목표 기한 (ISO 8601 형식)", example = "2025-12-31T00:00:00")
-        LocalDateTime dueDate,
+    @Schema(description = "목표 기한 날짜 (yyyy-MM-dd 형식)", example = "2025-12-31") String dueDate,
+    @Schema(description = "목표 기한 시간 (HH:mm 형식). dueDate 없이 단독 사용 불가.", example = "09:00")
+        String dueTime,
     @Schema(description = "참고 자료 (URL 또는 메모)", example = "https://toeic.ets.org")
         String reference) {}

--- a/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateRequest.java
@@ -1,0 +1,24 @@
+package plana.replan.domain.goal.dto.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "목표+투두 일괄 생성 요청")
+public record GoalWithTodosCreateRequest(
+    @Schema(
+            description = "목표 제목",
+            example = "토익 900점 달성",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+    @Schema(description = "목표 기한 (ISO 8601 형식)", example = "2025-12-31T00:00:00")
+        LocalDateTime dueDate,
+    @Schema(description = "참고 자료 (URL 또는 메모)", example = "https://toeic.ets.org") String reference,
+    @Schema(description = "생성할 투두 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "투두 목록은 필수입니다.")
+        @Valid
+        List<TodoItemRequest> todos) {}

--- a/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateRequest.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "목표+투두 일괄 생성 요청")
@@ -15,8 +14,9 @@ public record GoalWithTodosCreateRequest(
             requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "제목은 필수입니다.")
         String title,
-    @Schema(description = "목표 기한 (ISO 8601 형식)", example = "2025-12-31T00:00:00")
-        LocalDateTime dueDate,
+    @Schema(description = "목표 기한 날짜 (yyyy-MM-dd 형식)", example = "2025-12-31") String dueDate,
+    @Schema(description = "목표 기한 시간 (HH:mm 형식). dueDate 없이 단독 사용 불가.", example = "09:00")
+        String dueTime,
     @Schema(description = "참고 자료 (URL 또는 메모)", example = "https://toeic.ets.org") String reference,
     @Schema(description = "생성할 투두 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "투두 목록은 필수입니다.")

--- a/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateResponse.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/GoalWithTodosCreateResponse.java
@@ -1,0 +1,9 @@
+package plana.replan.domain.goal.dto.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "목표+투두 일괄 생성 응답")
+public record GoalWithTodosCreateResponse(
+    @Schema(description = "생성된 목표 ID", example = "10") Long goalId,
+    @Schema(description = "생성된 투두/루틴 목록") List<CreatedTodoItem> todos) {}

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -1,0 +1,26 @@
+package plana.replan.domain.goal.dto.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import plana.replan.domain.routine.entity.RoutineType;
+
+@Schema(description = "투두 항목 요청")
+public record TodoItemRequest(
+    @Schema(description = "투두 유형 (ONE_TIME / RECURRING)", example = "ONE_TIME") String type,
+    @Schema(description = "투두 제목", example = "단어 암기") String title,
+    @Schema(
+            description = "마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. RECURRING이면 null.",
+            example = "2025-06-01")
+        String dueDate,
+    @Schema(description = "마감 시간 (HH:mm 형식). ONE_TIME만 사용. RECURRING이면 null.", example = "09:00")
+        String dueTime,
+    @Schema(description = "반복 유형. RECURRING만 사용. ONE_TIME이면 null.", example = "DAILY")
+        RoutineType routineType,
+    @Schema(
+            description =
+                "반복 날짜. RECURRING만 사용. ONE_TIME이면 null. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자(1~31). DAILY: null.",
+            example = "null")
+        Integer routineDate,
+    @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,
+    @Schema(description = "하위 투두 제목 목록. ONE_TIME만 사용 가능.", example = "[\"챕터 1\", \"챕터 2\"]")
+        List<String> subTodos) {}

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -1,13 +1,17 @@
 package plana.replan.domain.goal.dto.create;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import plana.replan.domain.routine.entity.RoutineType;
 
 @Schema(description = "투두 항목 요청")
 public record TodoItemRequest(
-    @Schema(description = "투두 유형 (ONE_TIME / RECURRING)", example = "ONE_TIME") String type,
-    @Schema(description = "투두 제목", example = "단어 암기") String title,
+    @Schema(description = "투두 유형 (ONE_TIME / RECURRING)", example = "ONE_TIME")
+        @NotBlank(message = "투두 유형은 필수입니다.")
+        String type,
+    @Schema(description = "투두 제목", example = "단어 암기") @NotBlank(message = "투두 제목은 필수입니다.")
+        String title,
     @Schema(
             description = "마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. RECURRING이면 null.",
             example = "2025-06-01")

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -13,6 +13,8 @@ public enum GoalErrorCode implements ErrorCode {
   GOAL_INVALID_MONTH(400, "월은 1 이상 12 이하여야 합니다."),
   TODO_DUE_TIME_WITHOUT_DATE(400, "dueTime을 설정하려면 dueDate가 필요합니다."),
   GOAL_DUE_TIME_WITHOUT_DATE(400, "목표 기한의 dueTime을 설정하려면 dueDate가 필요합니다."),
+  TODO_INVALID_TYPE(400, "투두 유형은 ONE_TIME 또는 RECURRING이어야 합니다."),
+  TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING(400, "반복형 투두에는 하위 투두를 추가할 수 없습니다."),
   GEMINI_API_ERROR(502, "AI 추천 서비스에 일시적인 오류가 발생했습니다."),
   GEMINI_PARSE_ERROR(502, "AI 응답을 처리하는 중 오류가 발생했습니다.");
 

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -12,6 +12,7 @@ public enum GoalErrorCode implements ErrorCode {
   GOAL_INVALID_FILTER(400, "월별 조회 시 연도(year)는 필수입니다."),
   GOAL_INVALID_MONTH(400, "월은 1 이상 12 이하여야 합니다."),
   TODO_DUE_TIME_WITHOUT_DATE(400, "dueTime을 설정하려면 dueDate가 필요합니다."),
+  GOAL_DUE_TIME_WITHOUT_DATE(400, "목표 기한의 dueTime을 설정하려면 dueDate가 필요합니다."),
   GEMINI_API_ERROR(502, "AI 추천 서비스에 일시적인 오류가 발생했습니다."),
   GEMINI_PARSE_ERROR(502, "AI 응답을 처리하는 중 오류가 발생했습니다.");
 

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -11,6 +11,7 @@ public enum GoalErrorCode implements ErrorCode {
   GOAL_ACCESS_DENIED(403, "본인의 목표만 삭제할 수 있습니다."),
   GOAL_INVALID_FILTER(400, "월별 조회 시 연도(year)는 필수입니다."),
   GOAL_INVALID_MONTH(400, "월은 1 이상 12 이하여야 합니다."),
+  TODO_DUE_TIME_WITHOUT_DATE(400, "dueTime을 설정하려면 dueDate가 필요합니다."),
   GEMINI_API_ERROR(502, "AI 추천 서비스에 일시적인 오류가 발생했습니다."),
   GEMINI_PARSE_ERROR(502, "AI 응답을 처리하는 중 오류가 발생했습니다.");
 

--- a/src/main/java/plana/replan/domain/goal/service/GoalService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalService.java
@@ -1,6 +1,9 @@
 package plana.replan.domain.goal.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,6 +27,9 @@ import plana.replan.global.exception.CustomException;
 @RequiredArgsConstructor
 public class GoalService {
 
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
   private final GoalRepository goalRepository;
   private final UserRepository userRepository;
 
@@ -33,7 +39,7 @@ public class GoalService {
     Goal goal =
         Goal.builder()
             .title(request.title())
-            .dueDate(request.dueDate())
+            .dueDate(parseDueDate(request.dueDate(), request.dueTime()))
             .reference(request.reference())
             .user(user)
             .build();
@@ -87,6 +93,17 @@ public class GoalService {
                         .map(GoalSingleResponse::from)
                         .toList()))
         .toList();
+  }
+
+  private LocalDateTime parseDueDate(String date, String time) {
+    if (date == null && time != null) {
+      throw new CustomException(GoalErrorCode.GOAL_DUE_TIME_WITHOUT_DATE);
+    }
+    if (date == null) return null;
+    LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);
+    LocalTime localTime =
+        (time != null) ? LocalTime.parse(time, TIME_FORMATTER) : LocalTime.MIDNIGHT;
+    return LocalDateTime.of(localDate, localTime);
   }
 
   private User findUser(Long userId) {

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -13,19 +13,14 @@ import plana.replan.domain.goal.dto.create.CreatedTodoItem;
 import plana.replan.domain.goal.dto.create.GoalWithTodosCreateRequest;
 import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
 import plana.replan.domain.goal.dto.create.TodoItemRequest;
-import plana.replan.domain.goal.entity.Goal;
 import plana.replan.domain.goal.exception.GoalErrorCode;
-import plana.replan.domain.goal.repository.GoalRepository;
-import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.entity.RoutineType;
-import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
-import plana.replan.domain.tag.entity.Tag;
-import plana.replan.domain.tag.exception.TagErrorCode;
-import plana.replan.domain.tag.repository.TagRepository;
-import plana.replan.domain.todo.entity.Todo;
-import plana.replan.domain.todo.repository.TodoRepository;
-import plana.replan.domain.user.entity.User;
+import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoCreateRequestDto;
+import plana.replan.domain.todo.dto.TodoResponseDto;
+import plana.replan.domain.todo.service.TodoService;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
@@ -37,123 +32,95 @@ public class GoalWithTodosService {
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-  private final GoalRepository goalRepository;
-  private final TodoRepository todoRepository;
-  private final RoutineRepository routineRepository;
   private final UserRepository userRepository;
-  private final TagRepository tagRepository;
+  private final GoalService goalService;
+  private final TodoService todoService;
   private final RoutineService routineService;
 
   @Transactional
   public GoalWithTodosCreateResponse create(Long userId, GoalWithTodosCreateRequest request) {
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    userRepository
+        .findById(userId)
+        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-    Goal goal =
-        goalRepository.save(
-            Goal.builder()
-                .title(request.title())
-                .dueDate(parseGoalDueDate(request.dueDate(), request.dueTime()))
-                .reference(request.reference())
-                .user(user)
-                .build());
+    Long goalId =
+        goalService
+            .createGoal(
+                userId,
+                new plana.replan.domain.goal.dto.create.GoalCreateRequest(
+                    request.title(), request.dueDate(), request.dueTime(), request.reference()))
+            .id();
 
     List<CreatedTodoItem> createdItems = new ArrayList<>();
     for (TodoItemRequest item : request.todos()) {
       if ("RECURRING".equals(item.type())) {
-        createdItems.add(createRoutine(user, goal, item));
+        createdItems.add(createRoutine(userId, goalId, item));
       } else if ("ONE_TIME".equals(item.type())) {
-        createdItems.add(createTodo(user, goal, item));
+        createdItems.add(createTodo(userId, goalId, item));
       } else {
         throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
       }
     }
 
-    return new GoalWithTodosCreateResponse(goal.getId(), createdItems);
+    return new GoalWithTodosCreateResponse(goalId, createdItems);
   }
 
-  private CreatedTodoItem createTodo(User user, Goal goal, TodoItemRequest item) {
-    Tag tag = resolveTag(user, item.tagId());
-    LocalDateTime dueDate = parseTodoDueDate(item.dueDate(), item.dueTime());
+  private CreatedTodoItem createTodo(Long userId, Long goalId, TodoItemRequest item) {
+    if (item.subTodos() != null && !item.subTodos().isEmpty()) {
+      validateSubTodos(item.subTodos());
+    }
 
-    Todo todo =
-        todoRepository.save(
-            Todo.builder()
-                .title(item.title())
-                .dueDate(dueDate)
-                .isPinned(false)
-                .user(user)
-                .tag(tag)
-                .goal(goal)
-                .build());
+    TodoCreateRequestDto dto = buildTodoCreateRequest(item, goalId);
+    TodoResponseDto todo = todoService.createTodo(userId, dto);
 
     if (item.subTodos() != null) {
       for (String subTitle : item.subTodos()) {
-        todoRepository.save(
-            Todo.builder().title(subTitle).isPinned(false).user(user).parent(todo).build());
+        todoService.createSubTodo(userId, todo.getTodoId(), new SubTodoCreateRequestDto(subTitle));
       }
     }
 
-    return CreatedTodoItem.ofTodo(todo.getId(), todo.getTitle());
+    return CreatedTodoItem.ofTodo(todo.getTodoId(), todo.getTitle());
   }
 
-  private CreatedTodoItem createRoutine(User user, Goal goal, TodoItemRequest item) {
+  private CreatedTodoItem createRoutine(Long userId, Long goalId, TodoItemRequest item) {
     if (item.subTodos() != null && !item.subTodos().isEmpty()) {
       throw new CustomException(GoalErrorCode.TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING);
     }
 
-    Tag tag = resolveTag(user, item.tagId());
-    LocalDateTime dueDate = parseTodoDueDate(item.dueDate(), item.dueTime());
+    RoutineCreateRequestDto dto = buildRoutineCreateRequest(item, goalId);
+    var routine = routineService.createRoutine(userId, dto);
+
+    return CreatedTodoItem.ofRoutine(routine.getRoutineId(), routine.getTitle());
+  }
+
+  private TodoCreateRequestDto buildTodoCreateRequest(TodoItemRequest item, Long goalId) {
+    return new TodoCreateRequestDto(
+        item.title(), parseDateTime(item.dueDate(), item.dueTime()), item.tagId(), goalId);
+  }
+
+  private RoutineCreateRequestDto buildRoutineCreateRequest(TodoItemRequest item, Long goalId) {
     Integer routineDate = item.routineType() == RoutineType.DAILY ? null : item.routineDate();
-
-    Routine routine =
-        routineRepository.save(
-            Routine.builder()
-                .title(item.title())
-                .dueDate(dueDate)
-                .routineType(item.routineType())
-                .routineDate(routineDate)
-                .user(user)
-                .tag(tag)
-                .goal(goal)
-                .build());
-
-    if (routineService.isTodayMatch(routine)) {
-      routineService.createTodoFromRoutine(routine);
-    }
-
-    return CreatedTodoItem.ofRoutine(routine.getId(), routine.getTitle());
+    return new RoutineCreateRequestDto(
+        item.title(),
+        parseDateTime(item.dueDate(), item.dueTime()),
+        item.routineType(),
+        routineDate,
+        item.tagId(),
+        goalId);
   }
 
-  private Tag resolveTag(User user, Long tagId) {
-    if (tagId == null) return null;
-    Tag tag =
-        tagRepository
-            .findById(tagId)
-            .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
-    if (!tag.getUser().getId().equals(user.getId())) {
-      throw new CustomException(TagErrorCode.TAG_NOT_FOUND);
+  private void validateSubTodos(List<String> subTodos) {
+    for (String title : subTodos) {
+      if (title == null || title.isBlank()) {
+        throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
+      }
     }
-    return tag;
-  }
-
-  private LocalDateTime parseGoalDueDate(String date, String time) {
-    if (date == null && time != null) {
-      throw new CustomException(GoalErrorCode.GOAL_DUE_TIME_WITHOUT_DATE);
-    }
-    return parseDateTime(date, time);
-  }
-
-  private LocalDateTime parseTodoDueDate(String date, String time) {
-    if (date == null && time != null) {
-      throw new CustomException(GoalErrorCode.TODO_DUE_TIME_WITHOUT_DATE);
-    }
-    return parseDateTime(date, time);
   }
 
   private LocalDateTime parseDateTime(String date, String time) {
+    if (date == null && time != null) {
+      throw new CustomException(GoalErrorCode.TODO_DUE_TIME_WITHOUT_DATE);
+    }
     if (date == null) return null;
     LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);
     LocalTime localTime =

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -55,7 +55,7 @@ public class GoalWithTodosService {
         goalRepository.save(
             Goal.builder()
                 .title(request.title())
-                .dueDate(request.dueDate())
+                .dueDate(parseGoalDueDate(request.dueDate(), request.dueTime()))
                 .reference(request.reference())
                 .user(user)
                 .build());
@@ -144,10 +144,21 @@ public class GoalWithTodosService {
     return tag;
   }
 
+  private LocalDateTime parseGoalDueDate(String date, String time) {
+    if (date == null && time != null) {
+      throw new CustomException(GoalErrorCode.GOAL_DUE_TIME_WITHOUT_DATE);
+    }
+    return parseDateTime(date, time);
+  }
+
   private LocalDateTime parseDueDate(String date, String time) {
     if (date == null && time != null) {
       throw new CustomException(GoalErrorCode.TODO_DUE_TIME_WITHOUT_DATE);
     }
+    return parseDateTime(date, time);
+  }
+
+  private LocalDateTime parseDateTime(String date, String time) {
     if (date == null) return null;
     LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);
     LocalTime localTime =

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -15,6 +15,7 @@ import plana.replan.domain.goal.dto.create.GoalWithTodosCreateRequest;
 import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
 import plana.replan.domain.goal.dto.create.TodoItemRequest;
 import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
@@ -28,7 +29,6 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
-import plana.replan.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -146,7 +146,7 @@ public class GoalWithTodosService {
 
   private LocalDateTime parseDueDate(String date, String time) {
     if (date == null && time != null) {
-      throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+      throw new CustomException(GoalErrorCode.TODO_DUE_TIME_WITHOUT_DATE);
     }
     if (date == null) return null;
     LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -28,6 +28,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -144,6 +145,9 @@ public class GoalWithTodosService {
   }
 
   private LocalDateTime parseDueDate(String date, String time) {
+    if (date == null && time != null) {
+      throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+    }
     if (date == null) return null;
     LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);
     LocalTime localTime =

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -1,6 +1,5 @@
 package plana.replan.domain.goal.service;
 
-import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -20,6 +19,7 @@ import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -37,12 +37,12 @@ public class GoalWithTodosService {
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-  private final Clock clock;
   private final GoalRepository goalRepository;
   private final TodoRepository todoRepository;
   private final RoutineRepository routineRepository;
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
+  private final RoutineService routineService;
 
   @Transactional
   public GoalWithTodosCreateResponse create(Long userId, GoalWithTodosCreateRequest request) {
@@ -64,8 +64,10 @@ public class GoalWithTodosService {
     for (TodoItemRequest item : request.todos()) {
       if ("RECURRING".equals(item.type())) {
         createdItems.add(createRoutine(user, goal, item));
-      } else {
+      } else if ("ONE_TIME".equals(item.type())) {
         createdItems.add(createTodo(user, goal, item));
+      } else {
+        throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
       }
     }
 
@@ -74,8 +76,7 @@ public class GoalWithTodosService {
 
   private CreatedTodoItem createTodo(User user, Goal goal, TodoItemRequest item) {
     Tag tag = resolveTag(user, item.tagId());
-
-    LocalDateTime dueDate = parseDueDate(item.dueDate(), item.dueTime());
+    LocalDateTime dueDate = parseTodoDueDate(item.dueDate(), item.dueTime());
 
     Todo todo =
         todoRepository.save(
@@ -99,9 +100,12 @@ public class GoalWithTodosService {
   }
 
   private CreatedTodoItem createRoutine(User user, Goal goal, TodoItemRequest item) {
-    Tag tag = resolveTag(user, item.tagId());
+    if (item.subTodos() != null && !item.subTodos().isEmpty()) {
+      throw new CustomException(GoalErrorCode.TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING);
+    }
 
-    LocalDateTime dueDate = parseDueDate(item.dueDate(), item.dueTime());
+    Tag tag = resolveTag(user, item.tagId());
+    LocalDateTime dueDate = parseTodoDueDate(item.dueDate(), item.dueTime());
     Integer routineDate = item.routineType() == RoutineType.DAILY ? null : item.routineDate();
 
     Routine routine =
@@ -116,17 +120,8 @@ public class GoalWithTodosService {
                 .goal(goal)
                 .build());
 
-    if (isTodayMatch(routine)) {
-      todoRepository.save(
-          Todo.builder()
-              .title(routine.getTitle())
-              .dueDate(routine.getDueDate())
-              .isPinned(false)
-              .user(user)
-              .tag(tag)
-              .goal(goal)
-              .routine(routine)
-              .build());
+    if (routineService.isTodayMatch(routine)) {
+      routineService.createTodoFromRoutine(routine);
     }
 
     return CreatedTodoItem.ofRoutine(routine.getId(), routine.getTitle());
@@ -151,7 +146,7 @@ public class GoalWithTodosService {
     return parseDateTime(date, time);
   }
 
-  private LocalDateTime parseDueDate(String date, String time) {
+  private LocalDateTime parseTodoDueDate(String date, String time) {
     if (date == null && time != null) {
       throw new CustomException(GoalErrorCode.TODO_DUE_TIME_WITHOUT_DATE);
     }
@@ -164,18 +159,5 @@ public class GoalWithTodosService {
     LocalTime localTime =
         (time != null) ? LocalTime.parse(time, TIME_FORMATTER) : LocalTime.MIDNIGHT;
     return LocalDateTime.of(localDate, localTime);
-  }
-
-  private boolean isTodayMatch(Routine routine) {
-    LocalDate today = LocalDate.now(clock);
-    return switch (routine.getRoutineType()) {
-      case DAILY -> true;
-      case WEEKLY -> {
-        int todayBit = 1 << (today.getDayOfWeek().getValue() - 1);
-        yield routine.getRoutineDate() != null && (routine.getRoutineDate() & todayBit) != 0;
-      }
-      case MONTHLY -> routine.getRoutineDate() != null
-          && routine.getRoutineDate() == today.getDayOfMonth();
-    };
   }
 }

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -1,0 +1,166 @@
+package plana.replan.domain.goal.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.goal.dto.create.CreatedTodoItem;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateRequest;
+import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
+import plana.replan.domain.goal.dto.create.TodoItemRequest;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.repository.GoalRepository;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class GoalWithTodosService {
+
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+  private final Clock clock;
+  private final GoalRepository goalRepository;
+  private final TodoRepository todoRepository;
+  private final RoutineRepository routineRepository;
+  private final UserRepository userRepository;
+  private final TagRepository tagRepository;
+
+  @Transactional
+  public GoalWithTodosCreateResponse create(Long userId, GoalWithTodosCreateRequest request) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    Goal goal =
+        goalRepository.save(
+            Goal.builder()
+                .title(request.title())
+                .dueDate(request.dueDate())
+                .reference(request.reference())
+                .user(user)
+                .build());
+
+    List<CreatedTodoItem> createdItems = new ArrayList<>();
+    for (TodoItemRequest item : request.todos()) {
+      if ("RECURRING".equals(item.type())) {
+        createdItems.add(createRoutine(user, goal, item));
+      } else {
+        createdItems.add(createTodo(user, goal, item));
+      }
+    }
+
+    return new GoalWithTodosCreateResponse(goal.getId(), createdItems);
+  }
+
+  private CreatedTodoItem createTodo(User user, Goal goal, TodoItemRequest item) {
+    Tag tag = resolveTag(user, item.tagId());
+
+    LocalDateTime dueDate = parseDueDate(item.dueDate(), item.dueTime());
+
+    Todo todo =
+        todoRepository.save(
+            Todo.builder()
+                .title(item.title())
+                .dueDate(dueDate)
+                .isPinned(false)
+                .user(user)
+                .tag(tag)
+                .goal(goal)
+                .build());
+
+    if (item.subTodos() != null) {
+      for (String subTitle : item.subTodos()) {
+        todoRepository.save(
+            Todo.builder().title(subTitle).isPinned(false).user(user).parent(todo).build());
+      }
+    }
+
+    return CreatedTodoItem.ofTodo(todo.getId(), todo.getTitle());
+  }
+
+  private CreatedTodoItem createRoutine(User user, Goal goal, TodoItemRequest item) {
+    Tag tag = resolveTag(user, item.tagId());
+
+    LocalDateTime dueDate = parseDueDate(item.dueDate(), item.dueTime());
+    Integer routineDate = item.routineType() == RoutineType.DAILY ? null : item.routineDate();
+
+    Routine routine =
+        routineRepository.save(
+            Routine.builder()
+                .title(item.title())
+                .dueDate(dueDate)
+                .routineType(item.routineType())
+                .routineDate(routineDate)
+                .user(user)
+                .tag(tag)
+                .goal(goal)
+                .build());
+
+    if (isTodayMatch(routine)) {
+      todoRepository.save(
+          Todo.builder()
+              .title(routine.getTitle())
+              .dueDate(routine.getDueDate())
+              .isPinned(false)
+              .user(user)
+              .tag(tag)
+              .goal(goal)
+              .routine(routine)
+              .build());
+    }
+
+    return CreatedTodoItem.ofRoutine(routine.getId(), routine.getTitle());
+  }
+
+  private Tag resolveTag(User user, Long tagId) {
+    if (tagId == null) return null;
+    Tag tag =
+        tagRepository
+            .findById(tagId)
+            .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
+    if (!tag.getUser().getId().equals(user.getId())) {
+      throw new CustomException(TagErrorCode.TAG_NOT_FOUND);
+    }
+    return tag;
+  }
+
+  private LocalDateTime parseDueDate(String date, String time) {
+    if (date == null) return null;
+    LocalDate localDate = LocalDate.parse(date, DATE_FORMATTER);
+    LocalTime localTime =
+        (time != null) ? LocalTime.parse(time, TIME_FORMATTER) : LocalTime.MIDNIGHT;
+    return LocalDateTime.of(localDate, localTime);
+  }
+
+  private boolean isTodayMatch(Routine routine) {
+    LocalDate today = LocalDate.now(clock);
+    return switch (routine.getRoutineType()) {
+      case DAILY -> true;
+      case WEEKLY -> {
+        int todayBit = 1 << (today.getDayOfWeek().getValue() - 1);
+        yield routine.getRoutineDate() != null && (routine.getRoutineDate() & todayBit) != 0;
+      }
+      case MONTHLY -> routine.getRoutineDate() != null
+          && routine.getRoutineDate() == today.getDayOfMonth();
+    };
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -90,7 +90,7 @@ public class RoutineService {
     routines.stream().filter(this::isTodayMatch).forEach(this::createTodoFromRoutine);
   }
 
-  private boolean isTodayMatch(Routine routine) {
+  public boolean isTodayMatch(Routine routine) {
     LocalDate today = LocalDate.now(clock);
     return switch (routine.getRoutineType()) {
       case DAILY -> true;
@@ -103,7 +103,7 @@ public class RoutineService {
     };
   }
 
-  private void createTodoFromRoutine(Routine routine) {
+  public void createTodoFromRoutine(Routine routine) {
     LocalDateTime todayStart = LocalDate.now(clock).atStartOfDay();
     if (todoRepository.existsByRoutineAndDueDateBetween(
         routine, todayStart, todayStart.plusDays(1))) {

--- a/src/main/java/plana/replan/domain/todo/dto/SubTodoCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/SubTodoCreateRequestDto.java
@@ -1,11 +1,13 @@
 package plana.replan.domain.todo.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class SubTodoCreateRequestDto {
 
   @NotBlank(message = "제목은 필수입니다.")

--- a/src/main/java/plana/replan/domain/todo/dto/TodoCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoCreateRequestDto.java
@@ -2,11 +2,13 @@ package plana.replan.domain.todo.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class TodoCreateRequestDto {
 
   @NotBlank(message = "제목은 필수입니다.")
@@ -15,4 +17,6 @@ public class TodoCreateRequestDto {
   private LocalDateTime dueDate;
 
   private Long tagId;
+
+  private Long goalId;
 }

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.goal.entity.Goal;
+import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
@@ -46,6 +49,7 @@ public class TodoService {
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
   private final RoutineRepository routineRepository;
+  private final GoalRepository goalRepository;
 
   @Transactional
   public TodoResponseDto createTodo(Long userId, TodoCreateRequestDto request) {
@@ -68,6 +72,14 @@ public class TodoService {
       }
     }
 
+    Goal goal = null;
+    if (request.getGoalId() != null) {
+      goal =
+          goalRepository
+              .findById(request.getGoalId())
+              .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
+    }
+
     Todo todo =
         Todo.builder()
             .title(request.getTitle())
@@ -75,6 +87,7 @@ public class TodoService {
             .isPinned(false)
             .user(user)
             .tag(tag)
+            .goal(goal)
             .build();
 
     todoRepository.save(todo);

--- a/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
+++ b/src/test/java/plana/replan/domain/goal/controller/GoalControllerTest.java
@@ -29,6 +29,7 @@ import plana.replan.domain.goal.dto.list.GoalsByDateResponse;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.service.GoalAiService;
 import plana.replan.domain.goal.service.GoalService;
+import plana.replan.domain.goal.service.GoalWithTodosService;
 import plana.replan.global.config.SecurityConfig;
 import plana.replan.global.exception.CustomException;
 import plana.replan.global.jwt.JwtUtil;
@@ -41,6 +42,7 @@ class GoalControllerTest {
 
   @MockitoBean private GoalService goalService;
   @MockitoBean private GoalAiService goalAiService;
+  @MockitoBean private GoalWithTodosService goalWithTodosService;
   @MockitoBean private JwtUtil jwtUtil;
 
   private UsernamePasswordAuthenticationToken authToken(Long userId) {

--- a/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalServiceTest.java
@@ -50,8 +50,7 @@ class GoalServiceTest {
     given(goalRepository.save(any())).willReturn(savedGoal);
 
     GoalCreateRequest request =
-        new GoalCreateRequest(
-            "토익 900점 달성", LocalDateTime.of(2025, 12, 31, 0, 0), "https://toeic.ets.org");
+        new GoalCreateRequest("토익 900점 달성", "2025-12-31", null, "https://toeic.ets.org");
 
     GoalSingleResponse response = goalService.createGoal(1L, request);
 
@@ -73,7 +72,7 @@ class GoalServiceTest {
     given(savedGoal.getReference()).willReturn(null);
     given(goalRepository.save(any())).willReturn(savedGoal);
 
-    GoalCreateRequest request = new GoalCreateRequest("독서 50권", null, null);
+    GoalCreateRequest request = new GoalCreateRequest("독서 50권", null, null, null);
 
     GoalSingleResponse response = goalService.createGoal(1L, request);
 
@@ -86,7 +85,8 @@ class GoalServiceTest {
   void 목표_생성_유저_없음_404() {
     given(userRepository.findById(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> goalService.createGoal(999L, new GoalCreateRequest("제목", null, null)))
+    assertThatThrownBy(
+            () -> goalService.createGoal(999L, new GoalCreateRequest("제목", null, null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->


### PR DESCRIPTION
## Summary

- `POST /api/goals/with-todos` 엔드포인트 추가
- 투두 추천 결과를 단일 요청으로 목표 + 투두(일반형/반복형) + 하위투두를 일괄 생성
- 단일 트랜잭션으로 처리 — 중간 실패 시 전체 롤백

## Details

**새 API**
- 목표 기한을 `dueDate` (yyyy-MM-dd) + `dueTime` (HH:mm) 분리 — 기존 `POST /api/goals`도 동일하게 변경
- `type` 필드로 `ONE_TIME` / `RECURRING` 구분
- `RECURRING` 루틴 생성 시 오늘 날짜 조건 일치하면 투두 자동 생성 (기존 RoutineService 정책 재사용)
- `GoalWithTodosService`는 직접 엔티티를 빌드하지 않고 `GoalService`, `TodoService`, `RoutineService`에 위임

**에러 케이스**
- `dueTime`만 있고 `dueDate` 없으면 400
- `type`이 `ONE_TIME` / `RECURRING` 이외 값이면 400
- `RECURRING` 타입에 `subTodos` 포함하면 400
- 존재하지 않는 `tagId` 전달 시 404

**기타**
- `TodoCreateRequestDto`에 `goalId` 필드 추가 — `POST /api/todos/create`에서도 목표 연결 가능

## Test plan

- [x] `POST /api/goals/with-todos` — ONE_TIME + 하위투두 생성 확인
- [x] `POST /api/goals/with-todos` — RECURRING DAILY 생성 후 오늘 투두 자동 생성 확인
- [x] `POST /api/goals/with-todos` — ONE_TIME + RECURRING 혼합 확인
- [x] dueTime만 전달 → 400 확인
- [x] 유효하지 않은 type → 400 확인
- [x] RECURRING + subTodos → 400 확인
- [x] 두 번째 todo 실패 시 전체 롤백 확인
- [x] `POST /api/goals` — dueDate/dueTime 분리 후 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 목표와 할 일을 한 번에 생성하는 기능 추가
  * 할 일의 반복/일회성 유형 설정 지원

* **Improvements**
  * 목표 기한 입력 형식 개선 (날짜와 시간을 별도로 입력)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->