### PR TITLE
Feat: 회원가입 시 기본 태그(Study/Project/Health/Other) 자동 생성

### DIFF
--- a/src/main/java/plana/replan/domain/auth/service/AuthService.java
+++ b/src/main/java/plana/replan/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import plana.replan.domain.auth.dto.NaverLoginRequestDto;
 import plana.replan.domain.auth.dto.OAuthLoginResponseDto;
 import plana.replan.domain.auth.dto.OAuthRegisterRequestDto;
 import plana.replan.domain.auth.dto.SignUpRequestDto;
+import plana.replan.domain.tag.service.TagService;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;
@@ -43,6 +44,7 @@ public class AuthService {
   private final GoogleIdTokenVerifier googleIdTokenVerifier;
   private final RestClient restClient;
   private final S3Service s3Service;
+  private final TagService tagService;
 
   @Transactional
   public void signUp(SignUpRequestDto request) {
@@ -66,6 +68,7 @@ public class AuthService {
             .build();
 
     userRepository.save(user);
+    tagService.createDefaultTags(user);
   }
 
   @Transactional(readOnly = true)
@@ -160,6 +163,7 @@ public class AuthService {
                 .provider(provider)
                 .profileImage(profileImageUrl)
                 .build());
+    tagService.createDefaultTags(user);
 
     // 6. tempToken 삭제
     redisTemplate.delete("oauth-temp:" + tempToken);

--- a/src/main/java/plana/replan/domain/tag/service/TagService.java
+++ b/src/main/java/plana/replan/domain/tag/service/TagService.java
@@ -25,6 +25,15 @@ public class TagService {
 
   private static final Pattern HEX_COLOR = Pattern.compile("^#[0-9A-Fa-f]{6}$");
 
+  private static final List<DefaultTag> DEFAULT_TAGS =
+      List.of(
+          new DefaultTag("Study", "#FFEBE7"),
+          new DefaultTag("Project", "#F9ECF8"),
+          new DefaultTag("Health", "#E4F5EE"),
+          new DefaultTag("Other", "#E5EDFF"));
+
+  private record DefaultTag(String title, String color) {}
+
   private final TagRepository tagRepository;
   private final UserRepository userRepository;
   private final TodoRepository todoRepository;
@@ -86,6 +95,21 @@ public class TagService {
 
     tag.update(request.getTitle(), request.getColor());
     return TagResponseDto.from(tag);
+  }
+
+  @Transactional
+  public void createDefaultTags(User user) {
+    List<Tag> tags =
+        DEFAULT_TAGS.stream()
+            .map(
+                defaultTag ->
+                    Tag.builder()
+                        .title(defaultTag.title())
+                        .color(defaultTag.color())
+                        .user(user)
+                        .build())
+            .toList();
+    tagRepository.saveAll(tags);
   }
 
   private void validateColor(String color) {

--- a/src/main/resources/db/migration/V13__add_default_tags_for_existing_users.sql
+++ b/src/main/resources/db/migration/V13__add_default_tags_for_existing_users.sql
@@ -1,0 +1,12 @@
+-- 프론트엔드 기본 태그(Study/Project/Health/Other)를 회원가입 시 자동 생성하도록 변경하면서,
+-- 이미 가입된 유저들에게도 동일한 기본 태그를 1회성으로 백필한다.
+INSERT INTO tag (title, color, user_id, created_at)
+SELECT v.title, v.color, u.id, CURRENT_TIMESTAMP
+FROM users u
+CROSS JOIN (VALUES
+    ('Study', '#FFEBE7'),
+    ('Project', '#F9ECF8'),
+    ('Health', '#E4F5EE'),
+    ('Other', '#E5EDFF')
+) AS v(title, color)
+WHERE u.deleted_at IS NULL;

--- a/src/main/resources/db/migration/V13__add_default_tags_for_existing_users.sql
+++ b/src/main/resources/db/migration/V13__add_default_tags_for_existing_users.sql
@@ -9,4 +9,10 @@ CROSS JOIN (VALUES
     ('Health', '#E4F5EE'),
     ('Other', '#E5EDFF')
 ) AS v(title, color)
-WHERE u.deleted_at IS NULL;
+WHERE u.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM tag t
+    WHERE t.user_id = u.id
+      AND t.title = v.title
+      AND t.deleted_at IS NULL
+  );

--- a/src/test/java/plana/replan/domain/auth/service/AuthServiceRegisterTest.java
+++ b/src/test/java/plana/replan/domain/auth/service/AuthServiceRegisterTest.java
@@ -26,6 +26,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestClient;
 import plana.replan.domain.auth.dto.LoginResponseDto;
 import plana.replan.domain.auth.dto.OAuthRegisterRequestDto;
+import plana.replan.domain.tag.service.TagService;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
 import plana.replan.domain.user.entity.User;
@@ -46,6 +47,7 @@ class AuthServiceRegisterTest {
   @Mock private GoogleIdTokenVerifier googleIdTokenVerifier;
   @Mock private RestClient restClient;
   @Mock private S3Service s3Service;
+  @Mock private TagService tagService;
 
   @InjectMocks private AuthService authService;
 


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #190 


## 변경 사항
> 
  1. TagService: DEFAULT_TAGS 상수(Study/Project/Health/Other + hex 색상)와 createDefaultTags(User) 메서드 추가 — 기존 Tag 빌더/TagRepository.saveAll
  재사용.
  2. AuthService: TagService 주입 후, signUp()과 OAuth register()에서 유저 저장 직후 createDefaultTags(user) 호출 (같은 @Transactional 안이라
  가입·태그생성이 원자적으로 묶임).
  3. V13__add_default_tags_for_existing_users.sql: 기존 가입 유저 전체에 4개 기본 태그 백필.
  4. AuthServiceRegisterTest에 TagService mock 추가.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 가입 시 기본 태그가 자동으로 생성되도록 개선했습니다.
  * 기존 활성 사용자에게도 기본 태그가 일괄 추가되도록 반영했습니다.

* **버그 수정**
  * 새로 가입한 사용자와 기존 사용자 간 태그 구성 차이를 줄여, 처음 접속 시 더 일관된 태그 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->