### PR TITLE
fix: 월간 통계 배치 3차 코드리뷰 피드백 반영

### DIFF
--- a/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
@@ -1,0 +1,44 @@
+package plana.replan.domain.monthlyreport.batch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.listener.ChunkListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+public class GeminiThrottleChunkListener implements ChunkListener {
+
+  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
+  private long geminiCallDelayMs;
+
+  private boolean aiCalled;
+
+  void markAiCalled() {
+    aiCalled = true;
+  }
+
+  @Override
+  public void beforeChunk(ChunkContext context) {
+    aiCalled = false;
+  }
+
+  @Override
+  public void afterChunk(ChunkContext context) {
+    if (!aiCalled) return;
+    try {
+      Thread.sleep(geminiCallDelayMs);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Gemini throttle sleep 인터럽트");
+    }
+  }
+
+  @Override
+  public void afterChunkError(ChunkContext context) {
+    aiCalled = false;
+  }
+}

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportItemProcessor.java
@@ -21,9 +21,7 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
 
   private final MonthlyReportCalculator calculator;
   private final MonthlyReportAiService aiService;
-
-  @Value("${statistics.batch.gemini-call-delay-ms:2500}")
-  private long geminiCallDelayMs;
+  private final GeminiThrottleChunkListener throttleListener;
 
   @Value("#{T(java.time.YearMonth).parse(jobParameters['targetMonth'])}")
   private YearMonth targetMonth;
@@ -40,7 +38,7 @@ public class MonthlyReportItemProcessor implements ItemProcessor<User, MonthlyRe
     }
 
     AiInsight aiInsight = aiService.generateInsight(stats, targetMonth);
-    Thread.sleep(geminiCallDelayMs);
+    throttleListener.markAiCalled(); // sleep은 트랜잭션 밖 afterChunk()에서 실행
 
     return new MonthlyReportData(user, targetMonth.atDay(1), stats, aiInsight);
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportJobConfig.java
@@ -3,6 +3,7 @@ package plana.replan.domain.monthlyreport.batch;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
@@ -27,6 +28,7 @@ public class MonthlyReportJobConfig {
   private final MonthlyReportItemProcessor processor;
   private final MonthlyReportItemWriter writer;
   private final ReportSkipListener reportSkipListener;
+  private final GeminiThrottleChunkListener throttleListener;
 
   @Value("${statistics.batch.skip-limit:100}")
   private int skipLimit;
@@ -54,10 +56,12 @@ public class MonthlyReportJobConfig {
               return t instanceof RuntimeException && skipCount < skipLimit;
             })
         .listener(reportSkipListener)
+        .listener(throttleListener)
         .build();
   }
 
   @Bean
