### PR TITLE
Fix: 운영 배포 Firebase 키 주입 (deploy.yml develop 동기화)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,9 @@ jobs:
             aws ssm get-parameter --name /replan/prod/REDIS_HOST --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_HOST={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env
-            
+            # Firebase 서비스 계정 키(JSON)는 공백·따옴표가 있어 xargs 대신 한 줄로 직접 기록한다.
+            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})" >> /home/ubuntu/app/.env
+
             # GitHub Secrets에서 ECR 정보 추가
             echo "ECR_REGISTRY=${{ secrets.ECR_REGISTRY }}" >> /home/ubuntu/app/.env
             echo "ECR_REPOSITORY=${{ secrets.ECR_REPOSITORY }}" >> /home/ubuntu/app/.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,13 @@ jobs:
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env
             # Firebase 서비스 계정 키(JSON)는 공백·따옴표가 있어 xargs 대신 한 줄로 직접 기록한다.
-            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})" >> /home/ubuntu/app/.env
+            # 조회 실패 시 빈 값이 들어가면 앱이 또 기동 실패(502)하므로, 비어 있으면 배포를 중단한다.
+            FIREBASE_SERVICE_ACCOUNT_JSON="$(aws ssm get-parameter --name /replan/prod/FIREBASE_SERVICE_ACCOUNT_JSON --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }})"
+            if [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+              echo "FIREBASE_SERVICE_ACCOUNT_JSON 조회 실패 또는 빈 값 — 배포 중단" >&2
+              exit 1
+            fi
+            printf 'FIREBASE_SERVICE_ACCOUNT_JSON=%s\n' "$FIREBASE_SERVICE_ACCOUNT_JSON" >> /home/ubuntu/app/.env
 
             # GitHub Secrets에서 ECR 정보 추가
             echo "ECR_REGISTRY=${{ secrets.ECR_REGISTRY }}" >> /home/ubuntu/app/.env


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련

## Related Issues
close #

## 변경 사항
운영 핫픽스(#197, main)로 먼저 들어간 `deploy.yml` 수정을 develop에도 동기화합니다.
- 배포 시 SSM의 Firebase 서비스 계정 키를 `.env`로 주입(JSON이라 직접 기록)
- 조회 실패 시 빈 값이 들어가면 배포를 즉시 중단하는 안전장치 포함
- main과 develop의 deploy.yml을 일치시켜 다음 릴리즈에서 어긋나지 않게 함

## 테스트 결과
운영(main)에서 이미 동일 변경으로 배포 성공 + 앱 정상 기동(health 200) 확인 완료.
