### PR TITLE
ci: main 머지 시 태그·릴리즈 자동 생성

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release on merge to main
+
+# main으로 가는 PR이 머지되면, PR 제목(예: v0.13.0)을 버전으로 삼아
+# 태그와 GitHub 릴리즈를 자동으로 생성한다. 릴리즈 노트는 PR 본문을 사용한다.
+on:
+  pull_request:
+    types: [closed]
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create tag & release from PR title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.pull_request.title }}
+          NOTES: ${{ github.event.pull_request.body }}
+        run: |
+          # PR 제목이 vX.Y.Z 형식일 때만 릴리즈한다. (아니면 조용히 건너뜀)
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "PR 제목이 버전 형식(vX.Y.Z)이 아니라 릴리즈를 건너뜁니다: '$VERSION'"
+            exit 0
+          fi
+
+          # 이미 같은 태그가 있으면 중복 생성하지 않는다.
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "이미 존재하는 릴리즈라 건너뜁니다: $VERSION"
+            exit 0
+          fi
+
+          # 태그가 없으면 gh가 main 기준으로 태그까지 함께 생성한다.
+          gh release create "$VERSION" \
+            --target main \
+            --title "$VERSION" \
+            --notes "$NOTES"
+          echo "릴리즈 생성 완료: $VERSION"


### PR DESCRIPTION
## 무엇을

main으로 가는 PR이 머지되면, PR 제목(예: `v0.13.0`)을 버전으로 삼아 **태그와 GitHub 릴리즈를 자동으로 생성**하는 워크플로를 추가했습니다.

## 왜

지금은 main 머지 후 매번 손으로 태그를 만들고 릴리즈를 작성하는데, 이걸 자동화해서 "PR 제목에 버전 달고 머지"만 하면 끝나게 했습니다.

## 동작

- develop→main PR이 머지될 때 실행
- PR 제목이 `vX.Y.Z` 형식이면 그 이름으로 태그 + 릴리즈 생성 (릴리즈 노트는 PR 본문 사용)
- 제목이 버전 형식이 아니거나 이미 있는 릴리즈면 건너뜀
- 별도 시크릿 불필요 (기본 `GITHUB_TOKEN` 사용)

> 워크플로 파일이 main에 반영된 다음 릴리즈부터 동작합니다.
