### PR TITLE
Feat/109 statistics 2차 코드 리뷰 반영

### DIFF
--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -3,8 +3,7 @@ package plana.replan.domain.monthlyreport.batch;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.annotation.BeforeStep;
-import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -16,6 +15,7 @@ import plana.replan.domain.user.entity.User;
 
 @Slf4j
 @Component
+@StepScope
 @RequiredArgsConstructor
 public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyReportData> {
 
@@ -25,12 +25,8 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
 
+  @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
-
-  @BeforeStep
-  public void beforeStep(StepExecution stepExecution) {
-    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
-  }
 
   @Override
   public MonthlyReportData process(User user) throws Exception {

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/ReportSkipListener.java
@@ -3,9 +3,9 @@ package plana.replan.domain.monthlyreport.batch;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.listener.SkipListener;
-import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import plana.replan.domain.monthlyreport.entity.ReportGenerationFailure;
 import plana.replan.domain.monthlyreport.repository.ReportGenerationFailureRepository;
@@ -13,17 +13,14 @@ import plana.replan.domain.user.entity.User;
 
 @Slf4j
 @Component
+@StepScope
 @RequiredArgsConstructor
 public class ReportSkipListener implements SkipListener<User, MonthlyReportData> {
 
   private final ReportGenerationFailureRepository failureRepository;
 
+  @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
-
-  @BeforeStep
-  public void beforeStep(StepExecution stepExecution) {
-    targetMonth = YearMonth.parse(stepExecution.getJobParameters().getString("targetMonth"));
-  }
 
   @Override
   public void onSkipInProcess(User user, Throwable t) {

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
@@ -15,7 +15,7 @@ import plana.replan.global.common.ApiResult;
 @RestController
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
-@Profile("!prod")
+@Profile("local")
 public class DevMonthlyReportController {
 
   private final MonthlyReportService monthlyReportService;

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportAiService.java
@@ -1,7 +1,5 @@
 package plana.replan.domain.monthlyreport.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import plana.replan.domain.monthlyreport.entity.AiInsight;
 import plana.replan.domain.monthlyreport.entity.AnalysisData;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Service
@@ -24,7 +25,7 @@ public class MonthlyReportAiService {
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent";
 
   private final RestClient geminiRestClient;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
   @Value("${gemini.api-key}")
   private String apiKey;
@@ -131,7 +132,7 @@ public class MonthlyReportAiService {
       String writingTip = root.path("writing_tip").asText(null);
       return new AiInsight(insights, writingTip);
     } catch (Exception e) {
-      log.error("통계 AI 응답 파싱 실패: {}", raw, e);
+      log.error("통계 AI 응답 파싱 실패 (length={})", raw == null ? 0 : raw.length(), e);
       return new AiInsight(List.of(), null);
     }
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -51,7 +51,7 @@ public class MonthlyReportCalculator {
   @Transactional(readOnly = true)
   public CalculatedStats calculate(User user, YearMonth targetMonth) {
     LocalDateTime start = targetMonth.atDay(1).atStartOfDay();
-    LocalDateTime end = targetMonth.atEndOfMonth().atTime(23, 59, 59);
+    LocalDateTime end = targetMonth.plusMonths(1).atDay(1).atStartOfDay();
 
     List<Todo> todos = todoRepository.findMonthlyTodos(user, start, end);
     int totalTodos = todos.size();
@@ -114,7 +114,7 @@ public class MonthlyReportCalculator {
     }
 
     LocalDateTime prevStart = prevMonth.atDay(1).atStartOfDay();
-    LocalDateTime prevEnd = prevMonth.atEndOfMonth().atTime(23, 59, 59);
+    LocalDateTime prevEnd = targetMonth.atDay(1).atStartOfDay();
     List<Todo> prevTodos = todoRepository.findMonthlyTodos(user, prevStart, prevEnd);
 
     if (prevTodos.isEmpty()) return null;

--- a/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
+++ b/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
@@ -12,7 +12,7 @@ public interface ReplanRepository extends JpaRepository<Replan, Long> {
 
   @Query(
       "SELECT r FROM Replan r WHERE r.todo.user = :user"
-          + " AND r.createdAt BETWEEN :start AND :end")
+          + " AND r.createdAt >= :start AND r.createdAt < :end")
   List<Replan> findByUserAndCreatedAtBetween(
       @Param("user") User user,
       @Param("start") LocalDateTime start,

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -83,8 +83,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
-          + " AND ((t.dueDate BETWEEN :start AND :end)"
-          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+          + " AND ((t.dueDate >= :start AND t.dueDate < :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime >= :start AND t.completedTime < :end))")
   List<Todo> findMonthlyTodos(
       @Param("user") User user,
       @Param("start") LocalDateTime start,
@@ -92,8 +92,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.replan IS NOT NULL"
-          + " AND ((t.dueDate BETWEEN :start AND :end)"
-          + " OR (t.dueDate IS NULL AND t.completedTime BETWEEN :start AND :end))")
+          + " AND ((t.dueDate >= :start AND t.dueDate < :end)"
+          + " OR (t.dueDate IS NULL AND t.completedTime >= :start AND t.completedTime < :end))")
   List<Todo> findReplanDerivedMonthlyTodos(
       @Param("user") User user,
       @Param("start") LocalDateTime start,

--- a/src/main/resources/db/migration/V10__add_report_generation_failure.sql
+++ b/src/main/resources/db/migration/V10__add_report_generation_failure.sql
@@ -2,7 +2,7 @@ CREATE TABLE report_generation_failure
 (
     id            BIGSERIAL PRIMARY KEY,
     user_id       BIGINT  NOT NULL REFERENCES users (id),
-    target_month  DATE    NOT NULL,
+    target_month  DATE    NOT NULL CHECK (EXTRACT(DAY FROM target_month) = 1),
     retry_count   INTEGER NOT NULL DEFAULT 0,
     error_message TEXT,
     created_at    TIMESTAMP(6),


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #109


## 변경 사항
  - targetMonth 주입: @BeforeStep 뮤터블 필드 → @StepScope + @Value("#{jobParameters['targetMonth']}") (singleton 레이스 방지)
  - @Profile("!prod") → @Profile("local") (허용 목록 방식)
  - Gemini raw 응답 로그 제거 (길이만 기록, 개인정보 보호)
  - Jackson 네임스페이스 com.fasterxml.jackson → tools.jackson 통일 (Jackson 3)
  - 월간 구간 쿼리: BETWEEN → >= start AND < nextMonthStart (half-open interval, 월말 소수초 누락 방지)
  - buildPatterns(): failureReason1 단독 → Stream.of(r1, r2, r3).filter(nonNull) 3개 이유 모두 집계
  - hasActivity: 투두 존재 여부 → 첫 생성일 기준 월말까지 14일 이상 확인
  - Gemini API key: URL 쿼리 파라미터 → x-goog-api-key 헤더
  - 배치 skip limit/delay: @Value 외부 설정화
  - retryOneFailure(): @Transactional 메서드로 분리, Thread.sleep 트랜잭션 외부 실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 월간 데이터 조회 시 시간 경계 처리를 정확히 개선하여 데이터 집계 정확성 향상
  * 데이터베이스 제약 조건 추가로 데이터 무결성 강화

* **Refactor**
  * Spring Batch 초기화 메커니즘을 현대적 방식으로 개선
  * 월간 리포트 컨트롤러 활성화 조건을 로컬 개발 환경으로 제한
  * 내부 쿼리 조건 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->