### PR TITLE
v0.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.flywaydb:flyway-database-postgresql'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
 }
 

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
@@ -39,6 +39,6 @@ public class GeminiThrottleChunkListener implements ChunkListener {
 
   @Override
   public void afterChunkError(ChunkContext context) {
-    aiCalled = false;
+    // Gemini 호출 후 실패한 경우에도 throttle이 작동해야 429 연쇄를 막을 수 있으므로 리셋하지 않음
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
@@ -1,0 +1,44 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.listener.ChunkListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+public class GeminiThrottleChunkListener implements ChunkListener {
+
+  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
+  private long geminiCallDelayMs;
+
+  private boolean aiCalled;
+
+  void markAiCalled() {
+    aiCalled = true;
+  }
+
+  @Override
+  public void beforeChunk(ChunkContext context) {
+    aiCalled = false;
+  }
+
+  @Override
+  public void afterChunk(ChunkContext context) {
+    if (!aiCalled) return;
+    try {
+      Thread.sleep(geminiCallDelayMs);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Gemini throttle sleep 인터럽트");
+    }
+  }
+
+  @Override
+  public void afterChunkError(ChunkContext context) {
+    aiCalled = false;
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportData.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportData.java
@@ -1,0 +1,9 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import java.time.LocalDate;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.service.CalculatedStats;
+import plana.replan.domain.user.entity.User;
+
+record MonthlyReportData(
+    User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -3,6 +3,8 @@ package plana.replan.domain.monthlyreport.batch;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -23,9 +25,15 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
 
+  private YearMonth targetMonth;
+
+  @BeforeStep
+  public void beforeStep(StepExecution stepExecution) {
+    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
+  }
+
   @Override
   public MonthlyReportData process(User user) throws Exception {
-    YearMonth targetMonth = YearMonth.now().minusMonths(1);
     log.debug("통계 처리 중 - userId={}, targetMonth={}", user.getId(), targetMonth);
 
     CalculatedStats stats = calculator.calculate(user, targetMonth);

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -21,9 +21,7 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
 
   private final MonthlyReportCalculator calculator;
   private final MonthlyReportAiService aiService;
-
-  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
-  private long geminiCallDelayMs;
+  private final GeminiThrottleChunkListener throttleListener;
 
   @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
@@ -40,7 +38,7 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
     }
 
     AiInsight aiInsight = aiService.generateInsight(stats, targetMonth);
-    Thread.sleep(geminiCallDelayMs);
+    throttleListener.markAiCalled(); // sleep은 트랜잭션 밖 afterChunk()에서 실행
 
     return new MonthlyReportData(user, targetMonth.atDay(1), stats, aiInsight);
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -3,8 +3,7 @@ package plana.replan.domain.monthlyreport.batch;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.annotation.BeforeStep;
-import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -16,6 +15,7 @@ import plana.replan.domain.user.entity.User;
 
 @Slf4j
 @Component
+@StepScope
 @RequiredArgsConstructor
 public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyReportData> {
 
@@ -25,12 +25,8 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
 
+  @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
-
-  @BeforeStep
-  public void beforeStep(StepExecution stepExecution) {
-    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
-  }
 
   @Override
   public MonthlyReportData process(User user) throws Exception {

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -1,0 +1,41 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.service.CalculatedStats;
+import plana.replan.domain.monthlyreport.service.MonthlyReportAiService;
+import plana.replan.domain.monthlyreport.service.MonthlyReportCalculator;
+import plana.replan.domain.user.entity.User;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyReportData> {
+
+  private final MonthlyReportCalculator calculator;
+  private final MonthlyReportAiService aiService;
+
+  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
+  private long geminiCallDelayMs;
+
+  @Override
+  public MonthlyReportData process(User user) throws Exception {
+    YearMonth targetMonth = YearMonth.now().minusMonths(1);
+    log.debug("통계 처리 중 - userId={}, targetMonth={}", user.getId(), targetMonth);
+
+    CalculatedStats stats = calculator.calculate(user, targetMonth);
+
+    AiInsight aiInsight = null;
+    if (stats.hasActivity()) {
+      aiInsight = aiService.generateInsight(stats, targetMonth);
+      Thread.sleep(geminiCallDelayMs);
+    }
+
+    return new MonthlyReportData(user, targetMonth.atDay(1), stats, aiInsight);
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -38,11 +38,13 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
 
     CalculatedStats stats = calculator.calculate(user, targetMonth);
 
-    AiInsight aiInsight = null;
-    if (stats.hasActivity()) {
-      aiInsight = aiService.generateInsight(stats, targetMonth);
-      Thread.sleep(geminiCallDelayMs);
+    if (!stats.hasActivity()) {
+      log.debug("활동 데이터 부족으로 리포트 건너뜀 - userId={}", user.getId());
+      return null; // null 반환 시 Spring Batch가 writer 호출 생략
     }
+
+    AiInsight aiInsight = aiService.generateInsight(stats, targetMonth);
+    Thread.sleep(geminiCallDelayMs);
 
     return new MonthlyReportData(user, targetMonth.atDay(1), stats, aiInsight);
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemWriter.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemWriter.java
@@ -1,0 +1,54 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.monthlyreport.service.CalculatedStats;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyReportItemWriter implements ItemWriter<MonthlyReportData> {
+
+  private final MonthlyReportRepository monthlyReportRepository;
+
+  @Override
+  public void write(Chunk<? extends MonthlyReportData> chunk) {
+    for (MonthlyReportData data : chunk) {
+      CalculatedStats stats = data.stats();
+      monthlyReportRepository
+          .findByUserAndReportMonth(data.user(), data.reportMonth())
+          .ifPresentOrElse(
+              report ->
+                  report.update(
+                      stats.totalTodos(),
+                      stats.completedTodos(),
+                      stats.achievementRate(),
+                      stats.prevMonthDiff(),
+                      stats.replanCount(),
+                      stats.replanAchievementEffect(),
+                      stats.analysisData(),
+                      data.aiInsight()),
+              () ->
+                  monthlyReportRepository.save(
+                      MonthlyReport.builder()
+                          .user(data.user())
+                          .reportMonth(data.reportMonth())
+                          .totalTodos(stats.totalTodos())
+                          .completedTodos(stats.completedTodos())
+                          .achievementRate(stats.achievementRate())
+                          .prevMonthDiff(stats.prevMonthDiff())
+                          .replanCount(stats.replanCount())
+                          .replanAchievementEffect(stats.replanAchievementEffect())
+                          .analysisData(stats.analysisData())
+                          .aiInsight(data.aiInsight())
+                          .build()));
+
+      log.debug("리포트 저장 완료 - userId={}", data.user().getId());
+    }
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
@@ -1,12 +1,10 @@
 package plana.replan.domain.monthlyreport.batch;
 
 import jakarta.persistence.EntityManagerFactory;
-import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
-import org.springframework.batch.core.listener.SkipListener;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -15,8 +13,6 @@ import org.springframework.batch.infrastructure.item.database.builder.JpaCursorI
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
-import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
-import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
 import plana.replan.domain.user.entity.User;
 
 @Slf4j
@@ -29,7 +25,7 @@ public class MonthlyReportJobConfig {
   private final EntityManagerFactory entityManagerFactory;
   private final MonthlyReportItemProcessor processor;
   private final MonthlyReportItemWriter writer;
-  private final ReportGenerationFailureRepository failureRepository;
+  private final ReportSkipListener reportSkipListener;
 
   @Bean
   public Job monthlyReportJob(Step monthlyReportStep) {
@@ -47,7 +43,7 @@ public class MonthlyReportJobConfig {
         .faultTolerant()
         .skip(Exception.class)
         .skipLimit(Integer.MAX_VALUE)
-        .listener(reportSkipListener())
+        .listener(reportSkipListener)
         .build();
   }
 
@@ -58,38 +54,5 @@ public class MonthlyReportJobConfig {
         .entityManagerFactory(entityManagerFactory)
         .queryString("SELECT u FROM User u WHERE u.deletedAt IS NULL ORDER BY u.id ASC")
         .build();
-  }
-
-  @Bean
-  public SkipListener<User, MonthlyReportData> reportSkipListener() {
-    return new SkipListener<>() {
-      @Override
-      public void onSkipInProcess(User user, Throwable t) {
-        log.error("통계 생성 실패 - userId={}", user.getId(), t);
-        saveFailure(user, t.getMessage());
-      }
-
-      @Override
-      public void onSkipInRead(Throwable t) {
-        log.error("사용자 읽기 실패", t);
-      }
-
-      @Override
-      public void onSkipInWrite(MonthlyReportData data, Throwable t) {
-        log.error("리포트 저장 실패 - userId={}", data.user().getId(), t);
-        saveFailure(data.user(), t.getMessage());
-      }
-
-      private void saveFailure(User user, String message) {
-        try {
-          String truncated =
-              message != null && message.length() > 500 ? message.substring(0, 500) : message;
-          failureRepository.save(
-              ReportGenerationFailure.of(user, YearMonth.now().minusMonths(1).atDay(1), truncated));
-        } catch (Exception ex) {
-          log.error("실패 기록 저장 오류 - userId={}", user.getId(), ex);
-        }
-      }
-    };
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
@@ -10,6 +10,7 @@ import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.infrastructure.item.database.JpaCursorItemReader;
 import org.springframework.batch.infrastructure.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -27,6 +28,9 @@ public class MonthlyReportJobConfig {
   private final MonthlyReportItemWriter writer;
   private final ReportSkipListener reportSkipListener;
 
+  @Value("${statistics.batch.skip-limit:100}")
+  private int skipLimit;
+
   @Bean
   public Job monthlyReportJob(Step monthlyReportStep) {
     return new JobBuilder("monthlyReportJob", jobRepository).start(monthlyReportStep).build();
@@ -41,8 +45,14 @@ public class MonthlyReportJobConfig {
         .processor(processor)
         .writer(writer)
         .faultTolerant()
-        .skip(Exception.class)
-        .skipLimit(Integer.MAX_VALUE)
+        .skipPolicy(
+            (t, skipCount) -> {
+              // NPE·IllegalStateException은 버그 지표이므로 스킵 금지
+              if (t instanceof NullPointerException || t instanceof IllegalStateException) {
+                return false;
+              }
+              return t instanceof RuntimeException && skipCount < skipLimit;
+            })
         .listener(reportSkipListener)
         .build();
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
@@ -1,0 +1,95 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.listener.SkipListener;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.item.database.JpaCursorItemReader;
+import org.springframework.batch.infrastructure.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
+import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
+import plana.replan.domain.user.entity.User;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyReportJobConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final EntityManagerFactory entityManagerFactory;
+  private final MonthlyReportItemProcessor processor;
+  private final MonthlyReportItemWriter writer;
+  private final ReportGenerationFailureRepository failureRepository;
+
+  @Bean
+  public Job monthlyReportJob(Step monthlyReportStep) {
+    return new JobBuilder("monthlyReportJob", jobRepository).start(monthlyReportStep).build();
+  }
+
+  @Bean
+  public Step monthlyReportStep() {
+    return new StepBuilder("monthlyReportStep", jobRepository)
+        .<User, MonthlyReportData>chunk(1)
+        .transactionManager(transactionManager)
+        .reader(userItemReader())
+        .processor(processor)
+        .writer(writer)
+        .faultTolerant()
+        .skip(Exception.class)
+        .skipLimit(Integer.MAX_VALUE)
+        .listener(reportSkipListener())
+        .build();
+  }
+
+  @Bean
+  public JpaCursorItemReader<User> userItemReader() {
+    return new JpaCursorItemReaderBuilder<User>()
+        .name("userItemReader")
+        .entityManagerFactory(entityManagerFactory)
+        .queryString("SELECT u FROM User u WHERE u.deletedAt IS NULL ORDER BY u.id ASC")
+        .build();
+  }
+
+  @Bean
+  public SkipListener<User, MonthlyReportData> reportSkipListener() {
+    return new SkipListener<>() {
+      @Override
+      public void onSkipInProcess(User user, Throwable t) {
+        log.error("통계 생성 실패 - userId={}", user.getId(), t);
+        saveFailure(user, t.getMessage());
+      }
+
+      @Override
+      public void onSkipInRead(Throwable t) {
+        log.error("사용자 읽기 실패", t);
+      }
+
+      @Override
+      public void onSkipInWrite(MonthlyReportData data, Throwable t) {
+        log.error("리포트 저장 실패 - userId={}", data.user().getId(), t);
+        saveFailure(data.user(), t.getMessage());
+      }
+
+      private void saveFailure(User user, String message) {
+        try {
+          String truncated =
+              message != null && message.length() > 500 ? message.substring(0, 500) : message;
+          failureRepository.save(
+              ReportGenerationFailure.of(user, YearMonth.now().minusMonths(1).atDay(1), truncated));
+        } catch (Exception ex) {
+          log.error("실패 기록 저장 오류 - userId={}", user.getId(), ex);
+        }
+      }
+    };
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
@@ -3,6 +3,7 @@ package plana.replan.domain.monthlyreport.batch;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
@@ -27,6 +28,7 @@ public class MonthlyReportJobConfig {
   private final MonthlyReportItemProcessor processor;
   private final MonthlyReportItemWriter writer;
   private final ReportSkipListener reportSkipListener;
+  private final GeminiThrottleChunkListener throttleListener;
 
   @Value("${statistics.batch.skip-limit:100}")
   private int skipLimit;
@@ -54,10 +56,12 @@ public class MonthlyReportJobConfig {
               return t instanceof RuntimeException && skipCount < skipLimit;
             })
         .listener(reportSkipListener)
+        .listener(throttleListener)
         .build();
   }
 
   @Bean
+  @StepScope
   public JpaCursorItemReader<User> userItemReader() {
     return new JpaCursorItemReaderBuilder<User>()
         .name("userItemReader")

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
@@ -1,0 +1,116 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
+import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
+import plana.replan.domain.monthlyreport.service.CalculatedStats;
+import plana.replan.domain.monthlyreport.service.MonthlyReportAiService;
+import plana.replan.domain.monthlyreport.service.MonthlyReportCalculator;
+import plana.replan.domain.user.entity.User;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyReportScheduler {
+
+  private final JobOperator jobOperator;
+  private final Job monthlyReportJob;
+  private final ReportGenerationFailureRepository failureRepository;
+  private final MonthlyReportCalculator calculator;
+  private final MonthlyReportAiService aiService;
+  private final MonthlyReportRepository monthlyReportRepository;
+
+  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
+  private long geminiCallDelayMs;
+
+  @Scheduled(cron = "0 0 0 1 * *")
+  public void runMonthlyReportBatch() {
+    log.info("월간 리포트 배치 시작 - targetMonth={}", YearMonth.now().minusMonths(1));
+
+    JobParameters params =
+        new JobParametersBuilder().addLocalDateTime("runAt", LocalDateTime.now()).toJobParameters();
+
+    try {
+      var execution = jobOperator.start(monthlyReportJob, params);
+      log.info("월간 리포트 배치 완료 - status={}", execution.getStatus());
+    } catch (Exception e) {
+      log.error("월간 리포트 배치 실행 실패", e);
+    }
+  }
+
+  @Scheduled(cron = "0 0 3 * * *")
+  @Transactional
+  public void retryFailedReports() {
+    List<ReportGenerationFailure> failures = failureRepository.findByRetryCountLessThan(3);
+    if (failures.isEmpty()) return;
+
+    log.info("실패 리포트 재처리 시작 - count={}", failures.size());
+
+    for (ReportGenerationFailure failure : failures) {
+      User user = failure.getUser();
+      YearMonth targetMonth = YearMonth.from(failure.getTargetMonth());
+      try {
+        CalculatedStats stats = calculator.calculate(user, targetMonth);
+        AiInsight aiInsight = null;
+        if (stats.hasActivity()) {
+          aiInsight = aiService.generateInsight(stats, targetMonth);
+          Thread.sleep(geminiCallDelayMs);
+        }
+        upsertReport(user, failure.getTargetMonth(), stats, aiInsight);
+        failure.softDelete();
+        log.info("재처리 성공 - userId={}", user.getId());
+      } catch (Exception e) {
+        log.error("재처리 실패 - userId={}", user.getId(), e);
+        String msg = e.getMessage();
+        failure.incrementRetry(msg != null && msg.length() > 500 ? msg.substring(0, 500) : msg);
+      }
+    }
+  }
+
+  private void upsertReport(
+      User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {
+    monthlyReportRepository
+        .findByUserAndReportMonth(user, reportMonth)
+        .ifPresentOrElse(
+            report ->
+                report.update(
+                    stats.totalTodos(),
+                    stats.completedTodos(),
+                    stats.achievementRate(),
+                    stats.prevMonthDiff(),
+                    stats.replanCount(),
+                    stats.replanAchievementEffect(),
+                    stats.analysisData(),
+                    aiInsight),
+            () ->
+                monthlyReportRepository.save(
+                    MonthlyReport.builder()
+                        .user(user)
+                        .reportMonth(reportMonth)
+                        .totalTodos(stats.totalTodos())
+                        .completedTodos(stats.completedTodos())
+                        .achievementRate(stats.achievementRate())
+                        .prevMonthDiff(stats.prevMonthDiff())
+                        .replanCount(stats.replanCount())
+                        .replanAchievementEffect(stats.replanAchievementEffect())
+                        .analysisData(stats.analysisData())
+                        .aiInsight(aiInsight)
+                        .build()));
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
@@ -1,6 +1,5 @@
 package plana.replan.domain.monthlyreport.batch;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -13,16 +12,8 @@ import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import plana.replan.domain.monthlyreport.entity.AiInsight;
-import plana.replan.domain.monthlyreport.entity.MonthlyReport;
-import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
-import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
 import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
-import plana.replan.domain.monthlyreport.service.CalculatedStats;
-import plana.replan.domain.monthlyreport.service.MonthlyReportAiService;
-import plana.replan.domain.monthlyreport.service.MonthlyReportCalculator;
-import plana.replan.domain.user.entity.User;
+import plana.replan.domain.monthlyreport.service.MonthlyReportService;
 
 @Slf4j
 @Component
@@ -32,9 +23,7 @@ public class MonthlyReportScheduler {
   private final JobOperator jobOperator;
   private final Job monthlyReportJob;
   private final ReportGenerationFailureRepository failureRepository;
-  private final MonthlyReportCalculator calculator;
-  private final MonthlyReportAiService aiService;
-  private final MonthlyReportRepository monthlyReportRepository;
+  private final MonthlyReportService monthlyReportService;
 
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
@@ -59,62 +48,23 @@ public class MonthlyReportScheduler {
   }
 
   @Scheduled(cron = "0 0 3 * * *")
-  @Transactional
   public void retryFailedReports() {
-    List<ReportGenerationFailure> failures = failureRepository.findByRetryCountLessThan(3);
-    if (failures.isEmpty()) return;
+    List<Long> failureIds =
+        failureRepository.findByRetryCountLessThan(3).stream().map(f -> f.getId()).toList();
 
-    log.info("실패 리포트 재처리 시작 - count={}", failures.size());
+    if (failureIds.isEmpty()) return;
+    log.info("실패 리포트 재처리 시작 - count={}", failureIds.size());
 
-    for (ReportGenerationFailure failure : failures) {
-      User user = failure.getUser();
-      YearMonth targetMonth = YearMonth.from(failure.getTargetMonth());
+    for (Long failureId : failureIds) {
       try {
-        CalculatedStats stats = calculator.calculate(user, targetMonth);
-        AiInsight aiInsight = null;
-        if (stats.hasActivity()) {
-          aiInsight = aiService.generateInsight(stats, targetMonth);
-          Thread.sleep(geminiCallDelayMs);
-        }
-        upsertReport(user, failure.getTargetMonth(), stats, aiInsight);
-        failure.softDelete();
-        log.info("재처리 성공 - userId={}", user.getId());
-      } catch (Exception e) {
-        log.error("재처리 실패 - userId={}", user.getId(), e);
-        String msg = e.getMessage();
-        failure.incrementRetry(msg != null && msg.length() > 500 ? msg.substring(0, 500) : msg);
+        boolean hadActivity = monthlyReportService.retryOneFailure(failureId);
+        // Gemini를 호출한 경우에만 RPM 제한 대응 지연
+        if (hadActivity) Thread.sleep(geminiCallDelayMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        log.warn("재처리 인터럽트 - 종료");
+        break;
       }
     }
-  }
-
-  private void upsertReport(
-      User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {
-    monthlyReportRepository
-        .findByUserAndReportMonth(user, reportMonth)
-        .ifPresentOrElse(
-            report ->
-                report.update(
-                    stats.totalTodos(),
-                    stats.completedTodos(),
-                    stats.achievementRate(),
-                    stats.prevMonthDiff(),
-                    stats.replanCount(),
-                    stats.replanAchievementEffect(),
-                    stats.analysisData(),
-                    aiInsight),
-            () ->
-                monthlyReportRepository.save(
-                    MonthlyReport.builder()
-                        .user(user)
-                        .reportMonth(reportMonth)
-                        .totalTodos(stats.totalTodos())
-                        .completedTodos(stats.completedTodos())
-                        .achievementRate(stats.achievementRate())
-                        .prevMonthDiff(stats.prevMonthDiff())
-                        .replanCount(stats.replanCount())
-                        .replanAchievementEffect(stats.replanAchievementEffect())
-                        .analysisData(stats.analysisData())
-                        .aiInsight(aiInsight)
-                        .build()));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
@@ -41,10 +41,14 @@ public class MonthlyReportScheduler {
 
   @Scheduled(cron = "0 0 0 1 * *")
   public void runMonthlyReportBatch() {
-    log.info("월간 리포트 배치 시작 - targetMonth={}", YearMonth.now().minusMonths(1));
+    YearMonth targetMonth = YearMonth.now().minusMonths(1);
+    log.info("월간 리포트 배치 시작 - targetMonth={}", targetMonth);
 
     JobParameters params =
-        new JobParametersBuilder().addLocalDateTime("runAt", LocalDateTime.now()).toJobParameters();
+        new JobParametersBuilder()
+            .addLocalDateTime("runAt", LocalDateTime.now())
+            .addString("targetMonth", targetMonth.toString())
+            .toJobParameters();
 
     try {
       var execution = jobOperator.start(monthlyReportJob, params);

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
@@ -28,6 +28,9 @@ public class MonthlyReportScheduler {
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
 
+  @Value("${statistics.batch.max-retry-count:3}")
+  private int maxRetryCount;
+
   @Scheduled(cron = "0 0 0 1 * *")
   public void runMonthlyReportBatch() {
     YearMonth targetMonth = YearMonth.now().minusMonths(1);
@@ -41,7 +44,11 @@ public class MonthlyReportScheduler {
 
     try {
       var execution = jobOperator.start(monthlyReportJob, params);
-      log.info("월간 리포트 배치 완료 - status={}", execution.getStatus());
+      if (execution.getStatus().isUnsuccessful()) {
+        log.error("월간 리포트 배치 실패 - status={}", execution.getStatus());
+      } else {
+        log.info("월간 리포트 배치 완료 - status={}", execution.getStatus());
+      }
     } catch (Exception e) {
       log.error("월간 리포트 배치 실행 실패", e);
     }
@@ -50,7 +57,9 @@ public class MonthlyReportScheduler {
   @Scheduled(cron = "0 0 3 * * *")
   public void retryFailedReports() {
     List<Long> failureIds =
-        failureRepository.findByRetryCountLessThan(3).stream().map(f -> f.getId()).toList();
+        failureRepository.findByRetryCountLessThan(maxRetryCount).stream()
+            .map(f -> f.getId())
+            .toList();
 
     if (failureIds.isEmpty()) return;
     log.info("실패 리포트 재처리 시작 - count={}", failureIds.size());
@@ -64,6 +73,8 @@ public class MonthlyReportScheduler {
         Thread.currentThread().interrupt();
         log.warn("재처리 인터럽트 - 종료");
         break;
+      } catch (Exception e) {
+        log.error("재처리 중 예외 발생 - failureId={}", failureId, e);
       }
     }
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
@@ -46,7 +46,13 @@ public class ReportSkipListener implements SkipListener<User, MonthlyReportData>
     try {
       String truncated =
           message != null && message.length() > 500 ? message.substring(0, 500) : message;
-      failureRepository.save(ReportGenerationFailure.of(user, targetMonth.atDay(1), truncated));
+      failureRepository
+          .findByUserAndTargetMonth(user, targetMonth.atDay(1))
+          .ifPresentOrElse(
+              f -> f.incrementRetry(truncated),
+              () ->
+                  failureRepository.save(
+                      ReportGenerationFailure.of(user, targetMonth.atDay(1), truncated)));
     } catch (Exception ex) {
       log.error("실패 기록 저장 오류 - userId={}", user.getId(), ex);
     }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
@@ -3,9 +3,9 @@ package plana.replan.domain.monthlyreport.batch;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.listener.SkipListener;
-import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
 import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
@@ -13,17 +13,14 @@ import plana.replan.domain.user.entity.User;
 
 @Slf4j
 @Component
+@StepScope
 @RequiredArgsConstructor
 public class ReportSkipListener implements SkipListener<User, MonthlyReportData> {
 
   private final ReportGenerationFailureRepository failureRepository;
 
+  @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
-
-  @BeforeStep
-  public void beforeStep(StepExecution stepExecution) {
-    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
-  }
 
   @Override
   public void onSkipInProcess(User user, Throwable t) {

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
@@ -1,0 +1,54 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.listener.SkipListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.stereotype.Component;
+import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
+import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
+import plana.replan.domain.user.entity.User;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportSkipListener implements SkipListener<User, MonthlyReportData> {
+
+  private final ReportGenerationFailureRepository failureRepository;
+
+  private YearMonth targetMonth;
+
+  @BeforeStep
+  public void beforeStep(StepExecution stepExecution) {
+    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
+  }
+
+  @Override
+  public void onSkipInProcess(User user, Throwable t) {
+    log.error("통계 생성 실패 - userId={}", user.getId(), t);
+    saveFailure(user, t.getMessage());
+  }
+
+  @Override
+  public void onSkipInRead(Throwable t) {
+    log.error("사용자 읽기 실패", t);
+  }
+
+  @Override
+  public void onSkipInWrite(MonthlyReportData data, Throwable t) {
+    log.error("리포트 저장 실패 - userId={}", data.user().getId(), t);
+    saveFailure(data.user(), t.getMessage());
+  }
+
+  private void saveFailure(User user, String message) {
+    try {
+      String truncated =
+          message != null && message.length() > 500 ? message.substring(0, 500) : message;
+      failureRepository.save(ReportGenerationFailure.of(user, targetMonth.atDay(1), truncated));
+    } catch (Exception ex) {
+      log.error("실패 기록 저장 오류 - userId={}", user.getId(), ex);
+    }
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
@@ -1,9 +1,10 @@
 package plana.replan.domain.monthlyreport.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,14 +15,15 @@ import plana.replan.global.common.ApiResult;
 @RestController
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
-public class MonthlyReportController implements MonthlyReportControllerDocs {
+@Profile("!prod")
+public class DevMonthlyReportController {
 
   private final MonthlyReportService monthlyReportService;
 
-  @Override
-  @GetMapping
-  public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
+  @PostMapping("/generate")
+  public ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
       @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
-    return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
+    return ResponseEntity.ok(
+        ApiResult.ok(monthlyReportService.generateReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
@@ -1,9 +1,12 @@
 package plana.replan.domain.monthlyreport.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,13 +19,16 @@ import plana.replan.global.common.ApiResult;
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
 @Profile("local")
+@Validated
 public class DevMonthlyReportController {
 
   private final MonthlyReportService monthlyReportService;
 
   @PostMapping("/generate")
   public ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
-      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+      @AuthenticationPrincipal Long userId,
+      @RequestParam @Min(1) int year,
+      @RequestParam @Min(1) @Max(12) int month) {
     return ResponseEntity.ok(
         ApiResult.ok(monthlyReportService.generateReport(userId, year, month)));
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
@@ -15,7 +15,7 @@ import plana.replan.global.common.ApiResult;
 @RestController
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
-@Profile("!prod")
+@Profile("local")
 public class DevMonthlyReportController {
 
   private final MonthlyReportService monthlyReportService;

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -1,8 +1,11 @@
 package plana.replan.domain.monthlyreport.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +17,7 @@ import plana.replan.global.common.ApiResult;
 @RestController
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
+@Validated
 public class MonthlyReportController implements MonthlyReportControllerDocs {
 
   private final MonthlyReportService monthlyReportService;
@@ -21,7 +25,9 @@ public class MonthlyReportController implements MonthlyReportControllerDocs {
   @Override
   @GetMapping
   public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
-      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+      @AuthenticationPrincipal Long userId,
+      @RequestParam @Min(1) int year,
+      @RequestParam @Min(1) @Max(12) int month) {
     return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +24,13 @@ public class MonthlyReportController implements MonthlyReportControllerDocs {
   public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
       @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
     return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
+  }
+
+  @Override
+  @PostMapping("/generate")
+  public ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
+      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+    return ResponseEntity.ok(
+        ApiResult.ok(monthlyReportService.generateReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -1,7 +1,5 @@
 package plana.replan.domain.monthlyreport.controller;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,9 +23,7 @@ public class MonthlyReportController implements MonthlyReportControllerDocs {
   @Override
   @GetMapping
   public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam @Min(1) int year,
-      @RequestParam @Min(1) @Max(12) int month) {
+      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
     return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -1,0 +1,27 @@
+package plana.replan.domain.monthlyreport.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.monthlyreport.dto.MonthlyReportResponse;
+import plana.replan.domain.monthlyreport.service.MonthlyReportService;
+import plana.replan.global.common.ApiResult;
+
+@RestController
+@RequestMapping("/api/monthly-reports")
+@RequiredArgsConstructor
+public class MonthlyReportController implements MonthlyReportControllerDocs {
+
+  private final MonthlyReportService monthlyReportService;
+
+  @Override
+  @GetMapping
+  public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
+      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+    return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
@@ -1,0 +1,136 @@
+package plana.replan.domain.monthlyreport.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+import plana.replan.domain.monthlyreport.dto.MonthlyReportResponse;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "MonthlyReport", description = "월간 통계 리포트 API")
+public interface MonthlyReportControllerDocs {
+
+  @Operation(
+      summary = "월간 통계 조회",
+      description =
+          """
+          지정한 연월의 투두 달성 통계 리포트를 조회합니다.
+          리포트는 매월 1일 00:00에 배치 작업으로 자동 생성됩니다.
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          **Query Parameters**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | year | ✅ 필수 | integer | 조회 연도 | `2025` |
+          | month | ✅ 필수 | integer | 조회 월 (1~12) | `5` |
+
+          **Response Elements**
+
+          | 필드명 | 타입 | 설명 |
+          |--------|------|------|
+          | year | integer | 연도 |
+          | month | integer | 월 |
+          | totalTodos | integer | 해당 월 전체 투두 수 |
+          | completedTodos | integer | 달성 투두 수 |
+          | achievementRate | number | 달성률 (%) |
+          | prevMonthDiff | number | 전월 대비 달성률 차이 (%p). 전월 데이터 없으면 null |
+          | replanCount | integer | 리플랜 횟수 |
+          | replanAchievementEffect | number | 리플랜 달성 효과 (%). 리플랜 없으면 null |
+          | analysisData | object | 분석 데이터. 투두 활동 없으면 null |
+          | aiInsight | object | AI 인사이트. 투두 활동 없으면 null |
+          """)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "code": 200,
+                              "data": {
+                                "year": 2025,
+                                "month": 5,
+                                "totalTodos": 30,
+                                "completedTodos": 21,
+                                "achievementRate": 70.00,
+                                "prevMonthDiff": 5.50,
+                                "replanCount": 3,
+                                "replanAchievementEffect": 66.67,
+                                "analysisData": {
+                                  "topFailureReason": "심리적 저항",
+                                  "failureDistribution": [
+                                    {"reason": "심리적 저항", "count": 5, "rate": 55.56},
+                                    {"reason": "컨디션 난조", "count": 4, "rate": 44.44}
+                                  ],
+                                  "bestAchievementTag": {"title": "운동", "color": "#FF5733", "rate": 85.0},
+                                  "worstAchievementTag": {"title": "공부", "color": "#3399FF", "rate": 50.0},
+                                  "bestAchievementDay": {"day": "화요일", "rate": 90.0},
+                                  "worstAchievementDay": {"day": "월요일", "rate": 40.0},
+                                  "patternCombinations": [
+                                    {"reason": "심리적 저항", "tag": "공부", "day": null, "count": 3}
+                                  ]
+                                },
+                                "aiInsight": {
+                                  "insights": [
+                                    {"summary": "화요일 집중력이 가장 높습니다", "detail": "화요일 달성률이 90%로 가장 높았습니다."}
+                                  ],
+                                  "writingTip": "월요일에는 가벼운 투두 위주로 구성하면 달성률이 높아집니다."
+                                }
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {"code":401,"message":"EMPTY_TOKEN","data":null}
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {"code":401,"message":"EXPIRED_TOKEN","data":null}
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "리포트 없음",
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {"code":404,"message":"해당 월의 통계 리포트가 없습니다.","data":null}
+                            """)))
+  })
+  ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
+      @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam int month);
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -133,6 +135,7 @@ public interface MonthlyReportControllerDocs {
   })
   ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
       @AuthenticationPrincipal Long userId,
-      @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
-      @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam int month);
+      @Parameter(description = "조회 연도", example = "2025") @RequestParam @Min(1) int year,
+      @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam @Min(1) @Max(12)
+          int month);
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
@@ -133,4 +133,10 @@ public interface MonthlyReportControllerDocs {
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
       @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam int month);
+
+  @Operation(summary = "[dev] 월간 통계 수동 생성", description = "배치 없이 월간 통계를 즉시 계산·저장합니다. 개발/테스트 전용.")
+  ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "연도", example = "2026") @RequestParam int year,
+      @Parameter(description = "월 (1~12)", example = "5") @RequestParam int month);
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
@@ -63,7 +63,8 @@ public interface MonthlyReportControllerDocs {
                         value =
                             """
                             {
-                              "code": 200,
+                              "status": 200,
+                              "success": true,
                               "data": {
                                 "year": 2025,
                                 "month": 5,
@@ -93,7 +94,8 @@ public interface MonthlyReportControllerDocs {
                                   ],
                                   "writingTip": "월요일에는 가벼운 투두 위주로 구성하면 달성률이 높아집니다."
                                 }
-                              }
+                              },
+                              "error": null
                             }
                             """))),
     @ApiResponse(
@@ -107,13 +109,13 @@ public interface MonthlyReportControllerDocs {
                       name = "토큰 없음",
                       value =
                           """
-                          {"code":401,"message":"EMPTY_TOKEN","data":null}
+                          {"status":401,"success":false,"data":null,"error":{"code":"EMPTY_TOKEN","message":"토큰이 없습니다."}}
                           """),
                   @ExampleObject(
                       name = "만료된 토큰",
                       value =
                           """
-                          {"code":401,"message":"EXPIRED_TOKEN","data":null}
+                          {"status":401,"success":false,"data":null,"error":{"code":"EXPIRED_TOKEN","message":"만료된 토큰입니다."}}
                           """)
                 })),
     @ApiResponse(
@@ -126,17 +128,11 @@ public interface MonthlyReportControllerDocs {
                     @ExampleObject(
                         value =
                             """
-                            {"code":404,"message":"해당 월의 통계 리포트가 없습니다.","data":null}
+                            {"status":404,"success":false,"data":null,"error":{"code":"REPORT_NOT_FOUND","message":"해당 월의 통계 리포트가 없습니다."}}
                             """)))
   })
   ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
       @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam int month);
-
-  @Operation(summary = "[dev] 월간 통계 수동 생성", description = "배치 없이 월간 통계를 즉시 계산·저장합니다. 개발/테스트 전용.")
-  ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
-      @AuthenticationPrincipal Long userId,
-      @Parameter(description = "연도", example = "2026") @RequestParam int year,
-      @Parameter(description = "월 (1~12)", example = "5") @RequestParam int month);
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/dto/MonthlyReportResponse.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/dto/MonthlyReportResponse.java
@@ -1,0 +1,65 @@
+package plana.replan.domain.monthlyreport.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "월간 통계 응답")
+public record MonthlyReportResponse(
+    @Schema(description = "연도", example = "2025") int year,
+    @Schema(description = "월", example = "5") int month,
+    @Schema(description = "해당 월 전체 투두 수", example = "30") int totalTodos,
+    @Schema(description = "달성 투두 수", example = "21") int completedTodos,
+    @Schema(description = "달성률 (%)", example = "70.00") double achievementRate,
+    @Schema(description = "전월 대비 달성률 차이 (%p). 전월 데이터 없으면 null", example = "5.50")
+        Double prevMonthDiff,
+    @Schema(description = "리플랜 횟수", example = "3") int replanCount,
+    @Schema(description = "리플랜 달성 효과 (%). 리플랜 없으면 null", example = "66.67")
+        Double replanAchievementEffect,
+    @Schema(description = "분석 데이터. 투두 활동 없으면 null") AnalysisDataResponse analysisData,
+    @Schema(description = "AI 인사이트. 투두 활동 없으면 null") AiInsightResponse aiInsight) {
+
+  @Schema(description = "분석 데이터")
+  public record AnalysisDataResponse(
+      @Schema(description = "가장 많은 실패 원인", example = "심리적 저항") String topFailureReason,
+      @Schema(description = "실패 원인 분포") List<FailureDistributionItem> failureDistribution,
+      @Schema(description = "달성률 높은 태그. 태그가 2개 이상인 경우에만 존재") TagStatResponse bestAchievementTag,
+      @Schema(description = "달성률 낮은 태그. 태그가 2개 이상인 경우에만 존재") TagStatResponse worstAchievementTag,
+      @Schema(description = "달성률 높은 요일") DayStatResponse bestAchievementDay,
+      @Schema(description = "달성률 낮은 요일") DayStatResponse worstAchievementDay,
+      @Schema(description = "실패 패턴 조합 목록") List<PatternCombinationResponse> patternCombinations) {}
+
+  @Schema(description = "태그별 달성률")
+  public record TagStatResponse(
+      @Schema(description = "태그 이름", example = "운동") String title,
+      @Schema(description = "태그 색상 hex 코드. 태그가 삭제된 경우 null", example = "#FF5733") String color,
+      @Schema(description = "달성률 (%)", example = "85.00") double rate) {}
+
+  @Schema(description = "요일별 달성률")
+  public record DayStatResponse(
+      @Schema(description = "요일", example = "월요일") String day,
+      @Schema(description = "달성률 (%)", example = "75.00") double rate) {}
+
+  @Schema(description = "실패 원인 분포 항목")
+  public record FailureDistributionItem(
+      @Schema(description = "실패 원인 (depth-1 라벨)", example = "심리적 저항") String reason,
+      @Schema(description = "건수", example = "5") int count,
+      @Schema(description = "비율 (%)", example = "55.56") double rate) {}
+
+  @Schema(description = "실패 패턴 조합")
+  public record PatternCombinationResponse(
+      @Schema(description = "실패 원인", example = "심리적 저항") String reason,
+      @Schema(description = "연관 태그. 요일 패턴이면 null", example = "운동") String tag,
+      @Schema(description = "연관 요일. 태그 패턴이면 null", example = "월요일") String day,
+      @Schema(description = "발생 횟수", example = "3") int count) {}
+
+  @Schema(description = "AI 인사이트")
+  public record AiInsightResponse(
+      @Schema(description = "핵심 인사이트 목록") List<InsightItemResponse> insights,
+      @Schema(description = "투두 작성 팁", example = "월요일에는 가벼운 투두 위주로 구성하면 달성률이 높아집니다.")
+          String writingTip) {}
+
+  @Schema(description = "인사이트 항목")
+  public record InsightItemResponse(
+      @Schema(description = "한 줄 요약", example = "화요일 집중력이 가장 높습니다") String summary,
+      @Schema(description = "구체적 설명", example = "화요일 달성률이 90%로 가장 높았습니다.") String detail) {}
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/entity/MonthlyReport.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/entity/MonthlyReport.java
@@ -58,6 +58,25 @@ public class MonthlyReport extends BaseTimeEntity {
   @Column(name = "ai_insight")
   private AiInsight aiInsight;
 
+  public void update(
+      Integer totalTodos,
+      Integer completedTodos,
+      BigDecimal achievementRate,
+      BigDecimal prevMonthDiff,
+      Integer replanCount,
+      BigDecimal replanAchievementEffect,
+      AnalysisData analysisData,
+      AiInsight aiInsight) {
+    this.totalTodos = totalTodos;
+    this.completedTodos = completedTodos;
+    this.achievementRate = achievementRate;
+    this.prevMonthDiff = prevMonthDiff;
+    this.replanCount = replanCount;
+    this.replanAchievementEffect = replanAchievementEffect;
+    this.analysisData = analysisData;
+    this.aiInsight = aiInsight;
+  }
+
   @Builder
   public MonthlyReport(
       User user,

--- a/src/main/java/plana/replan/domain/monthlyreport/entity/ReportGenerationFailure.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/entity/ReportGenerationFailure.java
@@ -1,0 +1,56 @@
+package plana.replan.domain.monthlyreport.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import plana.replan.domain.user.entity.User;
+import plana.replan.global.entity.BaseTimeEntity;
+
+@Entity
+@Table(name = "report_generation_failure")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class ReportGenerationFailure extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "target_month", nullable = false)
+  private LocalDate targetMonth;
+
+  @Column(name = "retry_count", nullable = false)
+  private int retryCount = 0;
+
+  @Column(name = "error_message", columnDefinition = "TEXT")
+  private String errorMessage;
+
+  public static ReportGenerationFailure of(User user, LocalDate targetMonth, String errorMessage) {
+    ReportGenerationFailure failure = new ReportGenerationFailure();
+    failure.user = user;
+    failure.targetMonth = targetMonth;
+    failure.errorMessage = errorMessage;
+    return failure;
+  }
+
+  public void incrementRetry(String errorMessage) {
+    this.retryCount++;
+    this.errorMessage = errorMessage;
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/exception/MonthlyReportErrorCode.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/exception/MonthlyReportErrorCode.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.monthlyreport.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import plana.replan.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum MonthlyReportErrorCode implements ErrorCode {
+  REPORT_NOT_FOUND(404, "해당 월의 통계 리포트가 없습니다.");
+
+  private final int status;
+  private final String message;
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/repository/ReportGenerationFailureRepository.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/repository/ReportGenerationFailureRepository.java
@@ -1,0 +1,11 @@
+package plana.replan.domain.monthlyreport.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
+
+public interface ReportGenerationFailureRepository
+    extends JpaRepository<ReportGenerationFailure, Long> {
+
+  List<ReportGenerationFailure> findByRetryCountLessThan(int maxRetryCount);
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/repository/ReportGenerationFailureRepository.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/repository/ReportGenerationFailureRepository.java
@@ -1,11 +1,17 @@
 package plana.replan.domain.monthlyreport.repository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
+import plana.replan.domain.user.entity.User;
 
 public interface ReportGenerationFailureRepository
     extends JpaRepository<ReportGenerationFailure, Long> {
 
+  // @SQLRestriction("deleted_at IS NULL")이 적용되어 있으므로 소프트 삭제된 레코드는 자동 제외
   List<ReportGenerationFailure> findByRetryCountLessThan(int maxRetryCount);
+
+  Optional<ReportGenerationFailure> findByUserAndTargetMonth(User user, LocalDate targetMonth);
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/service/CalculatedStats.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/CalculatedStats.java
@@ -1,0 +1,14 @@
+package plana.replan.domain.monthlyreport.service;
+
+import java.math.BigDecimal;
+import plana.replan.domain.monthlyreport.entity.AnalysisData;
+
+public record CalculatedStats(
+    int totalTodos,
+    int completedTodos,
+    BigDecimal achievementRate,
+    BigDecimal prevMonthDiff,
+    int replanCount,
+    BigDecimal replanAchievementEffect,
+    AnalysisData analysisData,
+    boolean hasActivity) {}

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
@@ -1,0 +1,175 @@
+package plana.replan.domain.monthlyreport.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.entity.AnalysisData;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MonthlyReportAiService {
+
+  private static final String GEMINI_URL =
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent";
+
+  private final RestClient geminiRestClient;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Value("${gemini.api-key}")
+  private String apiKey;
+
+  public AiInsight generateInsight(CalculatedStats stats, YearMonth targetMonth) {
+    String prompt = buildPrompt(stats, targetMonth);
+    String raw = callGemini(prompt);
+    return parseInsight(raw);
+  }
+
+  private String buildPrompt(CalculatedStats stats, YearMonth targetMonth) {
+    AnalysisData ad = stats.analysisData();
+
+    String prevDiffText =
+        stats.prevMonthDiff() == null
+            ? "전월 데이터 없음"
+            : (stats.prevMonthDiff().signum() >= 0
+                ? "+" + stats.prevMonthDiff() + "%p"
+                : stats.prevMonthDiff() + "%p");
+
+    String bestTagText =
+        ad.bestAchievementTag() == null
+            ? "없음"
+            : String.format(
+                "%s (%.1f%%)", ad.bestAchievementTag().tag(), ad.bestAchievementTag().rate());
+    String worstTagText =
+        ad.worstAchievementTag() == null
+            ? "없음"
+            : String.format(
+                "%s (%.1f%%)", ad.worstAchievementTag().tag(), ad.worstAchievementTag().rate());
+    String bestDayText =
+        ad.bestAchievementDay() == null
+            ? "없음"
+            : String.format(
+                "%s (%.1f%%)", ad.bestAchievementDay().day(), ad.bestAchievementDay().rate());
+    String worstDayText =
+        ad.worstAchievementDay() == null
+            ? "없음"
+            : String.format(
+                "%s (%.1f%%)", ad.worstAchievementDay().day(), ad.worstAchievementDay().rate());
+
+    String failureText =
+        ad.failureDistribution() == null || ad.failureDistribution().isEmpty()
+            ? "리플랜 없음"
+            : ad.failureDistribution().stream()
+                .map(f -> String.format("- %s: %d건 (%.1f%%)", f.reason(), f.count(), f.rate()))
+                .reduce("", (a, b) -> a + "\n" + b)
+                .strip();
+
+    return """
+        당신은 할일 관리 전문 코치입니다.
+
+        사용자의 %d년 %d월 투두 달성 분석 데이터입니다:
+        - 전체 달성률: %.1f%%
+        - 전월 대비: %s
+        - 총 투두: %d개 (달성 %d개, 미달성 %d개)
+        - 리플랜 횟수: %d회
+
+        실패 원인 분포:
+        %s
+
+        달성률 높은 태그: %s
+        달성률 낮은 태그: %s
+        달성률 높은 요일: %s
+        달성률 낮은 요일: %s
+
+        위 데이터를 바탕으로 다음을 작성하세요:
+        1. 핵심 인사이트 2~3개 (summary: 한 줄 제목, detail: 2~3문장 구체적 설명)
+        2. 다음 달 투두 작성 팁 (3~4문장, 이 사용자의 데이터에 맞는 구체적인 팁)
+
+        모든 텍스트는 "~합니다", "~했습니다", "~입니다" 등 서술형으로 작성하세요.
+        "~하세요", "~해야 합니다" 등 명령·조언형 말투는 절대 사용하지 마세요.
+
+        반드시 아래 JSON만 출력하세요 (다른 설명 없이):
+        {"insights":[{"summary":"","detail":""}],"writing_tip":""}
+        """
+        .formatted(
+            targetMonth.getYear(),
+            targetMonth.getMonthValue(),
+            stats.achievementRate().doubleValue(),
+            prevDiffText,
+            stats.totalTodos(),
+            stats.completedTodos(),
+            stats.totalTodos() - stats.completedTodos(),
+            stats.replanCount(),
+            failureText,
+            bestTagText,
+            worstTagText,
+            bestDayText,
+            worstDayText);
+  }
+
+  private AiInsight parseInsight(String raw) {
+    try {
+      String json = extractJson(raw);
+      JsonNode root = objectMapper.readTree(json);
+
+      List<AiInsight.InsightItem> insights = new ArrayList<>();
+      for (JsonNode node : root.path("insights")) {
+        insights.add(
+            new AiInsight.InsightItem(node.path("summary").asText(), node.path("detail").asText()));
+      }
+
+      String writingTip = root.path("writing_tip").asText(null);
+      return new AiInsight(insights, writingTip);
+    } catch (Exception e) {
+      log.error("통계 AI 응답 파싱 실패: {}", raw, e);
+      return new AiInsight(List.of(), null);
+    }
+  }
+
+  private String callGemini(String prompt) {
+    Map<String, Object> body =
+        Map.of("contents", new Object[] {Map.of("parts", new Object[] {Map.of("text", prompt)})});
+
+    try {
+      String response =
+          geminiRestClient
+              .post()
+              .uri(GEMINI_URL + "?key=" + apiKey)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .body(String.class);
+
+      JsonNode root = objectMapper.readTree(response);
+      return root.path("candidates")
+          .path(0)
+          .path("content")
+          .path("parts")
+          .path(0)
+          .path("text")
+          .asText();
+    } catch (Exception e) {
+      log.error("Gemini 통계 API 호출 실패", e);
+      return "{\"insights\":[],\"writing_tip\":null}";
+    }
+  }
+
+  private String extractJson(String text) {
+    int start = text.indexOf('{');
+    int end = text.lastIndexOf('}');
+    if (start == -1 || end == -1 || end < start) {
+      throw new IllegalArgumentException("JSON 블록 없음: " + text);
+    }
+    return text.substring(start, end + 1);
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
@@ -1,7 +1,5 @@
 package plana.replan.domain.monthlyreport.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import plana.replan.domain.monthlyreport.entity.AiInsight;
 import plana.replan.domain.monthlyreport.entity.AnalysisData;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Service
@@ -24,7 +25,7 @@ public class MonthlyReportAiService {
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent";
 
   private final RestClient geminiRestClient;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
   @Value("${gemini.api-key}")
   private String apiKey;
@@ -131,7 +132,7 @@ public class MonthlyReportAiService {
       String writingTip = root.path("writing_tip").asText(null);
       return new AiInsight(insights, writingTip);
     } catch (Exception e) {
-      log.error("통계 AI 응답 파싱 실패: {}", raw, e);
+      log.error("통계 AI 응답 파싱 실패 (length={})", raw == null ? 0 : raw.length(), e);
       return new AiInsight(List.of(), null);
     }
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
@@ -144,7 +144,8 @@ public class MonthlyReportAiService {
       String response =
           geminiRestClient
               .post()
-              .uri(GEMINI_URL + "?key=" + apiKey)
+              .uri(GEMINI_URL)
+              .header("x-goog-api-key", apiKey)
               .contentType(MediaType.APPLICATION_JSON)
               .body(body)
               .retrieve()

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -1,0 +1,253 @@
+package plana.replan.domain.monthlyreport.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.monthlyreport.entity.AnalysisData;
+import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.replan.entity.FailureReasonCode;
+import plana.replan.domain.replan.entity.Replan;
+import plana.replan.domain.replan.repository.ReplanRepository;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.entity.User;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyReportCalculator {
+
+  private static final Map<DayOfWeek, String> DAY_NAMES =
+      Map.of(
+          DayOfWeek.MONDAY, "월요일",
+          DayOfWeek.TUESDAY, "화요일",
+          DayOfWeek.WEDNESDAY, "수요일",
+          DayOfWeek.THURSDAY, "목요일",
+          DayOfWeek.FRIDAY, "금요일",
+          DayOfWeek.SATURDAY, "토요일",
+          DayOfWeek.SUNDAY, "일요일");
+
+  private final TodoRepository todoRepository;
+  private final ReplanRepository replanRepository;
+  private final MonthlyReportRepository monthlyReportRepository;
+
+  @Transactional(readOnly = true)
+  public CalculatedStats calculate(User user, YearMonth targetMonth) {
+    LocalDateTime start = targetMonth.atDay(1).atStartOfDay();
+    LocalDateTime end = targetMonth.atEndOfMonth().atTime(23, 59, 59);
+
+    List<Todo> todos = todoRepository.findMonthlyTodos(user, start, end);
+    int totalTodos = todos.size();
+    int completedTodos = (int) todos.stream().filter(Todo::isCompleted).count();
+
+    BigDecimal achievementRate =
+        totalTodos == 0
+            ? BigDecimal.ZERO
+            : BigDecimal.valueOf(completedTodos * 100.0 / totalTodos)
+                .setScale(2, RoundingMode.HALF_UP);
+
+    BigDecimal prevMonthDiff = calcPrevMonthDiff(user, targetMonth, achievementRate);
+
+    List<Replan> replans = replanRepository.findByUserAndCreatedAtBetween(user, start, end);
+    int replanCount = replans.size();
+
+    BigDecimal replanAchievementEffect = null;
+    if (replanCount > 0) {
+      List<Todo> replanDerived = todoRepository.findReplanDerivedMonthlyTodos(user, start, end);
+      long completedDerived = replanDerived.stream().filter(Todo::isCompleted).count();
+      replanAchievementEffect =
+          BigDecimal.valueOf(completedDerived * 100.0 / replanCount)
+              .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    AnalysisData analysisData = buildAnalysisData(todos, replans);
+
+    return new CalculatedStats(
+        totalTodos,
+        completedTodos,
+        achievementRate,
+        prevMonthDiff,
+        replanCount,
+        replanAchievementEffect,
+        analysisData,
+        totalTodos > 0);
+  }
+
+  private BigDecimal calcPrevMonthDiff(
+      User user, YearMonth targetMonth, BigDecimal achievementRate) {
+    YearMonth prevMonth = targetMonth.minusMonths(1);
+    Optional<MonthlyReport> prevReport =
+        monthlyReportRepository.findByUserAndReportMonth(user, prevMonth.atDay(1));
+
+    if (prevReport.isPresent() && prevReport.get().getAchievementRate() != null) {
+      return achievementRate.subtract(prevReport.get().getAchievementRate());
+    }
+
+    LocalDateTime prevStart = prevMonth.atDay(1).atStartOfDay();
+    LocalDateTime prevEnd = prevMonth.atEndOfMonth().atTime(23, 59, 59);
+    List<Todo> prevTodos = todoRepository.findMonthlyTodos(user, prevStart, prevEnd);
+
+    if (prevTodos.isEmpty()) return null;
+
+    long prevCompleted = prevTodos.stream().filter(Todo::isCompleted).count();
+    BigDecimal prevRate =
+        BigDecimal.valueOf(prevCompleted * 100.0 / prevTodos.size())
+            .setScale(2, RoundingMode.HALF_UP);
+    return achievementRate.subtract(prevRate);
+  }
+
+  private AnalysisData buildAnalysisData(List<Todo> todos, List<Replan> replans) {
+    AnalysisData.TagStat bestTag = null;
+    AnalysisData.TagStat worstTag = null;
+    AnalysisData.DayStat bestDay = null;
+    AnalysisData.DayStat worstDay = null;
+
+    if (!todos.isEmpty()) {
+      Map<String, long[]> tagStats = new HashMap<>();
+      Map<DayOfWeek, long[]> dayStats = new EnumMap<>(DayOfWeek.class);
+
+      for (Todo t : todos) {
+        if (t.getTag() != null) {
+          String tagName = t.getTag().getTitle();
+          tagStats.computeIfAbsent(tagName, k -> new long[2]);
+          tagStats.get(tagName)[0]++;
+          if (t.isCompleted()) tagStats.get(tagName)[1]++;
+        }
+        if (t.getDueDate() != null) {
+          DayOfWeek day = t.getDueDate().getDayOfWeek();
+          dayStats.computeIfAbsent(day, k -> new long[2]);
+          dayStats.get(day)[0]++;
+          if (t.isCompleted()) dayStats.get(day)[1]++;
+        }
+      }
+
+      Map<String, Double> tagRates =
+          tagStats.entrySet().stream()
+              .filter(e -> e.getValue()[0] >= 2)
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, e -> e.getValue()[1] * 100.0 / e.getValue()[0]));
+
+      if (!tagRates.isEmpty()) {
+        String best = Collections.max(tagRates.entrySet(), Map.Entry.comparingByValue()).getKey();
+        String worst = Collections.min(tagRates.entrySet(), Map.Entry.comparingByValue()).getKey();
+        bestTag = new AnalysisData.TagStat(best, tagRates.get(best));
+        worstTag = new AnalysisData.TagStat(worst, tagRates.get(worst));
+      }
+
+      Map<DayOfWeek, Double> dayRates =
+          dayStats.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, e -> e.getValue()[1] * 100.0 / e.getValue()[0]));
+
+      if (!dayRates.isEmpty()) {
+        DayOfWeek bestDow =
+            Collections.max(dayRates.entrySet(), Map.Entry.comparingByValue()).getKey();
+        DayOfWeek worstDow =
+            Collections.min(dayRates.entrySet(), Map.Entry.comparingByValue()).getKey();
+        bestDay = new AnalysisData.DayStat(DAY_NAMES.get(bestDow), dayRates.get(bestDow));
+        worstDay = new AnalysisData.DayStat(DAY_NAMES.get(worstDow), dayRates.get(worstDow));
+      }
+    }
+
+    String topFailureReason = null;
+    List<AnalysisData.FailureItem> failureDistribution = List.of();
+    List<AnalysisData.PatternCombination> patterns = List.of();
+
+    if (!replans.isEmpty()) {
+      Map<String, Integer> reasonCount = new HashMap<>();
+      for (Replan r : replans) {
+        addReasonCount(reasonCount, r.getFailureReason1());
+        addReasonCount(reasonCount, r.getFailureReason2());
+        addReasonCount(reasonCount, r.getFailureReason3());
+      }
+
+      int total = reasonCount.values().stream().mapToInt(Integer::intValue).sum();
+      failureDistribution =
+          reasonCount.entrySet().stream()
+              .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+              .map(
+                  e ->
+                      new AnalysisData.FailureItem(
+                          e.getKey(), e.getValue(), total > 0 ? e.getValue() * 100.0 / total : 0.0))
+              .collect(Collectors.toList());
+
+      topFailureReason = failureDistribution.isEmpty() ? null : failureDistribution.get(0).reason();
+      patterns = buildPatterns(replans);
+    }
+
+    return new AnalysisData(
+        topFailureReason, failureDistribution, bestTag, worstTag, bestDay, worstDay, patterns);
+  }
+
+  private void addReasonCount(Map<String, Integer> counts, String code) {
+    if (code == null) return;
+    counts.merge(toDepth1Label(code), 1, Integer::sum);
+  }
+
+  private String toDepth1Label(String code) {
+    try {
+      FailureReasonCode fc = FailureReasonCode.valueOf(code);
+      while (fc.getParent() != null) {
+        fc = fc.getParent();
+      }
+      return fc.getLabel();
+    } catch (IllegalArgumentException e) {
+      return code;
+    }
+  }
+
+  private List<AnalysisData.PatternCombination> buildPatterns(List<Replan> replans) {
+    Map<String, Integer> tagReasonCount = new HashMap<>();
+    Map<String, Integer> dayReasonCount = new HashMap<>();
+
+    for (Replan r : replans) {
+      String reason = toDepth1Label(r.getFailureReason1());
+      Todo todo = r.getTodo();
+      String tagName = todo.getTag() != null ? todo.getTag().getTitle() : null;
+      String dayName =
+          todo.getDueDate() != null ? DAY_NAMES.get(todo.getDueDate().getDayOfWeek()) : null;
+
+      if (tagName != null) tagReasonCount.merge(reason + "||" + tagName, 1, Integer::sum);
+      if (dayName != null) dayReasonCount.merge(reason + "||" + dayName, 1, Integer::sum);
+    }
+
+    List<AnalysisData.PatternCombination> result = new ArrayList<>();
+
+    tagReasonCount.entrySet().stream()
+        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .limit(2)
+        .forEach(
+            e -> {
+              String[] parts = e.getKey().split("\\|\\|");
+              result.add(
+                  new AnalysisData.PatternCombination(parts[0], parts[1], null, e.getValue()));
+            });
+
+    dayReasonCount.entrySet().stream()
+        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .limit(2)
+        .forEach(
+            e -> {
+              String[] parts = e.getKey().split("\\|\\|");
+              result.add(
+                  new AnalysisData.PatternCombination(parts[0], null, parts[1], e.getValue()));
+            });
+
+    return result;
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -51,7 +51,7 @@ public class MonthlyReportCalculator {
   @Transactional(readOnly = true)
   public CalculatedStats calculate(User user, YearMonth targetMonth) {
     LocalDateTime start = targetMonth.atDay(1).atStartOfDay();
-    LocalDateTime end = targetMonth.atEndOfMonth().atTime(23, 59, 59);
+    LocalDateTime end = targetMonth.plusMonths(1).atDay(1).atStartOfDay();
 
     List<Todo> todos = todoRepository.findMonthlyTodos(user, start, end);
     int totalTodos = todos.size();
@@ -114,7 +114,7 @@ public class MonthlyReportCalculator {
     }
 
     LocalDateTime prevStart = prevMonth.atDay(1).atStartOfDay();
-    LocalDateTime prevEnd = prevMonth.atEndOfMonth().atTime(23, 59, 59);
+    LocalDateTime prevEnd = targetMonth.atDay(1).atStartOfDay();
     List<Todo> prevTodos = todoRepository.findMonthlyTodos(user, prevStart, prevEnd);
 
     if (prevTodos.isEmpty()) return null;

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -5,14 +5,18 @@ import java.math.RoundingMode;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,6 +79,19 @@ public class MonthlyReportCalculator {
 
     AnalysisData analysisData = buildAnalysisData(todos, replans);
 
+    boolean hasActivity = false;
+    if (totalTodos > 0) {
+      // 첫 투두 생성일이 대상 월 말일 기준 14일 이상 이전이어야 의미 있는 통계로 인정
+      LocalDateTime endOfMonth = targetMonth.atEndOfMonth().atTime(23, 59, 59);
+      hasActivity =
+          todos.stream()
+              .map(t -> t.getCreatedAt())
+              .filter(Objects::nonNull)
+              .min(Comparator.naturalOrder())
+              .map(first -> ChronoUnit.DAYS.between(first, endOfMonth) >= 14)
+              .orElse(false);
+    }
+
     return new CalculatedStats(
         totalTodos,
         completedTodos,
@@ -83,7 +100,7 @@ public class MonthlyReportCalculator {
         replanCount,
         replanAchievementEffect,
         analysisData,
-        totalTodos > 0);
+        hasActivity);
   }
 
   private BigDecimal calcPrevMonthDiff(
@@ -216,14 +233,19 @@ public class MonthlyReportCalculator {
     Map<String, Integer> dayReasonCount = new HashMap<>();
 
     for (Replan r : replans) {
-      String reason = toDepth1Label(r.getFailureReason1());
       Todo todo = r.getTodo();
       String tagName = todo.getTag() != null ? todo.getTag().getTitle() : null;
       String dayName =
           todo.getDueDate() != null ? DAY_NAMES.get(todo.getDueDate().getDayOfWeek()) : null;
 
-      if (tagName != null) tagReasonCount.merge(reason + "||" + tagName, 1, Integer::sum);
-      if (dayName != null) dayReasonCount.merge(reason + "||" + dayName, 1, Integer::sum);
+      Stream.of(r.getFailureReason1(), r.getFailureReason2(), r.getFailureReason3())
+          .filter(Objects::nonNull)
+          .map(this::toDepth1Label)
+          .forEach(
+              reason -> {
+                if (tagName != null) tagReasonCount.merge(reason + "||" + tagName, 1, Integer::sum);
+                if (dayName != null) dayReasonCount.merge(reason + "||" + dayName, 1, Integer::sum);
+              });
     }
 
     List<AnalysisData.PatternCombination> result = new ArrayList<>();

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -85,7 +85,7 @@ public class MonthlyReportCalculator {
       LocalDateTime endOfMonth = targetMonth.atEndOfMonth().atTime(23, 59, 59);
       hasActivity =
           todos.stream()
-              .map(t -> t.getCreatedAt())
+              .map(Todo::getCreatedAt)
               .filter(Objects::nonNull)
               .min(Comparator.naturalOrder())
               .map(first -> ChronoUnit.DAYS.between(first, endOfMonth) >= 14)

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
@@ -28,6 +28,61 @@ public class MonthlyReportService {
   private final UserRepository userRepository;
   private final MonthlyReportRepository monthlyReportRepository;
   private final TagRepository tagRepository;
+  private final MonthlyReportCalculator calculator;
+  private final MonthlyReportAiService aiService;
+
+  @Transactional
+  public MonthlyReportResponse generateReport(Long userId, int year, int month) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
+
+    YearMonth targetMonth = YearMonth.of(year, month);
+    CalculatedStats stats = calculator.calculate(user, targetMonth);
+
+    final AiInsight aiInsight =
+        stats.hasActivity() ? aiService.generateInsight(stats, targetMonth) : null;
+
+    LocalDate reportMonth = targetMonth.atDay(1);
+    MonthlyReport report =
+        monthlyReportRepository
+            .findByUserAndReportMonth(user, reportMonth)
+            .orElseGet(
+                () ->
+                    monthlyReportRepository.save(
+                        MonthlyReport.builder()
+                            .user(user)
+                            .reportMonth(reportMonth)
+                            .totalTodos(stats.totalTodos())
+                            .completedTodos(stats.completedTodos())
+                            .achievementRate(stats.achievementRate())
+                            .prevMonthDiff(stats.prevMonthDiff())
+                            .replanCount(stats.replanCount())
+                            .replanAchievementEffect(stats.replanAchievementEffect())
+                            .analysisData(stats.analysisData())
+                            .aiInsight(aiInsight)
+                            .build()));
+
+    report.update(
+        stats.totalTodos(),
+        stats.completedTodos(),
+        stats.achievementRate(),
+        stats.prevMonthDiff(),
+        stats.replanCount(),
+        stats.replanAchievementEffect(),
+        stats.analysisData(),
+        aiInsight);
+
+    List<Tag> userTags = tagRepository.findAllByUserOrderByCreatedAtDescIdDesc(user);
+    Map<String, String> tagColorMap =
+        userTags.stream()
+            .collect(
+                Collectors.toMap(
+                    Tag::getTitle, t -> t.getColor() != null ? t.getColor() : "", (a, b) -> a));
+
+    return toResponse(report, tagColorMap);
+  }
 
   @Transactional(readOnly = true)
   public MonthlyReportResponse getReport(Long userId, int year, int month) {

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
@@ -6,14 +6,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plana.replan.domain.monthlyreport.dto.MonthlyReportResponse;
 import plana.replan.domain.monthlyreport.entity.AiInsight;
 import plana.replan.domain.monthlyreport.entity.AnalysisData;
 import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
 import plana.replan.domain.monthlyreport.exception.MonthlyReportErrorCode;
 import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.repository.TagRepository;
 import plana.replan.domain.user.entity.User;
@@ -21,12 +24,14 @@ import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
 import plana.replan.global.exception.GlobalErrorCode;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MonthlyReportService {
 
   private final UserRepository userRepository;
   private final MonthlyReportRepository monthlyReportRepository;
+  private final ReportGenerationFailureRepository failureRepository;
   private final TagRepository tagRepository;
   private final MonthlyReportCalculator calculator;
   private final MonthlyReportAiService aiService;
@@ -40,7 +45,6 @@ public class MonthlyReportService {
 
     YearMonth targetMonth = YearMonth.of(year, month);
     CalculatedStats stats = calculator.calculate(user, targetMonth);
-
     final AiInsight aiInsight =
         stats.hasActivity() ? aiService.generateInsight(stats, targetMonth) : null;
 
@@ -48,6 +52,19 @@ public class MonthlyReportService {
     MonthlyReport report =
         monthlyReportRepository
             .findByUserAndReportMonth(user, reportMonth)
+            .map(
+                existing -> {
+                  existing.update(
+                      stats.totalTodos(),
+                      stats.completedTodos(),
+                      stats.achievementRate(),
+                      stats.prevMonthDiff(),
+                      stats.replanCount(),
+                      stats.replanAchievementEffect(),
+                      stats.analysisData(),
+                      aiInsight);
+                  return existing;
+                })
             .orElseGet(
                 () ->
                     monthlyReportRepository.save(
@@ -63,16 +80,6 @@ public class MonthlyReportService {
                             .analysisData(stats.analysisData())
                             .aiInsight(aiInsight)
                             .build()));
-
-    report.update(
-        stats.totalTodos(),
-        stats.completedTodos(),
-        stats.achievementRate(),
-        stats.prevMonthDiff(),
-        stats.replanCount(),
-        stats.replanAchievementEffect(),
-        stats.analysisData(),
-        aiInsight);
 
     List<Tag> userTags = tagRepository.findAllByUserOrderByCreatedAtDescIdDesc(user);
     Map<String, String> tagColorMap =
@@ -106,6 +113,64 @@ public class MonthlyReportService {
                     Tag::getTitle, t -> t.getColor() != null ? t.getColor() : "", (a, b) -> a));
 
     return toResponse(report, tagColorMap);
+  }
+
+  /**
+   * 실패 리포트 1건을 재처리한다. 성공 시 soft delete, 실패 시 retryCount 증가. Gemini 호출 여부(= hasActivity)를 반환해 호출자가
+   * sleep을 제어하게 한다.
+   */
+  @Transactional
+  public boolean retryOneFailure(Long failureId) {
+    ReportGenerationFailure failure =
+        failureRepository.findById(failureId).orElseThrow(RuntimeException::new);
+    User user = failure.getUser();
+    YearMonth targetMonth = YearMonth.from(failure.getTargetMonth());
+
+    try {
+      CalculatedStats stats = calculator.calculate(user, targetMonth);
+      AiInsight aiInsight =
+          stats.hasActivity() ? aiService.generateInsight(stats, targetMonth) : null;
+      upsertReport(user, failure.getTargetMonth(), stats, aiInsight);
+      failure.softDelete();
+      log.info("재처리 성공 - userId={}", user.getId());
+      return stats.hasActivity();
+    } catch (Exception e) {
+      log.error("재처리 실패 - userId={}", user.getId(), e);
+      String msg = e.getMessage();
+      failure.incrementRetry(msg != null && msg.length() > 500 ? msg.substring(0, 500) : msg);
+      return false;
+    }
+  }
+
+  public void upsertReport(
+      User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {
+    monthlyReportRepository
+        .findByUserAndReportMonth(user, reportMonth)
+        .ifPresentOrElse(
+            report ->
+                report.update(
+                    stats.totalTodos(),
+                    stats.completedTodos(),
+                    stats.achievementRate(),
+                    stats.prevMonthDiff(),
+                    stats.replanCount(),
+                    stats.replanAchievementEffect(),
+                    stats.analysisData(),
+                    aiInsight),
+            () ->
+                monthlyReportRepository.save(
+                    MonthlyReport.builder()
+                        .user(user)
+                        .reportMonth(reportMonth)
+                        .totalTodos(stats.totalTodos())
+                        .completedTodos(stats.completedTodos())
+                        .achievementRate(stats.achievementRate())
+                        .prevMonthDiff(stats.prevMonthDiff())
+                        .replanCount(stats.replanCount())
+                        .replanAchievementEffect(stats.replanAchievementEffect())
+                        .analysisData(stats.analysisData())
+                        .aiInsight(aiInsight)
+                        .build()));
   }
 
   private MonthlyReportResponse toResponse(MonthlyReport report, Map<String, String> tagColorMap) {

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
@@ -1,0 +1,135 @@
+package plana.replan.domain.monthlyreport.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.monthlyreport.dto.MonthlyReportResponse;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.entity.AnalysisData;
+import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.exception.MonthlyReportErrorCode;
+import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.user.entity.User;
+import plana.replan.domain.user.repository.UserRepository;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyReportService {
+
+  private final UserRepository userRepository;
+  private final MonthlyReportRepository monthlyReportRepository;
+  private final TagRepository tagRepository;
+
+  @Transactional(readOnly = true)
+  public MonthlyReportResponse getReport(Long userId, int year, int month) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND));
+
+    LocalDate reportMonth = YearMonth.of(year, month).atDay(1);
+
+    MonthlyReport report =
+        monthlyReportRepository
+            .findByUserAndReportMonth(user, reportMonth)
+            .orElseThrow(() -> new CustomException(MonthlyReportErrorCode.REPORT_NOT_FOUND));
+
+    List<Tag> userTags = tagRepository.findAllByUserOrderByCreatedAtDescIdDesc(user);
+    Map<String, String> tagColorMap =
+        userTags.stream()
+            .collect(
+                Collectors.toMap(
+                    Tag::getTitle, t -> t.getColor() != null ? t.getColor() : "", (a, b) -> a));
+
+    return toResponse(report, tagColorMap);
+  }
+
+  private MonthlyReportResponse toResponse(MonthlyReport report, Map<String, String> tagColorMap) {
+    AnalysisData ad = report.getAnalysisData();
+    AiInsight ai = report.getAiInsight();
+
+    MonthlyReportResponse.AnalysisDataResponse adResponse = null;
+    if (ad != null) {
+      adResponse =
+          new MonthlyReportResponse.AnalysisDataResponse(
+              ad.topFailureReason(),
+              toFailureDistribution(ad.failureDistribution()),
+              toTagStat(ad.bestAchievementTag(), tagColorMap),
+              toTagStat(ad.worstAchievementTag(), tagColorMap),
+              toDayStat(ad.bestAchievementDay()),
+              toDayStat(ad.worstAchievementDay()),
+              toPatterns(ad.patternCombinations()));
+    }
+
+    MonthlyReportResponse.AiInsightResponse aiResponse = null;
+    if (ai != null) {
+      aiResponse =
+          new MonthlyReportResponse.AiInsightResponse(
+              ai.insights() == null
+                  ? List.of()
+                  : ai.insights().stream()
+                      .map(
+                          i ->
+                              new MonthlyReportResponse.InsightItemResponse(
+                                  i.summary(), i.detail()))
+                      .collect(Collectors.toList()),
+              ai.writingTip());
+    }
+
+    return new MonthlyReportResponse(
+        report.getReportMonth().getYear(),
+        report.getReportMonth().getMonthValue(),
+        report.getTotalTodos() != null ? report.getTotalTodos() : 0,
+        report.getCompletedTodos() != null ? report.getCompletedTodos() : 0,
+        report.getAchievementRate() != null ? report.getAchievementRate().doubleValue() : 0.0,
+        report.getPrevMonthDiff() != null ? report.getPrevMonthDiff().doubleValue() : null,
+        report.getReplanCount() != null ? report.getReplanCount() : 0,
+        report.getReplanAchievementEffect() != null
+            ? report.getReplanAchievementEffect().doubleValue()
+            : null,
+        adResponse,
+        aiResponse);
+  }
+
+  private MonthlyReportResponse.TagStatResponse toTagStat(
+      AnalysisData.TagStat tagStat, Map<String, String> colorMap) {
+    if (tagStat == null) return null;
+    String color = colorMap.get(tagStat.tag());
+    return new MonthlyReportResponse.TagStatResponse(
+        tagStat.tag(), color != null && !color.isEmpty() ? color : null, tagStat.rate());
+  }
+
+  private MonthlyReportResponse.DayStatResponse toDayStat(AnalysisData.DayStat dayStat) {
+    if (dayStat == null) return null;
+    return new MonthlyReportResponse.DayStatResponse(dayStat.day(), dayStat.rate());
+  }
+
+  private List<MonthlyReportResponse.FailureDistributionItem> toFailureDistribution(
+      List<AnalysisData.FailureItem> items) {
+    if (items == null) return List.of();
+    return items.stream()
+        .map(
+            i -> new MonthlyReportResponse.FailureDistributionItem(i.reason(), i.count(), i.rate()))
+        .collect(Collectors.toList());
+  }
+
+  private List<MonthlyReportResponse.PatternCombinationResponse> toPatterns(
+      List<AnalysisData.PatternCombination> combinations) {
+    if (combinations == null) return List.of();
+    return combinations.stream()
+        .map(
+            c ->
+                new MonthlyReportResponse.PatternCombinationResponse(
+                    c.reason(), c.tag(), c.day(), c.count()))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
@@ -142,6 +142,7 @@ public class MonthlyReportService {
     }
   }
 
+  @Transactional
   public void upsertReport(
       User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {
     monthlyReportRepository

--- a/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
+++ b/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
@@ -1,0 +1,20 @@
+package plana.replan.domain.replan.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import plana.replan.domain.replan.entity.Replan;
+import plana.replan.domain.user.entity.User;
+
+public interface ReplanRepository extends JpaRepository<Replan, Long> {
+
+  @Query(
+      "SELECT r FROM Replan r WHERE r.todo.user = :user"
+          + " AND r.createdAt BETWEEN :start AND :end")
+  List<Replan> findByUserAndCreatedAtBetween(
+      @Param("user") User user,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+}

--- a/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
+++ b/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
@@ -12,7 +12,7 @@ public interface ReplanRepository extends JpaRepository<Replan, Long> {
 
   @Query(
       "SELECT r FROM Replan r WHERE r.todo.user = :user"
-          + " AND r.createdAt BETWEEN :start AND :end")
+          + " AND r.createdAt >= :start AND r.createdAt < :end")
   List<Replan> findByUserAndCreatedAtBetween(
       @Param("user") User user,
       @Param("start") LocalDateTime start,

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -83,8 +83,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
-          + " AND ((t.dueDate BETWEEN :start AND :end)"
-          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+          + " AND ((t.dueDate >= :start AND t.dueDate < :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime >= :start AND t.completedTime < :end))")
   List<Todo> findMonthlyTodos(
       @Param("user") User user,
       @Param("start") LocalDateTime start,
@@ -92,8 +92,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.replan IS NOT NULL"
-          + " AND ((t.dueDate BETWEEN :start AND :end)"
-          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+          + " AND ((t.dueDate >= :start AND t.dueDate < :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime >= :start AND t.completedTime < :end))")
   List<Todo> findReplanDerivedMonthlyTodos(
       @Param("user") User user,
       @Param("start") LocalDateTime start,

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -80,4 +80,22 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
       @Param("user") User user,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
+          + " AND ((t.dueDate BETWEEN :start AND :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+  List<Todo> findMonthlyTodos(
+      @Param("user") User user,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.replan IS NOT NULL"
+          + " AND ((t.dueDate BETWEEN :start AND :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+  List<Todo> findReplanDerivedMonthlyTodos(
+      @Param("user") User user,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 }

--- a/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package plana.replan.global.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,18 @@ public class GlobalExceptionHandler {
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .orElse(e.getMessage());
     log.error("ValidationException: {}", detail);
+    return ResponseEntity.badRequest()
+        .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiResult<?>> handleConstraintViolation(ConstraintViolationException e) {
+    String detail =
+        e.getConstraintViolations().stream()
+            .findFirst()
+            .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+            .orElse(e.getMessage());
+    log.error("ConstraintViolationException: {}", detail);
     return ResponseEntity.badRequest()
         .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,12 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  batch:
+    jdbc:
+      initialize-schema: never
+    job:
+      enabled: false
+
 management:
   endpoints:
     web:
@@ -38,7 +44,6 @@ google:
   client-ids:
     web: ${GOOGLE_WEB_CLIENT_ID}
 
-
 cloud:
   aws:
     region:
@@ -50,3 +55,7 @@ cloud:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
+
+statistics:
+  batch:
+    gemini-call-delay-ms: 2500

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,3 +59,4 @@ gemini:
 statistics:
   batch:
     gemini-call-delay-ms: 2500
+    max-retry-count: 3

--- a/src/main/resources/db/migration/V10__add_report_generation_failure.sql
+++ b/src/main/resources/db/migration/V10__add_report_generation_failure.sql
@@ -2,7 +2,7 @@ CREATE TABLE report_generation_failure
 (
     id            BIGSERIAL PRIMARY KEY,
     user_id       BIGINT  NOT NULL REFERENCES users (id),
-    target_month  DATE    NOT NULL,
+    target_month  DATE    NOT NULL CHECK (EXTRACT(DAY FROM target_month) = 1),
     retry_count   INTEGER NOT NULL DEFAULT 0,
     error_message TEXT,
     created_at    TIMESTAMP(6),

--- a/src/main/resources/db/migration/V10__add_report_generation_failure.sql
+++ b/src/main/resources/db/migration/V10__add_report_generation_failure.sql
@@ -1,0 +1,15 @@
+CREATE TABLE report_generation_failure
+(
+    id            BIGSERIAL PRIMARY KEY,
+    user_id       BIGINT  NOT NULL REFERENCES users (id),
+    target_month  DATE    NOT NULL,
+    retry_count   INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT,
+    created_at    TIMESTAMP(6),
+    updated_at    TIMESTAMP(6),
+    deleted_at    TIMESTAMP(6)
+);
+
+CREATE INDEX idx_report_gen_failure_retry
+    ON report_generation_failure (retry_count)
+    WHERE deleted_at IS NULL;

--- a/src/main/resources/db/migration/V11__add_unique_constraint_report_generation_failure.sql
+++ b/src/main/resources/db/migration/V11__add_unique_constraint_report_generation_failure.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX idx_report_gen_failure_unique_active
+    ON report_generation_failure (user_id, target_month)
+    WHERE deleted_at IS NULL;

--- a/src/main/resources/db/migration/V9__add_spring_batch_meta_tables.sql
+++ b/src/main/resources/db/migration/V9__add_spring_batch_meta_tables.sql
@@ -1,0 +1,77 @@
+CREATE TABLE batch_job_instance
+(
+    job_instance_id BIGINT       NOT NULL PRIMARY KEY,
+    version         BIGINT,
+    job_name        VARCHAR(100) NOT NULL,
+    job_key         VARCHAR(32)  NOT NULL,
+    CONSTRAINT job_inst_un UNIQUE (job_name, job_key)
+);
+
+CREATE TABLE batch_job_execution
+(
+    job_execution_id BIGINT        NOT NULL PRIMARY KEY,
+    version          BIGINT,
+    job_instance_id  BIGINT        NOT NULL,
+    create_time      TIMESTAMP(6)  NOT NULL,
+    start_time       TIMESTAMP(6) DEFAULT NULL,
+    end_time         TIMESTAMP(6) DEFAULT NULL,
+    status           VARCHAR(10),
+    exit_code        VARCHAR(2500),
+    exit_message     VARCHAR(2500),
+    last_updated     TIMESTAMP(6),
+    CONSTRAINT job_inst_exec_fk FOREIGN KEY (job_instance_id) REFERENCES batch_job_instance (job_instance_id)
+);
+
+CREATE TABLE batch_job_execution_params
+(
+    job_execution_id BIGINT        NOT NULL,
+    parameter_name   VARCHAR(100)  NOT NULL,
+    parameter_type   VARCHAR(100)  NOT NULL,
+    parameter_value  VARCHAR(2500),
+    identifying      CHAR(1)       NOT NULL,
+    CONSTRAINT job_exec_params_fk FOREIGN KEY (job_execution_id) REFERENCES batch_job_execution (job_execution_id)
+);
+
+CREATE TABLE batch_step_execution
+(
+    step_execution_id  BIGINT       NOT NULL PRIMARY KEY,
+    version            BIGINT       NOT NULL,
+    step_name          VARCHAR(100) NOT NULL,
+    job_execution_id   BIGINT       NOT NULL,
+    create_time        TIMESTAMP(6) NOT NULL,
+    start_time         TIMESTAMP(6) DEFAULT NULL,
+    end_time           TIMESTAMP(6) DEFAULT NULL,
+    status             VARCHAR(10),
+    commit_count       BIGINT,
+    read_count         BIGINT,
+    filter_count       BIGINT,
+    write_count        BIGINT,
+    read_skip_count    BIGINT,
+    write_skip_count   BIGINT,
+    process_skip_count BIGINT,
+    rollback_count     BIGINT,
+    exit_code          VARCHAR(2500),
+    exit_message       VARCHAR(2500),
+    last_updated       TIMESTAMP(6),
+    CONSTRAINT job_exec_step_fk FOREIGN KEY (job_execution_id) REFERENCES batch_job_execution (job_execution_id)
+);
+
+CREATE TABLE batch_step_execution_context
+(
+    step_execution_id  BIGINT        NOT NULL PRIMARY KEY,
+    short_context      VARCHAR(2500) NOT NULL,
+    serialized_context TEXT,
+    CONSTRAINT step_exec_ctx_fk FOREIGN KEY (step_execution_id) REFERENCES batch_step_execution (step_execution_id)
+);
+
+CREATE TABLE batch_job_execution_context
+(
+    job_execution_id   BIGINT        NOT NULL PRIMARY KEY,
+    short_context      VARCHAR(2500) NOT NULL,
+    serialized_context TEXT,
+    CONSTRAINT job_exec_ctx_fk FOREIGN KEY (job_execution_id) REFERENCES batch_job_execution (job_execution_id)
+);
+
+CREATE SEQUENCE batch_step_execution_seq MAXVALUE 9223372036854775807 NO CYCLE;
+CREATE SEQUENCE batch_job_execution_seq MAXVALUE 9223372036854775807 NO CYCLE;
+CREATE SEQUENCE batch_job_seq MAXVALUE 9223372036854775807 NO CYCLE;

--- a/src/test/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerTest.java
+++ b/src/test/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerTest.java
@@ -1,0 +1,140 @@
+package plana.replan.domain.monthlyreport.controller;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import plana.replan.domain.monthlyreport.dto.MonthlyReportResponse;
+import plana.replan.domain.monthlyreport.exception.MonthlyReportErrorCode;
+import plana.replan.domain.monthlyreport.service.MonthlyReportService;
+import plana.replan.global.config.SecurityConfig;
+import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
+import plana.replan.global.jwt.JwtUtil;
+
+@WebMvcTest(MonthlyReportController.class)
+@Import(SecurityConfig.class)
+class MonthlyReportControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private MonthlyReportService monthlyReportService;
+  @MockitoBean private JwtUtil jwtUtil;
+
+  private UsernamePasswordAuthenticationToken auth(Long userId) {
+    return new UsernamePasswordAuthenticationToken(
+        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+
+  private MonthlyReportResponse sampleResponse() {
+    return new MonthlyReportResponse(2025, 5, 30, 21, 70.00, 5.50, 3, 66.67, null, null);
+  }
+
+  // ── 인증 ──────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("인증 없이 호출: status=401, error.code=EMPTY_TOKEN")
+  void getReport_unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(get("/api/monthly-reports").param("year", "2025").param("month", "5"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  // ── 성공 ──────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("조회 성공: status=200, data 필드 검증")
+  void getReport_success_returns200() throws Exception {
+    given(monthlyReportService.getReport(any(), anyInt(), anyInt())).willReturn(sampleResponse());
+
+    mockMvc
+        .perform(
+            get("/api/monthly-reports")
+                .with(authentication(auth(1L)))
+                .param("year", "2025")
+                .param("month", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.year").value(2025))
+        .andExpect(jsonPath("$.data.month").value(5))
+        .andExpect(jsonPath("$.data.totalTodos").value(30))
+        .andExpect(jsonPath("$.data.completedTodos").value(21))
+        .andExpect(jsonPath("$.data.achievementRate").value(70.00))
+        .andExpect(jsonPath("$.data.prevMonthDiff").value(5.50))
+        .andExpect(jsonPath("$.data.replanCount").value(3))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("analysisData, aiInsight 모두 null인 응답: data.analysisData=null, data.aiInsight=null")
+  void getReport_nullAnalysis_nullFieldsReturned() throws Exception {
+    given(monthlyReportService.getReport(any(), anyInt(), anyInt()))
+        .willReturn(new MonthlyReportResponse(2025, 5, 0, 0, 0.0, null, 0, null, null, null));
+
+    mockMvc
+        .perform(
+            get("/api/monthly-reports")
+                .with(authentication(auth(1L)))
+                .param("year", "2025")
+                .param("month", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.analysisData").value(nullValue()))
+        .andExpect(jsonPath("$.data.aiInsight").value(nullValue()))
+        .andExpect(jsonPath("$.data.prevMonthDiff").value(nullValue()));
+  }
+
+  // ── 에러 ──────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("userId DB에 없음: status=404, error.code=NOT_FOUND")
+  void getReport_userNotFound_returns404() throws Exception {
+    willThrow(new CustomException(GlobalErrorCode.NOT_FOUND))
+        .given(monthlyReportService)
+        .getReport(any(), anyInt(), anyInt());
+
+    mockMvc
+        .perform(
+            get("/api/monthly-reports")
+                .with(authentication(auth(999L)))
+                .param("year", "2025")
+                .param("month", "5"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("NOT_FOUND"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("해당 월 리포트 없음: status=404, error.code=REPORT_NOT_FOUND")
+  void getReport_reportNotFound_returns404() throws Exception {
+    willThrow(new CustomException(MonthlyReportErrorCode.REPORT_NOT_FOUND))
+        .given(monthlyReportService)
+        .getReport(any(), anyInt(), anyInt());
+
+    mockMvc
+        .perform(
+            get("/api/monthly-reports")
+                .with(authentication(auth(1L)))
+                .param("year", "2025")
+                .param("month", "5"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("REPORT_NOT_FOUND"))
+        .andExpect(jsonPath("$.data").value(nullValue()));
+  }
+}

--- a/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiServiceTest.java
@@ -1,0 +1,131 @@
+package plana.replan.domain.monthlyreport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+import plana.replan.domain.monthlyreport.entity.AiInsight;
+import plana.replan.domain.monthlyreport.entity.AnalysisData;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyReportAiServiceTest {
+
+  @Mock private RestClient geminiRestClient;
+
+  private MonthlyReportAiService aiService;
+
+  @BeforeEach
+  void setUp() {
+    aiService = new MonthlyReportAiService(geminiRestClient);
+    ReflectionTestUtils.setField(aiService, "apiKey", "test-api-key");
+  }
+
+  private void stubGemini(String geminiResponseBody) {
+    RestClient.RequestBodyUriSpec uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+    RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+    RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+    given(geminiRestClient.post()).willReturn(uriSpec);
+    given(uriSpec.uri(anyString())).willReturn(bodySpec);
+    given(bodySpec.contentType(any(MediaType.class))).willReturn(bodySpec);
+    given(bodySpec.body(any(Object.class))).willReturn(bodySpec);
+    given(bodySpec.retrieve()).willReturn(responseSpec);
+    given(responseSpec.body(String.class)).willReturn(geminiResponseBody);
+  }
+
+  private CalculatedStats minimalStats() {
+    AnalysisData ad = new AnalysisData(null, List.of(), null, null, null, null, List.of());
+    return new CalculatedStats(10, 7, new BigDecimal("70.00"), null, 0, null, ad, true);
+  }
+
+  // ── 정상 파싱 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Gemini 정상 응답: insights와 writingTip 파싱")
+  void generateInsight_success_parsedCorrectly() {
+    String insightJson =
+        """
+        {"insights":[{"summary":"화요일 집중력 최고","detail":"화요일 달성률이 90%였습니다."}],"writing_tip":"월요일에는 가벼운 투두를 추천합니다."}
+        """;
+    String geminiResponse =
+        """
+        {"candidates":[{"content":{"parts":[{"text":"%s"}]}}]}
+        """
+            .formatted(insightJson.strip().replace("\"", "\\\""));
+
+    stubGemini(geminiResponse);
+
+    AiInsight result = aiService.generateInsight(minimalStats(), YearMonth.of(2025, 5));
+
+    assertThat(result.insights()).hasSize(1);
+    assertThat(result.insights().get(0).summary()).isEqualTo("화요일 집중력 최고");
+    assertThat(result.insights().get(0).detail()).isEqualTo("화요일 달성률이 90%였습니다.");
+    assertThat(result.writingTip()).isEqualTo("월요일에는 가벼운 투두를 추천합니다.");
+  }
+
+  @Test
+  @DisplayName("Gemini 응답 텍스트에 JSON 마크다운 블록 포함: { } 사이만 추출해 파싱")
+  void generateInsight_jsonInMarkdown_extractedAndParsed() {
+    String rawText =
+        "```json\\n{\\\"insights\\\":[{\\\"summary\\\":\\\"좋은 달\\\",\\\"detail\\\":\\\"잘 했습니다.\\\"}],\\\"writing_tip\\\":\\\"파이팅\\\"}\\n```";
+    String geminiResponse =
+        """
+        {"candidates":[{"content":{"parts":[{"text":"%s"}]}}]}
+        """
+            .formatted(rawText);
+
+    stubGemini(geminiResponse);
+
+    AiInsight result = aiService.generateInsight(minimalStats(), YearMonth.of(2025, 5));
+
+    assertThat(result.insights()).hasSize(1);
+    assertThat(result.insights().get(0).summary()).isEqualTo("좋은 달");
+    assertThat(result.writingTip()).isEqualTo("파이팅");
+  }
+
+  // ── fallback ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Gemini 응답 텍스트가 유효하지 않은 JSON: 빈 AiInsight 반환")
+  void generateInsight_malformedJson_returnsFallback() {
+    String geminiResponse =
+        """
+        {"candidates":[{"content":{"parts":[{"text":"이건 JSON이 아닙니다"}]}}]}
+        """;
+
+    stubGemini(geminiResponse);
+
+    AiInsight result = aiService.generateInsight(minimalStats(), YearMonth.of(2025, 5));
+
+    assertThat(result.insights()).isEmpty();
+    assertThat(result.writingTip()).isNull();
+  }
+
+  @Test
+  @DisplayName("RestClient 예외 발생: fallback JSON으로 빈 AiInsight 반환")
+  @SuppressWarnings("unchecked")
+  void generateInsight_restClientThrows_returnsFallback() {
+    RestClient.RequestBodyUriSpec uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+    given(geminiRestClient.post()).willReturn(uriSpec);
+    given(uriSpec.uri(anyString())).willThrow(new RuntimeException("네트워크 오류"));
+
+    AiInsight result = aiService.generateInsight(minimalStats(), YearMonth.of(2025, 5));
+
+    assertThat(result.insights()).isEmpty();
+    assertThat(result.writingTip()).isNull();
+  }
+}

--- a/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiServiceTest.java
@@ -41,6 +41,7 @@ class MonthlyReportAiServiceTest {
 
     given(geminiRestClient.post()).willReturn(uriSpec);
     given(uriSpec.uri(anyString())).willReturn(bodySpec);
+    given(bodySpec.header(anyString(), any(String[].class))).willReturn(bodySpec);
     given(bodySpec.contentType(any(MediaType.class))).willReturn(bodySpec);
     given(bodySpec.body(any(Object.class))).willReturn(bodySpec);
     given(bodySpec.retrieve()).willReturn(responseSpec);

--- a/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculatorTest.java
+++ b/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculatorTest.java
@@ -1,0 +1,314 @@
+package plana.replan.domain.monthlyreport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.monthlyreport.entity.MonthlyReport;
+import plana.replan.domain.monthlyreport.repository.MonthlyReportRepository;
+import plana.replan.domain.replan.entity.Replan;
+import plana.replan.domain.replan.repository.ReplanRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyReportCalculatorTest {
+
+  @Mock private TodoRepository todoRepository;
+  @Mock private ReplanRepository replanRepository;
+  @Mock private MonthlyReportRepository monthlyReportRepository;
+
+  @InjectMocks private MonthlyReportCalculator calculator;
+
+  private static final YearMonth TARGET = YearMonth.of(2025, 5);
+
+  private User user() {
+    User u =
+        User.builder()
+            .email("test@test.com")
+            .nickname("테스트")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(u, "id", 1L);
+    return u;
+  }
+
+  private Tag tag(String title) {
+    Tag t = Tag.builder().title(title).color("#3B82F6").user(user()).build();
+    ReflectionTestUtils.setField(t, "id", 1L);
+    return t;
+  }
+
+  private Todo todo(User user, boolean completed, Tag tag, LocalDateTime dueDate) {
+    Todo t =
+        Todo.builder().title("투두").user(user).tag(tag).dueDate(dueDate).isPinned(false).build();
+    ReflectionTestUtils.setField(t, "isCompleted", completed);
+    return t;
+  }
+
+  private Replan replan(Todo todo, String reason) {
+    return Replan.builder().todo(todo).failureReason1(reason).build();
+  }
+
+  private void stubNoPrev() {
+    given(monthlyReportRepository.findByUserAndReportMonth(any(), any()))
+        .willReturn(Optional.empty());
+  }
+
+  // ── 기본 달성률 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("투두 없음: totalTodos=0, achievementRate=0, hasActivity=false")
+  void calculate_noTodos_zeroStats() {
+    given(todoRepository.findMonthlyTodos(any(), any(), any())).willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(user(), TARGET);
+
+    assertThat(stats.totalTodos()).isZero();
+    assertThat(stats.completedTodos()).isZero();
+    assertThat(stats.achievementRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(stats.hasActivity()).isFalse();
+    assertThat(stats.replanCount()).isZero();
+    assertThat(stats.replanAchievementEffect()).isNull();
+  }
+
+  @Test
+  @DisplayName("투두 4개 중 3개 완료: achievementRate=75.00, hasActivity=true")
+  void calculate_partialCompletion_correctRate() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    List<Todo> todos =
+        List.of(
+            todo(u, true, null, due),
+            todo(u, true, null, due),
+            todo(u, true, null, due),
+            todo(u, false, null, due));
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(todos) // 당월
+        .willReturn(List.of()); // 전월
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.totalTodos()).isEqualTo(4);
+    assertThat(stats.completedTodos()).isEqualTo(3);
+    assertThat(stats.achievementRate()).isEqualByComparingTo(new BigDecimal("75.00"));
+    assertThat(stats.hasActivity()).isTrue();
+  }
+
+  // ── prevMonthDiff ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("이전 달 리포트 존재: prevMonthDiff = 현재 달성률 - 이전 달성률")
+  void calculate_prevReportExists_diffCalculated() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    List<Todo> todos = List.of(todo(u, true, null, due), todo(u, false, null, due)); // 50%
+
+    MonthlyReport prev =
+        MonthlyReport.builder()
+            .user(u)
+            .reportMonth(TARGET.minusMonths(1).atDay(1))
+            .totalTodos(10)
+            .completedTodos(4)
+            .achievementRate(new BigDecimal("40.00"))
+            .build();
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any())).willReturn(todos);
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    given(monthlyReportRepository.findByUserAndReportMonth(any(), any()))
+        .willReturn(Optional.of(prev));
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    // 50.00 - 40.00 = 10.00
+    assertThat(stats.prevMonthDiff()).isEqualByComparingTo(new BigDecimal("10.00"));
+  }
+
+  @Test
+  @DisplayName("이전 달 리포트 없고 이전 달 투두도 없음: prevMonthDiff=null")
+  void calculate_noPrevData_prevMonthDiffNull() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    List<Todo> todos = List.of(todo(u, true, null, due));
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(todos) // 당월
+        .willReturn(List.of()); // 전월
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.prevMonthDiff()).isNull();
+  }
+
+  // ── 태그별 달성률 ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("태그별 투두 2개 이상: bestTag=운동(100%), worstTag=독서(0%)")
+  void calculate_tagsWithMinTwo_tagStatsCalculated() {
+    User u = user();
+    Tag exercise = tag("운동");
+    Tag reading = tag("독서");
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+
+    List<Todo> todos =
+        List.of(
+            todo(u, true, exercise, due),
+            todo(u, true, exercise, due), // 운동: 2/2 = 100%
+            todo(u, false, reading, due),
+            todo(u, false, reading, due)); // 독서: 0/2 = 0%
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(todos)
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.analysisData().bestAchievementTag()).isNotNull();
+    assertThat(stats.analysisData().bestAchievementTag().tag()).isEqualTo("운동");
+    assertThat(stats.analysisData().worstAchievementTag()).isNotNull();
+    assertThat(stats.analysisData().worstAchievementTag().tag()).isEqualTo("독서");
+  }
+
+  @Test
+  @DisplayName("태그별 투두 1개: 2개 미만 조건으로 bestTag, worstTag 모두 null")
+  void calculate_tagWithOnlyOne_noTagStats() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    List<Todo> todos = List.of(todo(u, true, tag("운동"), due)); // 1개만
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(todos)
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.analysisData().bestAchievementTag()).isNull();
+    assertThat(stats.analysisData().worstAchievementTag()).isNull();
+  }
+
+  // ── 실패 사유 depth 변환 ─────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("depth-3 실패 사유(CONDITION_SLEEP_3H_UNDER)는 depth-1 라벨(컨디션 난조)로 그룹화")
+  void calculate_depth3FailureReason_groupedToDepth1Label() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    Todo t = todo(u, false, null, due);
+    Replan r = replan(t, "CONDITION_SLEEP_3H_UNDER");
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(List.of(t))
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of(r));
+    given(todoRepository.findReplanDerivedMonthlyTodos(any(), any(), any())).willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.analysisData().topFailureReason()).isEqualTo("컨디션 난조");
+    assertThat(stats.analysisData().failureDistribution()).hasSize(1);
+    assertThat(stats.analysisData().failureDistribution().get(0).reason()).isEqualTo("컨디션 난조");
+  }
+
+  @Test
+  @DisplayName("depth-1 실패 사유(MENTAL_RESISTANCE)는 그대로 라벨(심리적 저항)로 변환")
+  void calculate_depth1FailureReason_usesOwnLabel() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    Todo t = todo(u, false, null, due);
+    Replan r = replan(t, "MENTAL_RESISTANCE");
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(List.of(t))
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of(r));
+    given(todoRepository.findReplanDerivedMonthlyTodos(any(), any(), any())).willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.analysisData().topFailureReason()).isEqualTo("심리적 저항");
+  }
+
+  // ── 리플랜 효과 ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("리플랜 1개, 파생 투두 1개 달성: replanAchievementEffect=100.00")
+  void calculate_withReplans_effectCalculated() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    Todo t = todo(u, false, null, due);
+    Replan r = replan(t, "MENTAL_RESISTANCE");
+    Todo derived = todo(u, true, null, due);
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(List.of(t))
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of(r));
+    given(todoRepository.findReplanDerivedMonthlyTodos(any(), any(), any()))
+        .willReturn(List.of(derived));
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.replanCount()).isEqualTo(1);
+    assertThat(stats.replanAchievementEffect()).isEqualByComparingTo(new BigDecimal("100.00"));
+  }
+
+  @Test
+  @DisplayName("리플랜 없음: replanCount=0, replanAchievementEffect=null")
+  void calculate_noReplans_effectNull() {
+    User u = user();
+    LocalDateTime due = TARGET.atDay(10).atStartOfDay();
+    List<Todo> todos = List.of(todo(u, true, null, due));
+
+    given(todoRepository.findMonthlyTodos(any(), any(), any()))
+        .willReturn(todos)
+        .willReturn(List.of());
+    given(replanRepository.findByUserAndCreatedAtBetween(any(), any(), any()))
+        .willReturn(List.of());
+    stubNoPrev();
+
+    CalculatedStats stats = calculator.calculate(u, TARGET);
+
+    assertThat(stats.replanCount()).isZero();
+    assertThat(stats.replanAchievementEffect()).isNull();
+  }
+}

--- a/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculatorTest.java
+++ b/src/test/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculatorTest.java
@@ -60,6 +60,8 @@ class MonthlyReportCalculatorTest {
     Todo t =
         Todo.builder().title("투두").user(user).tag(tag).dueDate(dueDate).isPinned(false).build();
     ReflectionTestUtils.setField(t, "isCompleted", completed);
+    // 14일 조건 충족: 대상 월 1일에 생성된 것으로 설정 (월말 기준 30일+ 이전)
+    ReflectionTestUtils.setField(t, "createdAt", TARGET.atDay(1).atStartOfDay());
     return t;
   }
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -10,6 +10,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
 
 jwt:
   secret: testSecretKeyForTestingPurposeOnly1234


### PR DESCRIPTION
통계 리포트 관련 API 구현 을 위한 작업을 진행하였습니다.

### DB / 인프라

  - V9 — Spring Batch 메타 테이블 추가 (batch_job_instance, batch_job_execution 등 6개)
  - V10 — report_generation_failure 테이블 추가 (실패한 리포트 재시도 추적용)

### 배치 (batch/)

  - MonthlyReportJobConfig — JpaCursorItemReader → ItemProcessor → ItemWriter 체인으로 구성된 Chunk 기반 배치 Job.
  skip 설정으로 특정 사용자 실패가 전체 배치를 중단하지 않음
  - MonthlyReportItemProcessor — 사용자별 통계 계산 + Gemini API 호출 (Gemini 30 RPM 제한 대응 청크 크기 1)
  - MonthlyReportItemWriter — 리포트 upsert (이미 존재하면 update, 없으면 insert)
  - MonthlyReportScheduler — 0 0 0 1 * * 정기 실행 / 0 0 3 * * * 실패 재시도 (최대 3회)

### 서비스 (service/)

  - MonthlyReportCalculator — 달성률, 전월 대비 차이, 태그별/요일별 달성률, 실패 사유 depth-1 그룹핑, 리플랜 효과
  계산
  - MonthlyReportAiService — Gemini REST API 호출 및 JSON 파싱. 마크다운 블록 포함 응답 및 파싱 실패 모두 fallback
  처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 월간 통계 리포트 생성·조회 기능 및 스케줄러(정기 생성/재시도) 추가
  * AI 기반 월간 인사이트 자동 생성 및 호출 쓰로틀 적용
  * 실패 기록/재시도 관리와 리포트 업서트(생성/갱신) 지원
  * 상세 통계(달성률, 전월비, 리플랜 효과, 실패 분포·패턴) 제공
  * 개발용 수동 생성 API(로컬 전용) 추가

* **문서**
  * 월간 리포트용 OpenAPI 문서 추가

* **DB 마이그레이션**
  * 배치 메타 테이블 및 실패 기록 테이블/제약 추가

* **테스트**
  * 컨트롤러·계산·AI 서비스 테스트 추가

* **기타**
  * 입력 검증 예외 처리 개선 (ConstraintViolation)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->