+  @StepScope
   public JpaCursorItemReader<User> userItemReader() {
     return new JpaCursorItemReaderBuilder<User>()
         .name("userItemReader")

--- a/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/MonthlyReportScheduler.java
@@ -28,6 +28,9 @@ public class MonthlyReportScheduler {
   @Value("${statistics.batch.gemini-call-delay-ms:2500}")
   private long geminiCallDelayMs;
 
+  @Value("${statistics.batch.max-retry-count:3}")
+  private int maxRetryCount;
+
   @Scheduled(cron = "0 0 0 1 * *")
   public void runMonthlyReportBatch() {
     YearMonth targetMonth = YearMonth.now().minusMonths(1);
@@ -41,7 +44,11 @@ public class MonthlyReportScheduler {
 
     try {
       var execution = jobOperator.start(monthlyReportJob, params);
-      log.info("월간 리포트 배치 완료 - status={}", execution.getStatus());
+      if (execution.getStatus().isUnsuccessful()) {
+        log.error("월간 리포트 배치 실패 - status={}", execution.getStatus());
+      } else {
+        log.info("월간 리포트 배치 완료 - status={}", execution.getStatus());
+      }
     } catch (Exception e) {
       log.error("월간 리포트 배치 실행 실패", e);
     }
@@ -50,7 +57,9 @@ public class MonthlyReportScheduler {
   @Scheduled(cron = "0 0 3 * * *")
   public void retryFailedReports() {
     List<Long> failureIds =
-        failureRepository.findByRetryCountLessThan(3).stream().map(f -> f.getId()).toList();
+        failureRepository.findByRetryCountLessThan(maxRetryCount).stream()
+            .map(f -> f.getId())
+            .toList();
 
     if (failureIds.isEmpty()) return;
     log.info("실패 리포트 재처리 시작 - count={}", failureIds.size());
@@ -64,6 +73,8 @@ public class MonthlyReportScheduler {
         Thread.currentThread().interrupt();
         log.warn("재처리 인터럽트 - 종료");
         break;
+      } catch (Exception e) {
+        log.error("재처리 중 예외 발생 - failureId={}", failureId, e);
       }
     }
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/DevMonthlyReportController.java
@@ -1,9 +1,12 @@
 package plana.replan.domain.monthlyreport.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,13 +19,16 @@ import plana.replan.global.common.ApiResult;
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
 @Profile("local")
+@Validated
 public class DevMonthlyReportController {
 
   private final MonthlyReportService monthlyReportService;
 
   @PostMapping("/generate")
   public ResponseEntity<ApiResult<MonthlyReportResponse>> generateReport(
-      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+      @AuthenticationPrincipal Long userId,
+      @RequestParam @Min(1) int year,
+      @RequestParam @Min(1) @Max(12) int month) {
     return ResponseEntity.ok(
         ApiResult.ok(monthlyReportService.generateReport(userId, year, month)));
   }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -1,8 +1,11 @@
 package plana.replan.domain.monthlyreport.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +17,7 @@ import plana.replan.global.common.ApiResult;
 @RestController
 @RequestMapping("/api/monthly-reports")
 @RequiredArgsConstructor
+@Validated
 public class MonthlyReportController implements MonthlyReportControllerDocs {
 
   private final MonthlyReportService monthlyReportService;
@@ -21,7 +25,9 @@ public class MonthlyReportController implements MonthlyReportControllerDocs {
   @Override
   @GetMapping
   public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
-      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
+      @AuthenticationPrincipal Long userId,
+      @RequestParam @Min(1) int year,
+      @RequestParam @Min(1) @Max(12) int month) {
     return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportController.java
@@ -1,7 +1,5 @@
 package plana.replan.domain.monthlyreport.controller;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,9 +23,7 @@ public class MonthlyReportController implements MonthlyReportControllerDocs {
   @Override
   @GetMapping
   public ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam @Min(1) int year,
-      @RequestParam @Min(1) @Max(12) int month) {
+      @AuthenticationPrincipal Long userId, @RequestParam int year, @RequestParam int month) {
     return ResponseEntity.ok(ApiResult.ok(monthlyReportService.getReport(userId, year, month)));
   }
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/controller/MonthlyReportControllerDocs.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -133,6 +135,7 @@ public interface MonthlyReportControllerDocs {
   })
   ResponseEntity<ApiResult<MonthlyReportResponse>> getReport(
       @AuthenticationPrincipal Long userId,
-      @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
-      @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam int month);
+      @Parameter(description = "조회 연도", example = "2025") @RequestParam @Min(1) int year,
+      @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam @Min(1) @Max(12)
+          int month);
 }

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportCalculator.java
@@ -85,7 +85,7 @@ public class MonthlyReportCalculator {
       LocalDateTime endOfMonth = targetMonth.atEndOfMonth().atTime(23, 59, 59);
       hasActivity =
           todos.stream()
-              .map(t -> t.getCreatedAt())
+              .map(Todo::getCreatedAt)
               .filter(Objects::nonNull)
               .min(Comparator.naturalOrder())
               .map(first -> ChronoUnit.DAYS.between(first, endOfMonth) >= 14)

--- a/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/service/MonthlyReportService.java
@@ -142,6 +142,7 @@ public class MonthlyReportService {
     }
   }
 
+  @Transactional
   public void upsertReport(
       User user, LocalDate reportMonth, CalculatedStats stats, AiInsight aiInsight) {
     monthlyReportRepository

--- a/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package plana.replan.global.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,18 @@ public class GlobalExceptionHandler {
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .orElse(e.getMessage());
     log.error("ValidationException: {}", detail);
+    return ResponseEntity.badRequest()
+        .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiResult<?>> handleConstraintViolation(ConstraintViolationException e) {
+    String detail =
+        e.getConstraintViolations().stream()
+            .findFirst()
+            .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+            .orElse(e.getMessage());
+    log.error("ConstraintViolationException: {}", detail);
     return ResponseEntity.badRequest()
         .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,3 +59,4 @@ gemini:
 statistics:
   batch:
     gemini-call-delay-ms: 2500
+    max-retry-count: 3


### PR DESCRIPTION
- GeminiThrottleChunkListener(@StepScope)로 Gemini 호출 후 sleep을 트랜잭션 밖 afterChunk()로 이동
- MonthlyReportItemProcessor: @StepScope + @Value로 targetMonth 주입, throttleListener.markAiCalled() 연동
- MonthlyReportJobConfig: userItemReader @StepScope 추가, throttleListener 등록
- MonthlyReportScheduler: 재처리 루프 단건 예외 격리, maxRetryCount @Value 주입, 배치 상태 로그 구분
- MonthlyReportController / DevMonthlyReportController: @Validated + @Min/@Max 파라미터 검증 추가
- GlobalExceptionHandler: ConstraintViolationException 핸들러 추가 (400 반환)
- MonthlyReportService.upsertReport: @Transactional 추가
- MonthlyReportCalculator: 메서드 레퍼런스로 변경 (t -> t.getCreatedAt() → Todo::getCreatedAt)
- application.yaml: max-retry-count: 3 추가

## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 월간 리포트 조회 시 연도 및 월 입력값 검증 강화 (유효하지 않은 값에 대한 명확한 오류 응답)
  * 개선된 입력 값 오류 메시지 제공

* **Bug Fixes**
  * 배치 처리 중 예외 처리 로직 개선
  * 트랜잭션 안정성 강화

* **Chores**
  * 배치 재시도 횟수를 설정 기반으로 변경 가능하게 개선
  * API 코드 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->