### PR TITLE
fix: Gemini 호출 실패 시에도 throttle이 작동하도록 afterChunkError 리셋 제거

### DIFF
--- a/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
+++ b/src/main/java/plana/replan/domain/monthlyreport/batch/GeminiThrottleChunkListener.java
@@ -39,6 +39,6 @@ public class GeminiThrottleChunkListener implements ChunkListener {
 
   @Override
   public void afterChunkError(ChunkContext context) {
-    aiCalled = false;
+    // Gemini 호출 후 실패한 경우에도 throttle이 작동해야 429 연쇄를 막을 수 있으므로 리셋하지 않음
   }
 }


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #109


## 변경 사항
Gemini 호출 실패 시에도 throttle이 작동하도록 afterChunkError 리셋 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * AI 호출 실패 시 배치 처리의 안정성 및 신뢰성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->