### PR TITLE
fix: todo week/month 필터를 기준 날짜 기준 상대 범위로 변경

### DIFF
--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -1,11 +1,9 @@
 package plana.replan.domain.todo.service;
 
 import java.time.Clock;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -208,21 +206,19 @@ public class TodoService {
         todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       case "week" -> {
-        LocalDate monday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDate sunday = monday.plusDays(6);
+        LocalDate endDate = today.plusDays(6);
         todos =
             new ArrayList<>(
                 todoRepository.findAllTodosByDueDateRange(
-                    user, monday.atStartOfDay(), sunday.atTime(LocalTime.MAX)));
+                    user, startOfDay, endDate.atTime(LocalTime.MAX)));
         todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       case "month" -> {
-        LocalDate firstDay = today.withDayOfMonth(1);
-        LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
+        LocalDate endDate = today.plusMonths(1).minusDays(1);
         todos =
             new ArrayList<>(
                 todoRepository.findAllTodosByDueDateRange(
-                    user, firstDay.atStartOfDay(), lastDay.atTime(LocalTime.MAX)));
+                    user, startOfDay, endDate.atTime(LocalTime.MAX)));
         todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       default -> throw new CustomException(TodoErrorCode.INVALID_FILTER);

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -607,33 +608,58 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("getTodos - week 필터: 해당 주 월~일 범위의 완료/미완료 모두 조회")
+  @DisplayName("getTodos - week 필터: 기준 날짜부터 6일 후까지(총 7일) 범위의 완료/미완료 모두 조회")
   void getTodos_week_allTodosInWeekRange() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findAllTodosByDueDateRange(any(), any(), any()))
         .willReturn(List.of(activeTodo(1L, user)));
 
-    todoService.getTodos(1L, "week", "priority", null);
+    todoService.getTodos(1L, "week", "priority", LocalDate.of(2026, 6, 18));
 
-    verify(todoRepository).findAllTodosByDueDateRange(any(), any(), any());
+    ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
+    assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 6, 18).atStartOfDay());
+    assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 6, 24).atTime(23, 59, 59, 999999999));
     verify(todoRepository, never()).findActiveTodosByDueDateRange(any(), any(), any());
     verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
   }
 
   @Test
-  @DisplayName("getTodos - month 필터: 해당 달 1일~말일 범위의 완료/미완료 모두 조회")
+  @DisplayName("getTodos - month 필터: 기준 날짜부터 한 달 후 전날까지 범위의 완료/미완료 모두 조회")
   void getTodos_month_allTodosInMonthRange() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
     given(todoRepository.findAllTodosByDueDateRange(any(), any(), any()))
         .willReturn(List.of(activeTodo(1L, user)));
 
-    todoService.getTodos(1L, "month", "priority", null);
+    todoService.getTodos(1L, "month", "priority", LocalDate.of(2026, 6, 18));
 
-    verify(todoRepository).findAllTodosByDueDateRange(any(), any(), any());
+    ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
+    assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 6, 18).atStartOfDay());
+    assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 7, 17).atTime(23, 59, 59, 999999999));
     verify(todoRepository, never()).findActiveTodosByDueDateRange(any(), any(), any());
     verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("getTodos - month 필터: 1월 31일 기준이면 종료일이 2월 27일로 보정됨")
+  void getTodos_month_endOfMonthDateRolloverAdjusted() {
+    User user = testUser();
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    given(todoRepository.findAllTodosByDueDateRange(any(), any(), any()))
+        .willReturn(List.of(activeTodo(1L, user)));
+
+    todoService.getTodos(1L, "month", "priority", LocalDate.of(2026, 1, 31));
+
+    ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
+    assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 1, 31).atStartOfDay());
+    assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 2, 27).atTime(23, 59, 59, 999999999));
   }
 
   @Test


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #174 


## 변경 사항
> 캘린더 주(월~일)/월(1일~말일) 기준이 아니라, 기준 날짜부터 week는 6일 후까지, month는 한 달 후 전날까지로 범위를 계산하도록 수정.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 할일 조회 시 주/월 필터의 기간 계산 로직 수정

* **Tests**
  * 할일 조회 필터 테스트 케이스 업데이트 및 강화

* **Refactor**
  * 불필요한 import 정리 및 코드 정렬

<!-- end of auto-generated comment: release notes by coderabbit.ai -->