### PR TITLE
fix: 반복 Todo 선생성 방식 개선 — 다음 반복일 즉시 생성

### DIFF
--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -3,7 +3,6 @@ package plana.replan.domain.routine.service;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -84,21 +83,12 @@ public class RoutineService {
 
   @Transactional
   public void generateDailyTodos() {
-    List<Routine> routines = routineRepository.findAll();
-    routines.stream().filter(this::isTodayMatch).forEach(this::createTodoFromRoutine);
-  }
-
-  public boolean isTodayMatch(Routine routine) {
-    LocalDate today = LocalDate.now(clock);
-    return switch (routine.getRoutineType()) {
-      case DAILY -> true;
-      case WEEKLY -> {
-        int dayBit = 1 << (today.getDayOfWeek().getValue() - 1);
-        yield routine.getRoutineDate() != null && (routine.getRoutineDate() & dayBit) != 0;
-      }
-      case MONTHLY -> routine.getRoutineDate() != null
-          && routine.getRoutineDate() == today.getDayOfMonth();
-    };
+    LocalDate yesterday = LocalDate.now(clock).minusDays(1);
+    LocalDateTime start = yesterday.atStartOfDay();
+    LocalDateTime end = yesterday.atTime(23, 59, 59);
+    todoRepository
+        .findRoutineTodosByDueDateRange(start, end)
+        .forEach(todo -> createTodoFromRoutine(todo.getRoutine()));
   }
 
   public void createTodoFromRoutine(Routine routine) {

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -19,6 +19,10 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
 
+  @Query("SELECT t FROM Todo t WHERE t.routine IS NOT NULL AND t.dueDate BETWEEN :start AND :end")
+  List<Todo> findRoutineTodosByDueDateRange(
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
   @Query("SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false")
   List<Todo> findActiveTodosForUser(@Param("user") User user);
 

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -445,6 +445,8 @@ class RoutineServiceTest {
 
   // ========== generateDailyTodos (배치) ==========
 
+  // TEST_DATE = 2024-01-15 (월요일), 어제 = 2024-01-14 (일요일)
+
   private Routine buildRoutine(RoutineType type, Integer routineDate) {
     return Routine.builder()
         .title("테스트 루틴")
@@ -454,29 +456,19 @@ class RoutineServiceTest {
         .build();
   }
 
-  @Test
-  void generateDailyTodos_DAILY_루틴_Todo_생성됨() {
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.DAILY, null)));
-
-    routineService.generateDailyTodos();
-
-    verify(todoRepository).saveAndFlush(any(Todo.class));
+  private Todo buildTodoWithRoutine(Routine routine, LocalDateTime dueDate) {
+    return Todo.builder()
+        .title(routine.getTitle())
+        .dueDate(dueDate)
+        .isPinned(false)
+        .user(routine.getUser())
+        .routine(routine)
+        .build();
   }
 
   @Test
-  void generateDailyTodos_WEEKLY_오늘_요일_포함_Todo_생성됨() {
-    // TEST_DATE = Monday(bit=1). routineDate=1 → 일치
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.WEEKLY, 1)));
-
-    routineService.generateDailyTodos();
-
-    verify(todoRepository).saveAndFlush(any(Todo.class));
-  }
-
-  @Test
-  void generateDailyTodos_WEEKLY_오늘_요일_미포함_Todo_생성_안됨() {
-    // TEST_DATE = Monday(bit=1). routineDate=2 → Tuesday만 → 불일치
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.WEEKLY, 2)));
+  void generateDailyTodos_어제_마감_반복Todo_없으면_생성_안됨() {
+    given(todoRepository.findRoutineTodosByDueDateRange(any(), any())).willReturn(List.of());
 
     routineService.generateDailyTodos();
 
@@ -484,28 +476,56 @@ class RoutineServiceTest {
   }
 
   @Test
-  void generateDailyTodos_MONTHLY_오늘_날짜_일치_Todo_생성됨() {
-    // TEST_DATE = 15일. routineDate=15 → 일치
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.MONTHLY, 15)));
+  void generateDailyTodos_DAILY_어제_마감_반복Todo_있으면_오늘_dueDate로_생성됨() {
+    // 어제(2024-01-14) dueDate DAILY 반복 Todo → nextOccurrence(오늘=2024-01-15) = 2024-01-15
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
+    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+        .willReturn(List.of(yesterdayTodo));
 
     routineService.generateDailyTodos();
 
-    verify(todoRepository).saveAndFlush(any(Todo.class));
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDate.of(2024, 1, 15).atStartOfDay());
   }
 
   @Test
-  void generateDailyTodos_MONTHLY_오늘_날짜_불일치_Todo_생성_안됨() {
-    // TEST_DATE = 15일. routineDate=16 → 불일치
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.MONTHLY, 16)));
+  void generateDailyTodos_WEEKLY_어제_마감_반복Todo_있으면_다음_반복일_dueDate로_생성됨() {
+    // 어제(2024-01-14, 일) dueDate WEEKLY(화=2) → nextOccurrence(오늘=월) = 2024-01-16(화)
+    Routine routine = buildRoutine(RoutineType.WEEKLY, 2);
+    Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
+    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+        .willReturn(List.of(yesterdayTodo));
 
     routineService.generateDailyTodos();
 
-    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDate.of(2024, 1, 16).atStartOfDay());
   }
 
   @Test
-  void generateDailyTodos_이미_오늘_Todo_존재시_중복_생성_안됨() {
-    given(routineRepository.findAll()).willReturn(List.of(buildRoutine(RoutineType.DAILY, null)));
+  void generateDailyTodos_MONTHLY_어제_마감_반복Todo_있으면_다음_반복일_dueDate로_생성됨() {
+    // 어제(2024-01-14) dueDate MONTHLY(16일) → nextOccurrence(오늘=15일) = 2024-01-16
+    Routine routine = buildRoutine(RoutineType.MONTHLY, 16);
+    Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
+    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+        .willReturn(List.of(yesterdayTodo));
+
+    routineService.generateDailyTodos();
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDate.of(2024, 1, 16).atStartOfDay());
+  }
+
+  @Test
+  void generateDailyTodos_다음_반복일_Todo_이미_존재시_중복_생성_안됨() {
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
+    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+        .willReturn(List.of(yesterdayTodo));
     given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
 
     routineService.generateDailyTodos();


### PR DESCRIPTION
## Related Issues
close #132 


## 변경 사항
기존에는 배치 실행 당일이 반복일인 루틴에 대해서만 Todo를 생성해서,
오늘이 반복일이 아닌 경우 목록에서 다음 반복일 Todo를 확인할 수 없었음.

배치 로직을 "어제가 dueDate인 반복 Todo" 기준으로 변경해
마감일이 지난 직후 다음 반복일 Todo를 즉시 선생성하도록 개선.

- TodoRepository: findRoutineTodosByDueDateRange 쿼리 추가
- RoutineService.generateDailyTodos: 새 로직으로 교체
- RoutineService.isTodayMatch: 제거
- RoutineServiceTest: generateDailyTodos 관련 테스트 전면 교체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 일일 루틴 투두 생성 로직을 최적화하여 정확성과 성능을 개선했습니다.

* **Tests**
  * 루틴 투두 생성 관련 테스트를 업데이트하여 개선된 구현을 반영했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlanA-RePLAN/RePLAN-BE/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->