### PR TITLE
Fix: todo 목록 조회 all 필터에서 완료된 todo가 누락되던 문제 수정

### DIFF
--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -58,6 +58,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
           + " AND t.isActive = true")
   List<Todo> findActiveTodosForUser(@Param("user") User user);
 
+  @Query("SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isActive = true")
+  List<Todo> findAllActiveTodosForUser(@Param("user") User user);
+
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
           + " AND t.isPinned = true AND t.isActive = true")

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -193,8 +193,8 @@ public class TodoService {
     List<Todo> todos;
     switch (filter.toLowerCase()) {
       case "all" -> {
-        todos = new ArrayList<>(todoRepository.findActiveTodosForUser(user));
-        todos.sort(sortComparator);
+        todos = new ArrayList<>(todoRepository.findAllActiveTodosForUser(user));
+        todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       case "day" -> {
         List<Todo> active =

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -567,17 +567,19 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("getTodos - all 필터: 미완료 투두 전체 반환")
+  @DisplayName("getTodos - all 필터: 완료/미완료 투두 모두 반환, 미완료가 먼저")
   void getTodos_all_returnsActiveTodos() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(user))
-        .willReturn(List.of(activeTodo(1L, user), activeTodo(2L, user)));
+    given(todoRepository.findAllActiveTodosForUser(user))
+        .willReturn(List.of(activeTodo(1L, user), activeTodo(2L, user), completedTodo(3L, user)));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
-    assertThat(result).hasSize(2);
-    assertThat(result).extracting("isCompleted").containsOnly(false);
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).isCompleted()).isFalse();
+    assertThat(result.get(1).isCompleted()).isFalse();
+    assertThat(result.get(2).isCompleted()).isTrue();
   }
 
   @Test
@@ -585,7 +587,7 @@ class TodoServiceTest {
   void getTodos_all_emptyList() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(user)).willReturn(List.of());
+    given(todoRepository.findAllActiveTodosForUser(user)).willReturn(List.of());
 
     assertThat(todoService.getTodos(1L, "all", "priority", null)).isEmpty();
   }
@@ -685,7 +687,7 @@ class TodoServiceTest {
     Todo t2 = activeTodoWithSort(2L, user, false, 500.0);
     Todo t3 = activeTodoWithSort(3L, user, true, 9999.0);
 
-    given(todoRepository.findActiveTodosForUser(user)).willReturn(List.of(t1, t3, t2));
+    given(todoRepository.findAllActiveTodosForUser(user)).willReturn(List.of(t1, t3, t2));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
@@ -707,7 +709,7 @@ class TodoServiceTest {
     Todo earlyDate = activeTodoWithDueDate(3L, user, true, early);
     Todo midDate = activeTodoWithDueDate(4L, user, false, mid);
 
-    given(todoRepository.findActiveTodosForUser(user))
+    given(todoRepository.findAllActiveTodosForUser(user))
         .willReturn(List.of(noDate, lateDate, earlyDate, midDate));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "dueDate", null);
@@ -733,7 +735,7 @@ class TodoServiceTest {
   void getTodos_filterCaseInsensitive() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of());
+    given(todoRepository.findAllActiveTodosForUser(any())).willReturn(List.of());
 
     assertThatCode(() -> todoService.getTodos(1L, "ALL", "priority", null))
         .doesNotThrowAnyException();
@@ -759,7 +761,7 @@ class TodoServiceTest {
     Todo overdue = activeTodoWithDueDate(1L, user, false, LocalDateTime.of(2020, 1, 1, 0, 0));
 
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(overdue));
+    given(todoRepository.findAllActiveTodosForUser(any())).willReturn(List.of(overdue));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
@@ -788,7 +790,8 @@ class TodoServiceTest {
   void getTodos_noDueDate_isOverdueFalse() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(activeTodo(1L, user)));
+    given(todoRepository.findAllActiveTodosForUser(any()))
+        .willReturn(List.of(activeTodo(1L, user)));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "all", "priority", null);
 
@@ -809,7 +812,7 @@ class TodoServiceTest {
     ReflectionTestUtils.setField(todo, "id", 1L);
 
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosForUser(any())).willReturn(List.of(todo));
+    given(todoRepository.findAllActiveTodosForUser(any())).willReturn(List.of(todo));
 
     TodoListResponseDto dto = todoService.getTodos(1L, "all", "priority", null).get(0);
 


### PR DESCRIPTION
findActiveTodosForUser가 isCompleted=false를 강제해 all 필터가 실질적으로 미완료 전체만 반환했다. isCompleted 조건이 없는 findAllActiveTodosForUser를 추가해 all 필터가 완료/미완료 todo를 모두 반환하도록 수정.

## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #184 


## 변경 사항
findActiveTodosForUser가 isCompleted=false를 강제해 all 필터가 실질적으로 미완료 전체만 반환했다. isCompleted 조건이 없는 findAllActiveTodosForUser를 추가해 all 필터가 완료/미완료 todo를 모두 반환하도록 수정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 할 일 목록 조회 시 미완료 할 일을 우선적으로 표시하도록 개선했습니다.
  * 할 일 필터링 및 정렬 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->