### PR TITLE
fix: 루틴 생성 시 오늘이 반복일이 아니어도 다음 반복일자로 Todo 즉시 생성

### DIFF
--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -102,16 +102,16 @@ public class RoutineService {
   }
 
   public void createTodoFromRoutine(Routine routine) {
-    LocalDateTime todayStart = LocalDate.now(clock).atStartOfDay();
-    if (todoRepository.existsByRoutineAndDueDateBetween(
-        routine, todayStart, todayStart.plusDays(1))) {
+    LocalDate today = LocalDate.now(clock);
+    LocalDateTime dueDate = nextOccurrence(routine, today).atStartOfDay();
+    if (todoRepository.existsByRoutineAndDueDateBetween(routine, dueDate, dueDate.plusDays(1))) {
       return;
     }
     try {
       todoRepository.saveAndFlush(
           Todo.builder()
               .title(routine.getTitle())
-              .dueDate(todayStart)
+              .dueDate(dueDate)
               .isPinned(false)
               .user(routine.getUser())
               .tag(routine.getTag())
@@ -125,6 +125,36 @@ public class RoutineService {
       }
       // uq_todo_routine_duedate 충돌 — 동시 실행으로 이미 생성된 것으로 간주
     }
+  }
+
+  private LocalDate nextOccurrence(Routine routine, LocalDate today) {
+    return switch (routine.getRoutineType()) {
+      case DAILY -> today;
+      case WEEKLY -> {
+        int mask = routine.getRoutineDate();
+        for (int i = 0; i < 7; i++) {
+          LocalDate d = today.plusDays(i);
+          int bit = 1 << (d.getDayOfWeek().getValue() - 1);
+          if ((mask & bit) != 0) {
+            yield d;
+          }
+        }
+        yield today;
+      }
+      case MONTHLY -> {
+        int day = routine.getRoutineDate();
+        for (int k = 0; k < 12; k++) {
+          LocalDate firstOfMonth = today.withDayOfMonth(1).plusMonths(k);
+          if (firstOfMonth.lengthOfMonth() >= day) {
+            LocalDate candidate = firstOfMonth.withDayOfMonth(day);
+            if (!candidate.isBefore(today)) {
+              yield candidate;
+            }
+          }
+        }
+        yield today;
+      }
+    };
   }
 
   private void validateRoutineDate(RoutineType routineType, Integer routineDate) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -77,9 +77,7 @@ public class RoutineService {
                 .goal(goal)
                 .build());
 
-    if (isTodayMatch(routine)) {
-      createTodoFromRoutine(routine);
-    }
+    createTodoFromRoutine(routine);
 
     return RoutineResponseDto.from(routine);
   }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -391,15 +392,17 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_WEEKLY_오늘_요일_미포함이어도_Todo_즉시_생성됨() {
-    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 포함 → 반복일 아니지만 오늘자 Todo 생성
+  void 루틴_생성_WEEKLY_오늘_요일_미포함이어도_Todo_즉시_생성되고_다음_반복일이_dueDate() {
+    // TEST_DATE = 2024-01-15(Mon). routineDate=2 → Tuesday만 → 다음 발생 = 2024-01-16
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 2, null, null));
 
-    verify(todoRepository).saveAndFlush(any(Todo.class));
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDate.of(2024, 1, 16).atStartOfDay());
   }
 
   @Test
@@ -415,15 +418,17 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_MONTHLY_오늘_날짜_불일치여도_Todo_즉시_생성됨() {
-    // TEST_DATE = 15일. routineDate=16 → 반복일 아니지만 오늘자 Todo 생성
+  void 루틴_생성_MONTHLY_오늘_날짜_불일치여도_Todo_즉시_생성되고_다음_반복일이_dueDate() {
+    // TEST_DATE = 2024-01-15. routineDate=16 → 다음 발생 = 2024-01-16
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 16, null, null));
 
