### PR TITLE
feat: 루틴-하위 루틴 기능 추가 (#143)

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -244,6 +244,7 @@ public interface GoalControllerDocs {
           | todos[].routineDate | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자(1~31), DAILY: null | `null` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
+          | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |
 
           > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
 
@@ -259,13 +260,14 @@ public interface GoalControllerDocs {
           | todos[].title | string | 투두 제목 |
           | todos[].todoId | integer | 생성된 투두 ID. ONE_TIME만 해당. RECURRING이면 null. |
           | todos[].routineId | integer | 생성된 루틴 ID. RECURRING만 해당. ONE_TIME이면 null. |
+          | todos[].subRoutineIds | array | 생성된 하위 루틴 ID 목록. RECURRING + subRoutines 사용 시. |
 
           ---
 
           ### 주의사항
           - 모든 생성은 단일 트랜잭션으로 처리됩니다. 하나라도 실패하면 전체 롤백됩니다.
-          - RECURRING 투두는 오늘 날짜가 반복 조건과 일치하면 자동으로 오늘의 투두가 생성됩니다.
-          - 하위투두는 ONE_TIME 투두에만 생성할 수 있습니다.
+          - RECURRING 투두는 다음 반복일에 해당하는 Todo가 즉시 생성됩니다.
+          - 하위투두는 ONE_TIME 투두에만, 하위루틴은 RECURRING 투두에만 추가할 수 있습니다. 교차 사용 시 400.
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
@@ -284,8 +286,8 @@ public interface GoalControllerDocs {
                               "data": {
                                 "goalId": 10,
                                 "todos": [
-                                  { "type": "ONE_TIME", "title": "단어 암기", "todoId": 101, "routineId": null },
-                                  { "type": "RECURRING", "title": "리스닝 연습", "todoId": null, "routineId": 201 }
+                                  { "type": "ONE_TIME", "title": "단어 암기", "todoId": 101, "routineId": null, "subRoutineIds": [] },
+                                  { "type": "RECURRING", "title": "리스닝 연습", "todoId": null, "routineId": 201, "subRoutineIds": [301, 302] }
                                 ]
                               },
                               "error": null
@@ -396,7 +398,8 @@ public interface GoalControllerDocs {
                                       "routineType": "DAILY",
                                       "routineDate": null,
                                       "tagId": null,
-                                      "subTodos": []
+                                      "subTodos": [],
+                                      "subRoutines": ["받아쓰기", "쉐도잉"]
                                     }
                                   ]
                                 }

--- a/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
@@ -12,7 +12,8 @@ public record CreatedTodoItem(
     @Schema(description = "생성된 루틴 ID. RECURRING만 해당. ONE_TIME이면 null.", example = "null")
         Long routineId,
     @Schema(
-            description = "생성된 하위 루틴 ID 목록. RECURRING + subRoutines가 있을 때만 채워짐.",
+            description =
+                "생성된 하위 루틴 ID 목록. 항상 배열로 직렬화되며 null이 아니다. ONE_TIME이거나 subRoutines가 비어있으면 빈 배열.",
             example = "[201, 202]")
         List<Long> subRoutineIds) {
 

--- a/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/CreatedTodoItem.java
@@ -1,6 +1,7 @@
 package plana.replan.domain.goal.dto.create;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "생성된 투두 항목")
 public record CreatedTodoItem(
@@ -9,13 +10,17 @@ public record CreatedTodoItem(
     @Schema(description = "생성된 투두 ID. ONE_TIME만 해당. RECURRING이면 null.", example = "101")
         Long todoId,
     @Schema(description = "생성된 루틴 ID. RECURRING만 해당. ONE_TIME이면 null.", example = "null")
-        Long routineId) {
+        Long routineId,
+    @Schema(
+            description = "생성된 하위 루틴 ID 목록. RECURRING + subRoutines가 있을 때만 채워짐.",
+            example = "[201, 202]")
+        List<Long> subRoutineIds) {
 
   public static CreatedTodoItem ofTodo(Long todoId, String title) {
-    return new CreatedTodoItem("ONE_TIME", title, todoId, null);
+    return new CreatedTodoItem("ONE_TIME", title, todoId, null, List.of());
   }
 
-  public static CreatedTodoItem ofRoutine(Long routineId, String title) {
-    return new CreatedTodoItem("RECURRING", title, null, routineId);
+  public static CreatedTodoItem ofRoutine(Long routineId, String title, List<Long> subRoutineIds) {
+    return new CreatedTodoItem("RECURRING", title, null, routineId, subRoutineIds);
   }
 }

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -27,4 +27,6 @@ public record TodoItemRequest(
         Integer routineDate,
     @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,
     @Schema(description = "하위 투두 제목 목록. ONE_TIME만 사용 가능.", example = "[\"챕터 1\", \"챕터 2\"]")
-        List<String> subTodos) {}
+        List<String> subTodos,
+    @Schema(description = "하위 루틴 제목 목록. RECURRING만 사용 가능.", example = "[\"스트레칭\", \"유산소\"]")
+        List<String> subRoutines) {}

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -16,6 +16,7 @@ public enum GoalErrorCode implements ErrorCode {
   TODO_INVALID_TYPE(400, "투두 유형은 ONE_TIME 또는 RECURRING이어야 합니다."),
   TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING(400, "반복형 투두에는 하위 투두를 추가할 수 없습니다."),
   TODO_SUB_ROUTINE_NOT_ALLOWED_FOR_ONE_TIME(400, "단발성 투두에는 하위 루틴을 추가할 수 없습니다."),
+  TODO_SUB_ROUTINE_INVALID_TITLE(400, "하위 루틴 제목은 비어있을 수 없습니다."),
   GEMINI_API_ERROR(502, "AI 추천 서비스에 일시적인 오류가 발생했습니다."),
   GEMINI_PARSE_ERROR(502, "AI 응답을 처리하는 중 오류가 발생했습니다.");
 

--- a/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
+++ b/src/main/java/plana/replan/domain/goal/exception/GoalErrorCode.java
@@ -15,6 +15,7 @@ public enum GoalErrorCode implements ErrorCode {
   GOAL_DUE_TIME_WITHOUT_DATE(400, "목표 기한의 dueTime을 설정하려면 dueDate가 필요합니다."),
   TODO_INVALID_TYPE(400, "투두 유형은 ONE_TIME 또는 RECURRING이어야 합니다."),
   TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING(400, "반복형 투두에는 하위 투두를 추가할 수 없습니다."),
+  TODO_SUB_ROUTINE_NOT_ALLOWED_FOR_ONE_TIME(400, "단발성 투두에는 하위 루틴을 추가할 수 없습니다."),
   GEMINI_API_ERROR(502, "AI 추천 서비스에 일시적인 오류가 발생했습니다."),
   GEMINI_PARSE_ERROR(502, "AI 응답을 처리하는 중 오류가 발생했습니다.");
 

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -137,7 +137,7 @@ public class GoalWithTodosService {
   private void validateSubRoutines(List<String> subRoutines) {
     for (String title : subRoutines) {
       if (title == null || title.isBlank()) {
-        throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
+        throw new CustomException(GoalErrorCode.TODO_SUB_ROUTINE_INVALID_TITLE);
       }
     }
   }

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -15,6 +15,7 @@ import plana.replan.domain.goal.dto.create.GoalWithTodosCreateResponse;
 import plana.replan.domain.goal.dto.create.TodoItemRequest;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
@@ -66,6 +67,9 @@ public class GoalWithTodosService {
   }
 
   private CreatedTodoItem createTodo(Long userId, Long goalId, TodoItemRequest item) {
+    if (item.subRoutines() != null && !item.subRoutines().isEmpty()) {
+      throw new CustomException(GoalErrorCode.TODO_SUB_ROUTINE_NOT_ALLOWED_FOR_ONE_TIME);
+    }
     if (item.subTodos() != null && !item.subTodos().isEmpty()) {
       validateSubTodos(item.subTodos());
     }
@@ -86,11 +90,24 @@ public class GoalWithTodosService {
     if (item.subTodos() != null && !item.subTodos().isEmpty()) {
       throw new CustomException(GoalErrorCode.TODO_SUB_TODO_NOT_ALLOWED_FOR_RECURRING);
     }
+    if (item.subRoutines() != null && !item.subRoutines().isEmpty()) {
+      validateSubRoutines(item.subRoutines());
+    }
 
     RoutineCreateRequestDto dto = buildRoutineCreateRequest(item, goalId);
     var routine = routineService.createRoutine(userId, dto);
 
-    return CreatedTodoItem.ofRoutine(routine.getRoutineId(), routine.getTitle());
+    List<Long> subRoutineIds = new ArrayList<>();
+    if (item.subRoutines() != null) {
+      for (String childTitle : item.subRoutines()) {
+        var child =
+            routineService.createChildRoutine(
+                userId, routine.getRoutineId(), new SubRoutineCreateRequestDto(childTitle));
+        subRoutineIds.add(child.routineId());
+      }
+    }
+
+    return CreatedTodoItem.ofRoutine(routine.getRoutineId(), routine.getTitle(), subRoutineIds);
   }
 
   private TodoCreateRequestDto buildTodoCreateRequest(TodoItemRequest item, Long goalId) {
@@ -111,6 +128,14 @@ public class GoalWithTodosService {
 
   private void validateSubTodos(List<String> subTodos) {
     for (String title : subTodos) {
+      if (title == null || title.isBlank()) {
+        throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
+      }
+    }
+  }
+
+  private void validateSubRoutines(List<String> subRoutines) {
+    for (String title : subRoutines) {
       if (title == null || title.isBlank()) {
         throw new CustomException(GoalErrorCode.TODO_INVALID_TYPE);
       }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -5,12 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.global.common.ApiResult;
 
@@ -27,5 +30,15 @@ public class RoutineController implements RoutineControllerDocs {
       @AuthenticationPrincipal Long userId, @Valid @RequestBody RoutineCreateRequestDto request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResult.ok(routineService.createRoutine(userId, request)));
+  }
+
+  @Override
+  @PostMapping("/{parentId}/children")
+  public ResponseEntity<ApiResult<SubRoutineResponseDto>> createChildRoutine(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long parentId,
+      @Valid @RequestBody SubRoutineCreateRequestDto request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResult.ok(routineService.createChildRoutine(userId, parentId, request)));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.global.common.ApiResult;
 
@@ -57,5 +59,14 @@ public class RoutineController implements RoutineControllerDocs {
       @AuthenticationPrincipal Long userId, @PathVariable Long id) {
     routineService.deleteChildRoutine(userId, id);
     return ResponseEntity.ok(ApiResult.ok(null));
+  }
+
+  @Override
+  @PatchMapping("/children/{id}")
+  public ResponseEntity<ApiResult<SubRoutineResponseDto>> updateChildRoutine(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long id,
+      @Valid @RequestBody SubRoutineUpdateRequestDto request) {
+    return ResponseEntity.ok(ApiResult.ok(routineService.updateChildRoutine(userId, id, request)));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +41,21 @@ public class RoutineController implements RoutineControllerDocs {
       @Valid @RequestBody SubRoutineCreateRequestDto request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResult.ok(routineService.createChildRoutine(userId, parentId, request)));
+  }
+
+  @Override
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResult<Void>> deleteMotherRoutine(
+      @AuthenticationPrincipal Long userId, @PathVariable Long id) {
+    routineService.deleteMotherRoutine(userId, id);
+    return ResponseEntity.ok(ApiResult.ok(null));
+  }
+
+  @Override
+  @DeleteMapping("/children/{id}")
+  public ResponseEntity<ApiResult<Void>> deleteChildRoutine(
+      @AuthenticationPrincipal Long userId, @PathVariable Long id) {
+    routineService.deleteChildRoutine(userId, id);
+    return ResponseEntity.ok(ApiResult.ok(null));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -16,6 +16,7 @@ import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.global.common.ApiResult;
 
 @Tag(name = "Routine", description = "루틴 관련 API. 모든 요청에 JWT 인증 필수.")
@@ -503,4 +504,50 @@ public interface RoutineControllerDocs {
   ResponseEntity<ApiResult<Void>> deleteChildRoutine(
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "하위 루틴 ID", example = "11") @PathVariable Long id);
+
+  @Operation(
+      summary = "하위 루틴 수정",
+      description =
+          """
+          하위 루틴의 `title`만 수정합니다. 스케줄/태그/목표는 엄마를 따라가므로 수정 대상이 아닙니다.
+
+          - 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET).
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | id | ✅ 필수 | integer | 하위 루틴 ID | `11` |
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 변경할 하위 루틴 제목 | `"유산소 30분"` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "수정 성공"),
+    @ApiResponse(responseCode = "400", description = "title 누락 또는 엄마 루틴 ID 사용"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없거나 본인 소유가 아님")
+  })
+  ResponseEntity<ApiResult<SubRoutineResponseDto>> updateChildRoutine(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "하위 루틴 ID", example = "11") @PathVariable Long id,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples =
+                          @ExampleObject(
+                              name = "title 수정",
+                              value =
+                                  """
+                              {
+                                "title": "유산소 30분"
+                              }
+                              """)))
+          @RequestBody
+          SubRoutineUpdateRequestDto request);
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -408,4 +408,99 @@ public interface RoutineControllerDocs {
                               """)))
           @RequestBody
           SubRoutineCreateRequestDto request);
+
+  @Operation(
+      summary = "엄마 루틴 삭제",
+      description =
+          """
+          엄마 루틴을 삭제합니다 (soft delete). 매달려 있던 모든 하위 루틴도 함께 사라집니다.
+
+          - 이미 생성된 Todo는 정책상 함께 삭제되지 않습니다. 다음 스케줄러 사이클부터 새 Todo가 생성되지 않을 뿐입니다.
+          - 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET) — 하위 루틴은 `/children/{id}`로 삭제하세요.
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | id | ✅ 필수 | integer | 엄마 루틴 ID | `1` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "삭제 성공"),
+    @ApiResponse(
+        responseCode = "400",
+        description = "하위 루틴 ID를 넘긴 경우",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_INVALID_TARGET",
+                                "message": "이 API는 해당 루틴 종류(엄마/하위)에만 사용할 수 있습니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(
+        responseCode = "404",
+        description = "루틴을 찾을 수 없거나 본인 소유가 아님",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_NOT_FOUND",
+                                "message": "루틴을 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<Void>> deleteMotherRoutine(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "엄마 루틴 ID", example = "1") @PathVariable Long id);
+
+  @Operation(
+      summary = "하위 루틴 삭제",
+      description =
+          """
+          하위 루틴 하나를 삭제합니다 (soft delete). 엄마 루틴은 영향 없습니다.
+
+          - 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET) — 엄마 루틴은 `/{id}`로 삭제하세요.
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | id | ✅ 필수 | integer | 하위 루틴 ID | `11` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "삭제 성공"),
+    @ApiResponse(responseCode = "400", description = "엄마 루틴 ID를 넘긴 경우"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없거나 본인 소유가 아님")
+  })
+  ResponseEntity<ApiResult<Void>> deleteChildRoutine(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "하위 루틴 ID", example = "11") @PathVariable Long id);
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -1,6 +1,7 @@
 package plana.replan.domain.routine.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -9,9 +10,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.global.common.ApiResult;
 
 @Tag(name = "Routine", description = "루틴 관련 API. 모든 요청에 JWT 인증 필수.")
@@ -249,4 +253,159 @@ public interface RoutineControllerDocs {
                       }))
           @RequestBody
           RoutineCreateRequestDto request);
+
+  @Operation(
+      summary = "하위 루틴 추가",
+      description =
+          """
+          엄마 루틴 아래에 하위 루틴을 추가합니다.
+
+          ### 정책
+          - 하위 루틴은 `title`만 자체 값입니다. 스케줄(`routineType`/`routineDate`), `dueDate`, `tag`, `goal`, `user`는 모두 엄마 루틴을 따릅니다.
+          - 1단계 깊이만 허용합니다. 하위 루틴 ID를 `parentId`로 넘기면 404로 거부됩니다.
+          - 호출 시점에 엄마 루틴의 살아있는 다음 발생일 Todo가 있으면, 해당 엄마 Todo 아래에 하위 Todo가 즉시 매달립니다. 없으면 다음 스케줄러 사이클에서 함께 생성됩니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          ---
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | parentId | ✅ 필수 | integer | 엄마 루틴 ID | `1` |
+
+          ---
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 하위 루틴 제목 | `"스트레칭"` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "하위 루틴 생성 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "routineId": 11,
+                                "title": "스트레칭",
+                                "parentId": 1
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "title 누락",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "INVALID_INPUT",
+                                "message": "제목은 필수입니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "엄마 루틴을 찾을 수 없거나, 본인 소유가 아니거나, 하위 루틴 ID를 parentId로 넘긴 경우 (정책상 모두 동일 응답)",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_NOT_FOUND",
+                                "message": "루틴을 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<SubRoutineResponseDto>> createChildRoutine(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "엄마 루틴 ID", example = "1") @PathVariable Long parentId,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples =
+                          @ExampleObject(
+                              name = "하위 루틴 생성",
+                              value =
+                                  """
+                              {
+                                "title": "스트레칭"
+                              }
+                              """)))
+          @RequestBody
+          SubRoutineCreateRequestDto request);
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -416,7 +416,7 @@ public interface RoutineControllerDocs {
           """
           엄마 루틴을 삭제합니다 (soft delete). 매달려 있던 모든 하위 루틴도 함께 사라집니다.
 
-          - 이미 생성된 Todo는 정책상 함께 삭제되지 않습니다. 다음 스케줄러 사이클부터 새 Todo가 생성되지 않을 뿐입니다.
+          - 이미 생성된 Todo는 함께 삭제되지 않습니다. 다만 삭제된 루틴을 참조하던 살아있는 Todo는 **`routine` 참조가 null로 끊겨** 일반 Todo처럼 남습니다. 그래서 조회 시 해당 Todo의 `routineType`이 `null`로 나옵니다. 다음 스케줄러 사이클부터는 새 Todo가 생성되지 않습니다.
           - 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET) — 하위 루틴은 `/children/{id}`로 삭제하세요.
 
           ### Request Headers
@@ -486,6 +486,7 @@ public interface RoutineControllerDocs {
           """
           하위 루틴 하나를 삭제합니다 (soft delete). 엄마 루틴은 영향 없습니다.
 
+          - 이미 생성된 Todo는 함께 삭제되지 않습니다. 다만 삭제된 하위 루틴을 참조하던 살아있는 Todo는 **`routine` 참조가 null로 끊겨** 남으며, 조회 시 `routineType`이 `null`로 나옵니다. (엄마 Todo와의 `parent` 관계는 그대로 유지됩니다.)
           - 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET) — 엄마 루틴은 `/{id}`로 삭제하세요.
 
           ### Path Variable

--- a/src/main/java/plana/replan/domain/routine/dto/SubRoutineCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/SubRoutineCreateRequestDto.java
@@ -1,0 +1,10 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "하위 루틴 생성 요청. 엄마 루틴의 스케줄/태그/목표를 그대로 따라가며, title만 자체 값.")
+public record SubRoutineCreateRequestDto(
+    @Schema(description = "하위 루틴 제목", example = "스트레칭", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title) {}

--- a/src/main/java/plana/replan/domain/routine/dto/SubRoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/SubRoutineResponseDto.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import plana.replan.domain.routine.entity.Routine;
+
+@Schema(description = "하위 루틴 응답. title 외 모든 스케줄/태그/목표는 엄마 루틴을 따른다.")
+public record SubRoutineResponseDto(
+    @Schema(description = "하위 루틴 ID", example = "11") Long routineId,
+    @Schema(description = "하위 루틴 제목", example = "스트레칭") String title,
+    @Schema(description = "엄마 루틴 ID", example = "1") Long parentId) {
+
+  public static SubRoutineResponseDto from(Routine child) {
+    return new SubRoutineResponseDto(
+        child.getId(),
+        child.getTitle(),
+        child.getParent() != null ? child.getParent().getId() : null);
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/dto/SubRoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/SubRoutineUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "하위 루틴 수정 요청. title만 수정 가능.")
+public record SubRoutineUpdateRequestDto(
+    @Schema(
+            description = "변경할 하위 루틴 제목",
+            example = "유산소 30분",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title) {}

--- a/src/main/java/plana/replan/domain/routine/entity/Routine.java
+++ b/src/main/java/plana/replan/domain/routine/entity/Routine.java
@@ -2,6 +2,8 @@ package plana.replan.domain.routine.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,11 +51,30 @@ public class Routine extends BaseTimeEntity {
   @JoinColumn(name = "goal_id")
   private Goal goal;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Routine parent;
+
+  @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+  private List<Routine> children = new ArrayList<>();
+
   public void update(String title, RoutineType routineType, Integer routineDate, Tag tag) {
     this.title = requireNonBlank(title);
     this.routineType = routineType;
     this.routineDate = routineDate;
     this.tag = tag;
+  }
+
+  public void updateTitle(String title) {
+    this.title = requireNonBlank(title);
+  }
+
+  public boolean isMother() {
+    return parent == null;
+  }
+
+  public boolean isChild() {
+    return parent != null;
   }
 
   @Builder
@@ -64,14 +85,28 @@ public class Routine extends BaseTimeEntity {
       Integer routineDate,
       User user,
       Tag tag,
-      Goal goal) {
+      Goal goal,
+      Routine parent) {
     this.title = requireNonBlank(title);
     this.user = Objects.requireNonNull(user, "유저는 필수입니다.");
-    this.dueDate = dueDate;
-    this.routineType = routineType;
-    this.routineDate = routineDate;
-    this.tag = tag;
-    this.goal = goal;
+    if (parent != null) {
+      if (parent.isChild()) {
+        throw new IllegalArgumentException("하위 루틴 아래에 또 하위 루틴을 만들 수 없습니다.");
+      }
+      this.parent = parent;
+      // 하위 루틴은 모든 필드를 부모에 의존. title과 user만 자기 것.
+      this.dueDate = null;
+      this.routineType = null;
+      this.routineDate = null;
+      this.tag = null;
+      this.goal = null;
+    } else {
+      this.dueDate = dueDate;
+      this.routineType = routineType;
+      this.routineDate = routineDate;
+      this.tag = tag;
+      this.goal = goal;
+    }
   }
 
   private static String requireNonBlank(String title) {

--- a/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
+++ b/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
@@ -7,7 +7,9 @@ import plana.replan.global.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum RoutineErrorCode implements ErrorCode {
-  ROUTINE_INVALID_DATE(400, "유효하지 않은 반복 날짜입니다.");
+  ROUTINE_INVALID_DATE(400, "유효하지 않은 반복 날짜입니다."),
+  ROUTINE_NOT_FOUND(404, "루틴을 찾을 수 없습니다."),
+  ROUTINE_INVALID_TARGET(400, "이 API는 해당 루틴 종류(엄마/하위)에만 사용할 수 있습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -1,5 +1,7 @@
 package plana.replan.domain.routine.repository;
 
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +14,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
   @Modifying
   @Query("UPDATE Routine r SET r.tag = null WHERE r.tag = :tag AND r.deletedAt IS NULL")
   void clearTagFromRoutines(@Param("tag") Tag tag);
+
+  @EntityGraph(attributePaths = "children")
+  Optional<Routine> findWithChildrenById(Long id);
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -166,10 +166,17 @@ public class RoutineService {
 
   /**
    * TodoService.handleRoutineUpdate처럼 권한 검증이 이미 끝난 cross-domain 호출용. children 일괄 softDelete + 자기
-   * softDelete 정책을 한 지점에 모으기 위한 헬퍼.
+   * softDelete 정책을 한 지점에 모으기 위한 헬퍼. 해당 루틴들을 참조하는 살아있는 Todo는 routine 참조를 null로 끊는다
+   * — @SQLRestriction이 걸려있어 deleted routine을 lazy-load할 때 EntityNotFoundException이 터지기 때문 (목록 조회
+   * 500 방지).
    */
   public void cascadeSoftDelete(Routine routine) {
-    routine.getChildren().forEach(c -> c.softDelete());
+    routine.getChildren().forEach(this::detachAndSoftDelete);
+    detachAndSoftDelete(routine);
+  }
+
+  private void detachAndSoftDelete(Routine routine) {
+    todoRepository.findAllByRoutine(routine).forEach(t -> t.updateRoutine(null));
     routine.softDelete();
   }
 

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -15,6 +15,7 @@ import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
@@ -115,6 +116,18 @@ public class RoutineService {
     motherTodo.ifPresent(mt -> attachChildTodoUnder(mt, child));
 
     return SubRoutineResponseDto.from(child);
+  }
+
+  /** 하위 루틴 title 수정. 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */
+  @Transactional
+  public SubRoutineResponseDto updateChildRoutine(
+      Long userId, Long routineId, SubRoutineUpdateRequestDto request) {
+    Routine routine = findOwnedRoutine(userId, routineId);
+    if (routine.isMother()) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
+    }
+    routine.updateTitle(request.title());
+    return SubRoutineResponseDto.from(routine);
   }
 
   /** 엄마 루틴 전용 삭제. 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -3,6 +3,7 @@ package plana.replan.domain.routine.service;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,8 @@ import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
+import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
@@ -79,6 +82,39 @@ public class RoutineService {
     createTodoTreeFromMother(routine);
 
     return RoutineResponseDto.from(routine);
+  }
+
+  @Transactional
+  public SubRoutineResponseDto createChildRoutine(
+      Long userId, Long parentId, SubRoutineCreateRequestDto request) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    Routine parent =
+        routineRepository
+            .findById(parentId)
+            .orElseThrow(() -> new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+
+    if (!parent.getUser().getId().equals(userId)) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND);
+    }
+    if (parent.isChild()) {
+      // 2단계 중첩 금지 — 하위 루틴 ID를 parentId로 넘긴 경우
+      throw new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND);
+    }
+
+    Routine child =
+        routineRepository.save(
+            Routine.builder().title(request.title()).user(parent.getUser()).parent(parent).build());
+
+    // 엄마의 살아있는 다음 발생일 Todo가 있으면 즉시 매단다.
+    LocalDateTime todayStart = LocalDate.now(clock).atStartOfDay();
+    Optional<Todo> motherTodo =
+        todoRepository.findFirstUpcomingMotherTodoByRoutine(parent, todayStart);
+    motherTodo.ifPresent(mt -> attachChildTodoUnder(mt, child));
+
+    return SubRoutineResponseDto.from(child);
   }
 
   @Transactional

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -220,7 +220,7 @@ public class RoutineService {
   }
 
   private Todo saveRoutineTodo(Routine routine, LocalDateTime dueDate, Todo parentTodo) {
-    if (todoRepository.existsByRoutineAndDueDateBetween(routine, dueDate, dueDate.plusDays(1))) {
+    if (todoRepository.existsByRoutineAndDueDate(routine, dueDate)) {
       return null;
     }
     try {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -76,7 +76,7 @@ public class RoutineService {
                 .goal(goal)
                 .build());
 
-    createTodoFromRoutine(routine);
+    createTodoTreeFromMother(routine);
 
     return RoutineResponseDto.from(routine);
   }
@@ -87,33 +87,61 @@ public class RoutineService {
     LocalDateTime start = yesterday.atStartOfDay();
     LocalDateTime end = yesterday.atTime(23, 59, 59);
     todoRepository
-        .findRoutineTodosByDueDateRange(start, end)
-        .forEach(todo -> createTodoFromRoutine(todo.getRoutine()));
+        .findMotherRoutineTodosForRollover(start, end)
+        .forEach(todo -> createTodoTreeFromMother(todo.getRoutine()));
   }
 
-  public void createTodoFromRoutine(Routine routine) {
+  /**
+   * 엄마 루틴 1건으로 (1) 엄마 Todo와 (2) 모든 살아있는 하위 루틴의 Todo를 한꺼번에 생성한다. 스케줄러와 엄마 루틴 생성 API 양쪽에서 호출되는 단일
+   * 진입점이다. 하위 루틴은 routineType이 null이므로 nextOccurrence 호출 대상이 아니며, dueDate는 엄마 Todo의 dueDate를 그대로
+   * 상속한다.
+   */
+  public void createTodoTreeFromMother(Routine motherRoutine) {
+    if (motherRoutine.isChild()) {
+      throw new IllegalStateException("createTodoTreeFromMother는 엄마 루틴에만 호출 가능합니다.");
+    }
     LocalDate today = LocalDate.now(clock);
-    LocalDateTime dueDate = nextOccurrence(routine, today).atStartOfDay();
-    if (todoRepository.existsByRoutineAndDueDateBetween(routine, dueDate, dueDate.plusDays(1))) {
+    LocalDateTime dueDate = nextOccurrence(motherRoutine, today).atStartOfDay();
+
+    Todo motherTodo = saveRoutineTodo(motherRoutine, dueDate, null);
+    if (motherTodo == null) {
       return;
     }
+    motherRoutine.getChildren().forEach(child -> saveRoutineTodo(child, dueDate, motherTodo));
+  }
+
+  /** 기존 엄마 Todo에 하위 Todo 1개를 매단다. 하위 루틴 추가 API에서 호출. dueDate/tag/goal/user는 엄마 Todo에서 상속한다. */
+  public void attachChildTodoUnder(Todo motherTodo, Routine childRoutine) {
+    if (!childRoutine.isChild()) {
+      throw new IllegalStateException("attachChildTodoUnder는 하위 루틴에만 호출 가능합니다.");
+    }
+    saveRoutineTodo(childRoutine, motherTodo.getDueDate(), motherTodo);
+  }
+
+  private Todo saveRoutineTodo(Routine routine, LocalDateTime dueDate, Todo parentTodo) {
+    if (todoRepository.existsByRoutineAndDueDateBetween(routine, dueDate, dueDate.plusDays(1))) {
+      return null;
+    }
     try {
-      todoRepository.saveAndFlush(
+      Routine motherForInherit = routine.isChild() ? routine.getParent() : routine;
+      return todoRepository.saveAndFlush(
           Todo.builder()
               .title(routine.getTitle())
               .dueDate(dueDate)
               .isPinned(false)
-              .user(routine.getUser())
-              .tag(routine.getTag())
-              .goal(routine.getGoal())
+              .user(motherForInherit.getUser())
+              .tag(motherForInherit.getTag())
+              .goal(motherForInherit.getGoal())
               .routine(routine)
+              .parent(parentTodo)
               .build());
     } catch (DataIntegrityViolationException e) {
       String msg = e.getMostSpecificCause().getMessage();
       if (msg == null || !msg.contains("uq_todo_routine_duedate")) {
         throw e;
       }
-      // uq_todo_routine_duedate 충돌 — 동시 실행으로 이미 생성된 것으로 간주
+      // uq_todo_routine_duedate 충돌 — 동시 INSERT로 이미 생성된 것으로 간주
+      return null;
     }
   }
 

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -168,8 +168,10 @@ public class RoutineService {
    * TodoService.handleRoutineUpdate처럼 권한 검증이 이미 끝난 cross-domain 호출용. children 일괄 softDelete + 자기
    * softDelete 정책을 한 지점에 모으기 위한 헬퍼. 해당 루틴들을 참조하는 살아있는 Todo는 routine 참조를 null로 끊는다
    * — @SQLRestriction이 걸려있어 deleted routine을 lazy-load할 때 EntityNotFoundException이 터지기 때문 (목록 조회
-   * 500 방지).
+   * 500 방지). 외부 public 진입점이므로 호출자 트랜잭션 유무와 무관하게 routine.getChildren() 지연 로딩이
+   * 안전하도록 @Transactional(propagation = REQUIRED)로 트랜잭션을 보장한다.
    */
+  @Transactional
   public void cascadeSoftDelete(Routine routine) {
     routine.getChildren().forEach(this::detachAndSoftDelete);
     detachAndSoftDelete(routine);

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -117,6 +117,49 @@ public class RoutineService {
     return SubRoutineResponseDto.from(child);
   }
 
+  /** 엄마 루틴 전용 삭제. 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */
+  @Transactional
+  public void deleteMotherRoutine(Long userId, Long routineId) {
+    Routine routine = findOwnedRoutine(userId, routineId);
+    if (routine.isChild()) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
+    }
+    cascadeSoftDelete(routine);
+  }
+
+  /** 하위 루틴 전용 삭제. 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */
+  @Transactional
+  public void deleteChildRoutine(Long userId, Long routineId) {
+    Routine routine = findOwnedRoutine(userId, routineId);
+    if (routine.isMother()) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
+    }
+    cascadeSoftDelete(routine);
+  }
+
+  private Routine findOwnedRoutine(Long userId, Long routineId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    Routine routine =
+        routineRepository
+            .findById(routineId)
+            .orElseThrow(() -> new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+    if (!routine.getUser().getId().equals(userId)) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND);
+    }
+    return routine;
+  }
+
+  /**
+   * TodoService.handleRoutineUpdate처럼 권한 검증이 이미 끝난 cross-domain 호출용. children 일괄 softDelete + 자기
+   * softDelete 정책을 한 지점에 모으기 위한 헬퍼.
+   */
+  public void cascadeSoftDelete(Routine routine) {
+    routine.getChildren().forEach(c -> c.softDelete());
+    routine.softDelete();
+  }
+
   @Transactional
   public void generateDailyTodos() {
     LocalDate yesterday = LocalDate.now(clock).minusDays(1);

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -22,10 +22,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
 
-  @Query("SELECT t FROM Todo t WHERE t.routine IS NOT NULL AND t.dueDate BETWEEN :start AND :end")
-  List<Todo> findRoutineTodosByDueDateRange(
-      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
-
   @Query(
       "SELECT t FROM Todo t JOIN t.routine r"
           + " WHERE t.parent IS NULL"

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -22,6 +22,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
 
+  List<Todo> findAllByRoutine(Routine routine);
+
   @Query(
       "SELECT t FROM Todo t JOIN t.routine r"
           + " WHERE t.parent IS NULL"

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -20,7 +20,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   @Query("UPDATE Todo t SET t.tag = null WHERE t.tag = :tag AND t.deletedAt IS NULL")
   void clearTagFromTodos(@Param("tag") Tag tag);
 
-  boolean existsByRoutineAndDueDateBetween(Routine routine, LocalDateTime start, LocalDateTime end);
+  boolean existsByRoutineAndDueDate(Routine routine, LocalDateTime dueDate);
 
   List<Todo> findAllByRoutine(Routine routine);
 

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -2,6 +2,9 @@ package plana.replan.domain.todo.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,6 +25,31 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   @Query("SELECT t FROM Todo t WHERE t.routine IS NOT NULL AND t.dueDate BETWEEN :start AND :end")
   List<Todo> findRoutineTodosByDueDateRange(
       @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT t FROM Todo t JOIN t.routine r"
+          + " WHERE t.parent IS NULL"
+          + " AND t.dueDate BETWEEN :start AND :end"
+          + " AND r.deletedAt IS NULL")
+  List<Todo> findMotherRoutineTodosForRollover(
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT t FROM Todo t"
+          + " WHERE t.routine = :routine"
+          + " AND t.parent IS NULL"
+          + " AND t.dueDate >= :fromDate"
+          + " ORDER BY t.dueDate ASC")
+  List<Todo> findUpcomingMotherTodosByRoutine(
+      @Param("routine") Routine routine,
+      @Param("fromDate") LocalDateTime fromDate,
+      Pageable pageable);
+
+  default Optional<Todo> findFirstUpcomingMotherTodoByRoutine(
+      Routine routine, LocalDateTime fromDate) {
+    return findUpcomingMotherTodosByRoutine(routine, fromDate, PageRequest.of(0, 1)).stream()
+        .findFirst();
+  }
 
   @Query("SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false")
   List<Todo> findActiveTodosForUser(@Param("user") User user);

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -18,6 +18,7 @@ import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
 import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -49,6 +50,7 @@ public class TodoService {
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
   private final RoutineRepository routineRepository;
+  private final RoutineService routineService;
   private final GoalRepository goalRepository;
 
   @Transactional
@@ -282,7 +284,7 @@ public class TodoService {
 
     if (request.getRoutineType() == null) {
       if (existingRoutine != null) {
-        existingRoutine.softDelete();
+        routineService.cascadeSoftDelete(existingRoutine);
         todo.updateRoutine(null);
       }
       return;

--- a/src/main/resources/db/migration/V5__add_parent_id_to_routine.sql
+++ b/src/main/resources/db/migration/V5__add_parent_id_to_routine.sql
@@ -1,0 +1,17 @@
+ALTER TABLE routine
+    ADD COLUMN parent_id BIGINT REFERENCES routine (id);
+
+CREATE INDEX idx_routine_parent_id ON routine (parent_id);
+
+ALTER TABLE routine
+    ADD CONSTRAINT ck_routine_child_has_no_schedule
+        CHECK (
+            parent_id IS NULL
+                OR (
+                       routine_type IS NULL
+                           AND routine_date IS NULL
+                           AND due_date IS NULL
+                           AND tag_id IS NULL
+                           AND goal_id IS NULL
+                   )
+            );

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -435,7 +435,7 @@ class RoutineServiceTest {
   void 루틴_생성_오늘_이미_Todo_존재시_중복_생성_안됨() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
-    given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
+    given(todoRepository.existsByRoutineAndDueDate(any(), any())).willReturn(true);
 
     routineService.createRoutine(
         1L, new RoutineCreateRequestDto("아침 스트레칭", null, RoutineType.DAILY, null, null, null));
@@ -526,7 +526,7 @@ class RoutineServiceTest {
     Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
     given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
         .willReturn(List.of(yesterdayTodo));
-    given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
+    given(todoRepository.existsByRoutineAndDueDate(any(), any())).willReturn(true);
 
     routineService.generateDailyTodos();
 

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -468,7 +468,7 @@ class RoutineServiceTest {
 
   @Test
   void generateDailyTodos_어제_마감_반복Todo_없으면_생성_안됨() {
-    given(todoRepository.findRoutineTodosByDueDateRange(any(), any())).willReturn(List.of());
+    given(todoRepository.findMotherRoutineTodosForRollover(any(), any())).willReturn(List.of());
 
     routineService.generateDailyTodos();
 
@@ -480,7 +480,7 @@ class RoutineServiceTest {
     // 어제(2024-01-14) dueDate DAILY 반복 Todo → nextOccurrence(오늘=2024-01-15) = 2024-01-15
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
-    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
         .willReturn(List.of(yesterdayTodo));
 
     routineService.generateDailyTodos();
@@ -495,7 +495,7 @@ class RoutineServiceTest {
     // 어제(2024-01-14, 일) dueDate WEEKLY(화=2) → nextOccurrence(오늘=월) = 2024-01-16(화)
     Routine routine = buildRoutine(RoutineType.WEEKLY, 2);
     Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
-    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
         .willReturn(List.of(yesterdayTodo));
 
     routineService.generateDailyTodos();
@@ -510,7 +510,7 @@ class RoutineServiceTest {
     // 어제(2024-01-14) dueDate MONTHLY(16일) → nextOccurrence(오늘=15일) = 2024-01-16
     Routine routine = buildRoutine(RoutineType.MONTHLY, 16);
     Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
-    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
         .willReturn(List.of(yesterdayTodo));
 
     routineService.generateDailyTodos();
@@ -524,7 +524,7 @@ class RoutineServiceTest {
   void generateDailyTodos_다음_반복일_Todo_이미_존재시_중복_생성_안됨() {
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     Todo yesterdayTodo = buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atStartOfDay());
-    given(todoRepository.findRoutineTodosByDueDateRange(any(), any()))
+    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
         .willReturn(List.of(yesterdayTodo));
     given(todoRepository.existsByRoutineAndDueDateBetween(any(), any(), any())).willReturn(true);
 

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -58,6 +58,7 @@ class TodoServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private TagRepository tagRepository;
   @Mock private RoutineRepository routineRepository;
+  @Mock private plana.replan.domain.routine.service.RoutineService routineService;
 
   @InjectMocks private TodoService todoService;
 
@@ -1611,7 +1612,7 @@ class TodoServiceTest {
     TodoDetailResponseDto result =
         todoService.updateTodo(1L, 1L, updateTodoRequest("제목", null, null, null, null));
 
-    assertThat(ReflectionTestUtils.getField(routine, "deletedAt")).isNotNull();
+    verify(routineService).cascadeSoftDelete(routine);
     assertThat(result.getRoutineType()).isNull();
   }
 


### PR DESCRIPTION
## 개요

루틴에 1단계 self-ref(`parent_id`)를 도입해 "엄마 루틴 + 하위 루틴" 구조를 지원한다. Todo의 기존 root/sub 분리 패턴과 정확히 같은 형태.

엄마 루틴 한 건을 만들면 매일 새벽 스케줄러가 엄마 Todo + 모든 하위 Todo를 한 트리로 묶어 생성한다. 하위 루틴은 `title`만 자기 것이고 스케줄/태그/목표/기한/유저는 모두 엄마를 따라간다.

## 변경 사항

### 신규 API
- `POST /api/routines/{parentId}/children` — 하위 루틴 추가. 엄마의 살아있는 다음 발생일 Todo가 있으면 즉시 그 엄마 Todo 아래에 하위 Todo를 매단다.
- `PATCH /api/routines/children/{id}` — 하위 루틴 title 수정 (다른 필드 불가).
- `DELETE /api/routines/{id}` — 엄마 루틴 전용 삭제 (cascade로 하위까지 soft delete).
- `DELETE /api/routines/children/{id}` — 하위 루틴 단독 삭제.

### 확장 API
- `POST /api/goals/with-todos` — RECURRING 항목에 `subRoutines: List<String>` 지원 추가. RoutineService에 위임만 한다.

### 스케줄러
- `generateDailyTodos`가 엄마 routine Todo만 fetch하도록 변경. parent IS NULL 필터로 하위 routine을 nextOccurrence에 넣어 NPE 나는 사고를 막고, JOIN에 routine.deleted_at IS NULL을 명시해 소프트-삭제된 엄마 routine의 좀비 Todo가 양산되지 않게 했다.
- `createTodoTreeFromMother`와 `attachChildTodoUnder` 헬퍼로 시나리오를 분리했다.

### DB 마이그레이션 (V5)
- `routine.parent_id` 컬럼 + self-FK + 인덱스.
- CHECK 제약: 하위 루틴(parent_id IS NOT NULL)은 routine_type / routine_date / due_date / tag_id / goal_id가 모두 NULL이어야 한다.
- ON DELETE CASCADE는 일부러 걸지 않았다 — soft delete 정책이므로 DB cascade는 어차피 동작하지 않으며, 자식 cascade는 Service의 `cascadeSoftDelete`에서 명시 처리한다.

### 운영 적용 체크
- routine 테이블 row 수 확인 후 수십만 단위면 CHECK를 NOT VALID로 분리, 인덱스도 CONCURRENTLY로 별도 적용 검토.
- 배포 순서: V5 적용 → 앱 배포. 기존 앱은 parent_id를 모르지만 nullable이라 INSERT가 깨지지 않음.

### Cascade 삭제 시 좀비 Todo 차단
`cascadeSoftDelete`가 routine을 죽이기 전에 그 routine을 참조하는 살아있는 Todo의 `routine` 참조를 null로 끊는다. `@SQLRestriction`이 걸린 routine을 lazy-load할 때 EntityNotFoundException으로 떨어져 목록 조회가 500이 나는 사고 방지. `TodoService.handleRoutineUpdate`의 간접 삭제 경로도 이 헬퍼로 교체했다.

## 테스트 (로컬 수행 완료)

- 엄마+하위 생성 시 Todo 트리(엄마 Todo + 하위 Todo들)가 같은 dueDate로 한꺼번에 생성됨
- 하위 루틴 ID로 또 하위 만들기 시도 → 404 (2단계 차단)
- 하위 루틴 title 수정 정상, 엄마 ID로 시도 시 400
- 잘못된 삭제 경로(엄마 ID를 children 경로로 등) → 400
- 엄마 삭제 시 하위까지 모두 soft delete
- 하위 루틴 추가 시 엄마의 오늘 Todo에 하위 Todo가 즉시 매달림 (dueDate 상속)
- 목표+투두 일괄 생성에서 RECURRING + subRoutines로 엄마+하위 루틴이 한 트랜잭션에 생성됨, 교차 사용은 400
- cascade 삭제 후 Todo 목록 조회 정상 (좀비 차단 검증)

## 관련 이슈
Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 반복 루틴에서 하위 루틴 생성 및 관리 기능 추가
  * 하위 루틴 생성, 수정, 삭제를 위한 새로운 API 엔드포인트 추가

* **버그 수정**
  * 단발성 투두에 하위 루틴이 추가되지 않도록 검증 강화

* **문서**
  * 목표 및 루틴 API 문서에 하위 루틴 관련 스펙 및 예시 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->