### PR TITLE
fix: 투두 목록 조회 API에 date 쿼리 파라미터 추가

### DIFF
--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -1,6 +1,7 @@
 package plana.replan.domain.todo.controller;
 
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -55,8 +56,9 @@ public class TodoController implements TodoControllerDocs {
   public ResponseEntity<ApiResult<List<TodoListResponseDto>>> getTodos(
       @AuthenticationPrincipal Long userId,
       @RequestParam(defaultValue = "all") String filter,
-      @RequestParam(defaultValue = "priority") String sort) {
-    return ResponseEntity.ok(ApiResult.ok(todoService.getTodos(userId, filter, sort)));
+      @RequestParam(defaultValue = "priority") String sort,
+      @RequestParam(required = false) LocalDate date) {
+    return ResponseEntity.ok(ApiResult.ok(todoService.getTodos(userId, filter, sort, date)));
   }
 
   @Override

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -1053,15 +1054,16 @@ public interface TodoControllerDocs {
           |-----------|-----------|------|--------|------|------|
           | filter | ❌ 선택 | string | `all` | 조회 범위 필터 (`all`, `day`, `week`, `month`) | `day` |
           | sort | ❌ 선택 | string | `priority` | 정렬 기준 (`priority`, `dueDate`) | `dueDate` |
+          | date | ❌ 선택 | string | 오늘 | 기준 날짜 (yyyy-MM-dd 형식). 생략 시 서버 기준 오늘 사용 | `"2026-05-28"` |
 
           **filter 값별 조회 조건**
 
           | filter | 조회 대상 |
           |--------|----------|
-          | `all` | 완료되지 않은 모든 투두 (마감일 무관) |
-          | `day` | 오늘 마감인 미완료 투두 + 오늘 완료된 투두 |
-          | `week` | 오늘부터 7일 이내 마감인 미완료 투두 |
-          | `month` | 오늘부터 한 달 이내 마감인 미완료 투두 |
+          | `all` | 완료되지 않은 모든 투두 (마감일 무관, date 무시) |
+          | `day` | 기준 날짜에 마감인 미완료 투두 + 기준 날짜에 완료된 투두 |
+          | `week` | 기준 날짜부터 7일 이내 마감인 미완료 투두 |
+          | `month` | 기준 날짜부터 한 달 이내 마감인 미완료 투두 |
 
           **sort 값별 정렬 기준**
 
@@ -1205,7 +1207,10 @@ public interface TodoControllerDocs {
           String filter,
       @Parameter(description = "정렬 기준 (priority/dueDate)", example = "priority")
           @RequestParam(defaultValue = "priority")
-          String sort);
+          String sort,
+      @Parameter(description = "기준 날짜 (yyyy-MM-dd). 생략 시 오늘", example = "2026-05-28")
+          @RequestParam(required = false)
+          LocalDate date);
 
   @Operation(
       summary = "투두 생성",

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -165,7 +165,8 @@ public class TodoService {
   }
 
   @Transactional(readOnly = true)
-  public List<TodoListResponseDto> getTodos(Long userId, String filter, String sort) {
+  public List<TodoListResponseDto> getTodos(
+      Long userId, String filter, String sort, LocalDate date) {
     if (userId == null) {
       throw new CustomException(UserErrorCode.USER_NOT_FOUND);
     }
@@ -183,7 +184,7 @@ public class TodoService {
 
     Comparator<Todo> sortComparator = buildSortComparator(sort);
 
-    LocalDate today = LocalDate.now(clock);
+    LocalDate today = date != null ? date : LocalDate.now(clock);
     var startOfDay = today.atStartOfDay();
     var endOfDay = today.atTime(LocalTime.MAX);
 

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -424,7 +424,7 @@ class TodoControllerTest {
   @Test
   @DisplayName("투두 목록 조회 성공 (기본 filter=all, sort=priority): status=200, 배열 반환")
   void getTodos_success_defaultParams() throws Exception {
-    given(todoService.getTodos(any(), any(), any()))
+    given(todoService.getTodos(any(), any(), any(), any()))
         .willReturn(List.of(sampleDto(1L, false, false), sampleDto(2L, false, false)));
 
     mockMvc
@@ -443,7 +443,7 @@ class TodoControllerTest {
     TodoListResponseDto dto =
         new TodoListResponseDto(
             1L, "투두", null, true, 500.0, false, 3L, "영어", "BLUE", "DAILY", true);
-    given(todoService.getTodos(any(), any(), any())).willReturn(List.of(dto));
+    given(todoService.getTodos(any(), any(), any(), any())).willReturn(List.of(dto));
 
     mockMvc
         .perform(get("/api/todos").with(authentication(authToken(1L))))
@@ -460,7 +460,7 @@ class TodoControllerTest {
   @Test
   @DisplayName("filter=day: status=200, 완료 투두 포함")
   void getTodos_success_dayFilter() throws Exception {
-    given(todoService.getTodos(any(), any(), any()))
+    given(todoService.getTodos(any(), any(), any(), any()))
         .willReturn(List.of(sampleDto(1L, false, false), sampleDto(2L, true, false)));
 
     mockMvc
@@ -473,7 +473,7 @@ class TodoControllerTest {
   @Test
   @DisplayName("filter=week, sort=dueDate: status=200")
   void getTodos_success_weekFilter_dueDateSort() throws Exception {
-    given(todoService.getTodos(any(), any(), any()))
+    given(todoService.getTodos(any(), any(), any(), any()))
         .willReturn(List.of(sampleDto(1L, false, false)));
 
     mockMvc
@@ -487,7 +487,7 @@ class TodoControllerTest {
   void getTodos_invalidFilter() throws Exception {
     willThrow(new CustomException(TodoErrorCode.INVALID_FILTER))
         .given(todoService)
-        .getTodos(any(), any(), any());
+        .getTodos(any(), any(), any(), any());
 
     mockMvc
         .perform(get("/api/todos?filter=invalid").with(authentication(authToken(1L))))
@@ -501,7 +501,7 @@ class TodoControllerTest {
   void getTodos_invalidSort() throws Exception {
     willThrow(new CustomException(TodoErrorCode.INVALID_SORT))
         .given(todoService)
-        .getTodos(any(), any(), any());
+        .getTodos(any(), any(), any(), any());
 
     mockMvc
         .perform(get("/api/todos?sort=invalid").with(authentication(authToken(1L))))
@@ -515,7 +515,7 @@ class TodoControllerTest {
   void getTodos_userNotFound() throws Exception {
     willThrow(new CustomException(UserErrorCode.USER_NOT_FOUND))
         .given(todoService)
-        .getTodos(any(), any(), any());
+        .getTodos(any(), any(), any(), any());
 
     mockMvc
         .perform(get("/api/todos").with(authentication(authToken(999L))))

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -522,7 +522,7 @@ class TodoServiceTest {
   @Test
   @DisplayName("getTodos - userId null: USER_NOT_FOUND 예외")
   void getTodos_nullUserId_throws() {
-    assertThatThrownBy(() -> todoService.getTodos(null, "all", "priority"))
+    assertThatThrownBy(() -> todoService.getTodos(null, "all", "priority", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -533,7 +533,7 @@ class TodoServiceTest {
   @Test
   @DisplayName("getTodos - filter null: INVALID_FILTER 예외")
   void getTodos_nullFilter_throws() {
-    assertThatThrownBy(() -> todoService.getTodos(1L, null, "priority"))
+    assertThatThrownBy(() -> todoService.getTodos(1L, null, "priority", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -544,7 +544,7 @@ class TodoServiceTest {
   @Test
   @DisplayName("getTodos - sort null: INVALID_SORT 예외")
   void getTodos_nullSort_throws() {
-    assertThatThrownBy(() -> todoService.getTodos(1L, "all", null))
+    assertThatThrownBy(() -> todoService.getTodos(1L, "all", null, null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -557,7 +557,7 @@ class TodoServiceTest {
   void getTodos_userNotFound_throws() {
     given(userRepository.findById(99L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> todoService.getTodos(99L, "all", "priority"))
+    assertThatThrownBy(() -> todoService.getTodos(99L, "all", "priority", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -573,7 +573,7 @@ class TodoServiceTest {
     given(todoRepository.findActiveTodosForUser(user))
         .willReturn(List.of(activeTodo(1L, user), activeTodo(2L, user)));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
     assertThat(result).hasSize(2);
     assertThat(result).extracting("isCompleted").containsOnly(false);
@@ -586,7 +586,7 @@ class TodoServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findActiveTodosForUser(user)).willReturn(List.of());
 
-    assertThat(todoService.getTodos(1L, "all", "priority")).isEmpty();
+    assertThat(todoService.getTodos(1L, "all", "priority", null)).isEmpty();
   }
 
   @Test
@@ -599,7 +599,7 @@ class TodoServiceTest {
     given(todoRepository.findCompletedTodosByCompletedTimeRange(any(), any(), any()))
         .willReturn(List.of(completedTodo(2L, user)));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority", null);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0).isCompleted()).isFalse();
@@ -614,7 +614,7 @@ class TodoServiceTest {
     given(todoRepository.findActiveTodosByDueDateRange(any(), any(), any()))
         .willReturn(List.of(activeTodo(1L, user)));
 
-    todoService.getTodos(1L, "week", "priority");
+    todoService.getTodos(1L, "week", "priority", null);
 
     verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
   }
@@ -627,7 +627,7 @@ class TodoServiceTest {
     given(todoRepository.findActiveTodosByDueDateRange(any(), any(), any()))
         .willReturn(List.of(activeTodo(1L, user)));
 
-    todoService.getTodos(1L, "month", "priority");
+    todoService.getTodos(1L, "month", "priority", null);
 
     verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
   }
@@ -637,7 +637,7 @@ class TodoServiceTest {
   void getTodos_invalidFilter_throws() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
-    assertThatThrownBy(() -> todoService.getTodos(1L, "invalid", "priority"))
+    assertThatThrownBy(() -> todoService.getTodos(1L, "invalid", "priority", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -657,7 +657,7 @@ class TodoServiceTest {
 
     given(todoRepository.findActiveTodosForUser(user)).willReturn(List.of(t1, t3, t2));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
     assertThat(result).extracting("todoId").containsExactly(2L, 1L, 3L);
   }
@@ -680,7 +680,7 @@ class TodoServiceTest {
     given(todoRepository.findActiveTodosForUser(user))
         .willReturn(List.of(noDate, lateDate, earlyDate, midDate));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "dueDate");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "dueDate", null);
 
     assertThat(result).extracting("todoId").containsExactly(3L, 4L, 2L, 1L);
   }
@@ -690,7 +690,7 @@ class TodoServiceTest {
   void getTodos_invalidSort_throws() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
-    assertThatThrownBy(() -> todoService.getTodos(1L, "all", "invalid"))
+    assertThatThrownBy(() -> todoService.getTodos(1L, "all", "invalid", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -705,7 +705,8 @@ class TodoServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of());
 
-    assertThatCode(() -> todoService.getTodos(1L, "ALL", "priority")).doesNotThrowAnyException();
+    assertThatCode(() -> todoService.getTodos(1L, "ALL", "priority", null))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -713,7 +714,7 @@ class TodoServiceTest {
   void getTodos_sortCaseMismatch_throws() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
-    assertThatThrownBy(() -> todoService.getTodos(1L, "all", "PRIORITY"))
+    assertThatThrownBy(() -> todoService.getTodos(1L, "all", "PRIORITY", null))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -730,7 +731,7 @@ class TodoServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(overdue));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
     assertThat(result.get(0).isOverdue()).isTrue();
   }
@@ -747,7 +748,7 @@ class TodoServiceTest {
     given(todoRepository.findCompletedTodosByCompletedTimeRange(any(), any(), any()))
         .willReturn(List.of(completed));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority", null);
 
     assertThat(result.get(0).isOverdue()).isFalse();
   }
@@ -759,7 +760,7 @@ class TodoServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(activeTodo(1L, user)));
 
-    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority");
+    List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
     assertThat(result.get(0).isOverdue()).isFalse();
   }
@@ -780,7 +781,7 @@ class TodoServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(todo));
 
-    TodoListResponseDto dto = todoService.getTodos(1L, "all", "priority").get(0);
+    TodoListResponseDto dto = todoService.getTodos(1L, "all", "priority", null).get(0);
 
     assertThat(dto.getTagId()).isEqualTo(5L);
     assertThat(dto.getTagTitle()).isEqualTo("업무");


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #136 


## 변경 사항
> 캘린더에서 다른 날짜를 선택할 때 해당 날짜 기준으로 투두를 조회할 수 있도록. date 파라미터(yyyy-MM-dd)를 추가한다. 생략 시 서버 기준 오늘 날짜를 사용한다.


## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 할일 목록 조회 시 선택적 날짜 기준 필터링 기능 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->