-    verify(todoRepository).saveAndFlush(any(Todo.class));
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDate.of(2024, 1, 16).atStartOfDay());
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -391,15 +391,15 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_WEEKLY_오늘_요일_미포함_Todo_생성_안됨() {
-    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 포함 → 불일치
+  void 루틴_생성_WEEKLY_오늘_요일_미포함이어도_Todo_즉시_생성됨() {
+    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 포함 → 반복일 아니지만 오늘자 Todo 생성
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L, new RoutineCreateRequestDto("루틴", null, RoutineType.WEEKLY, 2, null, null));
 
-    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+    verify(todoRepository).saveAndFlush(any(Todo.class));
   }
 
   @Test
@@ -415,15 +415,15 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_MONTHLY_오늘_날짜_불일치_Todo_생성_안됨() {
-    // TEST_DATE = 15일. routineDate=16 → 불일치
+  void 루틴_생성_MONTHLY_오늘_날짜_불일치여도_Todo_즉시_생성됨() {
+    // TEST_DATE = 15일. routineDate=16 → 반복일 아니지만 오늘자 Todo 생성
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L, new RoutineCreateRequestDto("루틴", null, RoutineType.MONTHLY, 16, null, null));
 
-    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+    verify(todoRepository).saveAndFlush(any(Todo.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 기존: 루틴 생성 시 오늘이 반복일일 때만 Todo가 만들어져, 오늘이 반복일이 아니면 방금 만든 루틴이 todo 어디에도 안 보이는 문제.
- 변경: 루틴 생성 직후 항상 Todo를 1건 만들되, dueDate를 **다음 반복일**로 설정.

## Details
- \`RoutineService.createRoutine\` 에서 \`isTodayMatch\` 가드 제거 — 생성 시 항상 \`createTodoFromRoutine\` 호출
- \`createTodoFromRoutine\` 이 \`nextOccurrence(routine, today)\` 로 다음 발생일을 계산해 dueDate 로 사용
  - DAILY: 오늘
  - WEEKLY: 오늘 포함 7일 안에서 비트마스크에 매치되는 가장 가까운 날
  - MONTHLY: 이번 달에 \`routineDate\` 일이 남아있으면 이번 달, 아니면 다음 달의 같은 일자 (해당 일자가 없는 달은 스킵)
- 자정 배치(\`generateDailyTodos\`)는 그대로 \`isTodayMatch\` 로 컷하므로 항상 오늘이 다음 발생일 → 기존 동작 동일

## 예시 (오늘이 금요일이라 가정)
- WEEKLY 매주 목요일 → 다음 주 목요일 dueDate
- WEEKLY 월·수·금(=21) → 오늘 금요일 dueDate
- MONTHLY 16일을 29일에 생성 → 다음 달 16일 dueDate
- DAILY → 오늘 dueDate

## Test plan
- [x] \`./gradlew build\` 통과
- [x] \`RoutineServiceTest\` — WEEKLY/MONTHLY 오늘 미포함 케이스에서 dueDate가 다음 반복일로 잡히는지 \`ArgumentCaptor\` 로 검증
- [x] 로컬에서 \`POST /api/routines\` / \`POST /api/goals/with-todos\` 로 요청 후 \`GET /api/todos\` 응답의 dueDate 확인

## Follow-up (별도 이슈 예정)
스케줄러가 각 반복일 당일 자정에만 해당 날짜 Todo 를 생성하기 때문에, 평상시(루틴 생성 이후)에는 다음 반복일이 도래하기 전까지 todo 목록에서 보이지 않음. \"오늘부터 N일 또는 다음 발생일까지 미리 생성\" 같은 정책을 별도 이슈로 다룰 예정.

closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 루틴 기반 할일 생성 로직 개선: 일일, 주간, 월간 루틴의 다음 발생 날짜를 정확하게 계산하여 할일의 마감일을 설정하도록 수정
  * 루틴 타입별 다음 발생일 계산 알고리즘 추가로 더욱 정확한 할일 일정 관리 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->