### PR TITLE
v0.16.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,9 @@ jobs:
             aws ssm get-parameter --name /replan/prod/REDIS_HOST --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_HOST={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env
-            
+            # Firebase 서비스 계정 키(JSON)는 공백·따옴표가 있어 xargs 대신 한 줄로 직접 기록한다.
+            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})" >> /home/ubuntu/app/.env
+
             # GitHub Secrets에서 ECR 정보 추가
             echo "ECR_REGISTRY=${{ secrets.ECR_REGISTRY }}" >> /home/ubuntu/app/.env
             echo "ECR_REPOSITORY=${{ secrets.ECR_REPOSITORY }}" >> /home/ubuntu/app/.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,13 @@ jobs:
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env
             # Firebase 서비스 계정 키(JSON)는 공백·따옴표가 있어 xargs 대신 한 줄로 직접 기록한다.
-            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})" >> /home/ubuntu/app/.env
+            # 조회 실패 시 빈 값이 들어가면 앱이 또 기동 실패(502)하므로, 비어 있으면 배포를 중단한다.
+            FIREBASE_SERVICE_ACCOUNT_JSON="$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})"
+            if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+              echo "FIREBASE_SERVICE_ACCOUNT_JSON 조회 실패 또는 빈 값 — 배포 중단" >&2
+              exit 1
+            fi
+            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$FIREBASE_SERVICE_ACCOUNT_JSON" >> /home/ubuntu/app/.env
 
             # GitHub Secrets에서 ECR 정보 추가
             echo "ECR_REGISTRY=${{ secrets.ECR_REGISTRY }}" >> /home/ubuntu/app/.env


### PR DESCRIPTION
## v0.16.1

알림 기능(v0.16.0)이 운영에서 Firebase 키 없이 기동 실패(502)하던 문제를 고칩니다.

- 배포 시 SSM의 `/replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON`(서비스 계정 키)을 읽어 서버 환경변수로 주입하도록 `deploy.yml`을 수정했습니다.
- 이제 앱이 FCM 초기화에 필요한 키를 받아 정상 기동합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 과정에서 Firebase 서비스 계정 정보가 함께 환경 설정 파일에 반영되도록 개선했습니다.
  * 운영 환경 배포 시 필요한 인증 정보가 더 안정적으로 설정되어, 관련 기능 사용 시 오류 가능성이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->