### PR TITLE
Feat: Todo 단건 수정 / 부모 루틴 전체 수정 API 분리

### DIFF
--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -392,6 +392,7 @@ public class ReplanService {
     effectiveRoutineDate = normalizeRoutineDate(effectiveType, effectiveRoutineDate);
     routine.update(
         op.title() != null ? op.title() : routine.getTitle(),
+        routine.getDueDate(),
         effectiveType,
         effectiveRoutineDate,
         op.dueTime() != null ? parseTime(op.dueTime()) : routine.getRoutineTime(),

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -12,12 +12,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
@@ -54,6 +56,15 @@ public class RoutineController implements RoutineControllerDocs {
       @Valid @RequestBody SubRoutineCreateRequestDto request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResult.ok(routineService.createChildRoutine(userId, parentId, request)));
+  }
+
+  @Override
+  @PutMapping("/{id}")
+  public ResponseEntity<ApiResult<RoutineResponseDto>> updateMotherRoutine(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long id,
+      @Valid @RequestBody RoutineUpdateRequestDto request) {
+    return ResponseEntity.ok(ApiResult.ok(routineService.updateMotherRoutine(userId, id, request)));
   }
 
   @Override

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
@@ -588,6 +589,248 @@ public interface RoutineControllerDocs {
                               """)))
           @RequestBody
           SubRoutineCreateRequestDto request);
+
+  @Operation(
+      summary = "엄마 루틴 수정",
+      description =
+          """
+          엄마 루틴의 스케줄, 제목, 태그, 종료일을 전체 수정합니다. goalId는 수정할 수 없습니다.
+
+          - 이미 생성된 과거/오늘 Todo row는 변경되지 않습니다. 미래에 생성될 Todo부터 새 값을 따라갑니다.
+          - 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET) — 하위 루틴 제목 변경은 `PATCH /api/routines/children/{id}` 사용.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          ---
+
+          ### Path Variable
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | id | ✅ 필수 | integer | 엄마 루틴 ID | `1` |
+
+          ---
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ✅ 필수 | string | 루틴 제목 | `"영어 단어 외우기"` |
+          | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
+          | dueDate | ❌ 선택 | string | 반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거 | `"2025-12-31T00:00:00"` |
+          | routineTime | ❌ 선택 | string | 반복되는 날의 마감 시각 (HH:mm:ss 형식). null이면 23:59:59로 처리 | `"09:00:00"` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1~일=64). MONTHLY: 일자 (1~31). DAILY: 불필요 | `21` |
+          | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `1` |
+
+          > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
+
+          ---
+
+          ### routineDate 규칙
+
+          | routineType | routineDate 의미 | 유효 범위 |
+          |-------------|-----------------|-----------|
+          | `DAILY` | 사용 안 함 (무시) | — |
+          | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
+          | `MONTHLY` | 반복할 일자 | 1 ~ 31 |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "수정 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "routineId": 1,
+                                "title": "영어 단어 외우기",
+                                "dueDate": "2025-12-31T00:00:00",
+                                "routineTime": "09:00:00",
+                                "routineType": "WEEKLY",
+                                "routineDate": 21,
+                                "tagId": 1,
+                                "tagTitle": "영어",
+                                "tagColor": "BLUE",
+                                "goalId": 2
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "400",
+        description = "입력값 오류 (title/routineType 누락, 또는 routineDate 범위 오류, 또는 하위 루틴 ID 사용)",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "title 누락",
+                      value =
+                          """
+                          {
+                            "status": 400,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "INVALID_INPUT",
+                              "message": "제목은 필수입니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "routineDate 범위 오류",
+                      value =
+                          """
+                          {
+                            "status": 400,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "ROUTINE_INVALID_DATE",
+                              "message": "유효하지 않은 반복 날짜입니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "하위 루틴 ID 사용",
+                      value =
+                          """
+                          {
+                            "status": 400,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "ROUTINE_INVALID_TARGET",
+                              "message": "이 API는 해당 루틴 종류(엄마/하위)에만 사용할 수 있습니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "루틴을 찾을 수 없거나 본인 소유가 아님, 또는 태그를 찾을 수 없음",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "루틴 없음",
+                      value =
+                          """
+                          {
+                            "status": 404,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "ROUTINE_NOT_FOUND",
+                              "message": "루틴을 찾을 수 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "태그 없음",
+                      value =
+                          """
+                          {
+                            "status": 404,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "TAG_NOT_FOUND",
+                              "message": "태그를 찾을 수 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<RoutineResponseDto>> updateMotherRoutine(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "엄마 루틴 ID", example = "1") @PathVariable Long id,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = "application/json",
+                      examples = {
+                        @ExampleObject(
+                            name = "WEEKLY — 전체 필드",
+                            value =
+                                """
+                                {
+                                  "title": "영어 단어 외우기",
+                                  "dueDate": "2025-12-31T00:00:00",
+                                  "routineTime": "09:00:00",
+                                  "routineType": "WEEKLY",
+                                  "routineDate": 21,
+                                  "tagId": 1
+                                }
+                                """),
+                        @ExampleObject(
+                            name = "DAILY — 필수 필드만",
+                            summary = "DAILY는 routineDate 불필요, optional 필드 생략",
+                            value =
+                                """
+                                {
+                                  "title": "아침 스트레칭",
+                                  "routineType": "DAILY"
+                                }
+                                """)
+                      }))
+          @RequestBody
+          RoutineUpdateRequestDto request);
 
   @Operation(
       summary = "엄마 루틴 삭제",

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
@@ -1,0 +1,37 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import plana.replan.domain.routine.entity.RoutineType;
+
+@Schema(description = "엄마 루틴 수정 요청 (goalId 수정 불가)")
+public record RoutineUpdateRequestDto(
+    @Schema(
+            description = "루틴 제목",
+            example = "영어 단어 외우기",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+    @Schema(
+            description = "반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거",
+            example = "2025-12-31T00:00:00")
+        LocalDateTime dueDate,
+    @Schema(
+            description = "반복 시각 (HH:mm:ss). 반복되는 날의 마감 시각. null이면 23:59:59로 처리",
+            example = "09:00:00")
+        LocalTime routineTime,
+    @Schema(
+            description = "반복 유형 (DAILY / WEEKLY / MONTHLY)",
+            example = "WEEKLY",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "반복 유형은 필수입니다.")
+        RoutineType routineType,
+    @Schema(
+            description =
+                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요.",
+            example = "21")
+        Integer routineDate,
+    @Schema(description = "태그 ID. null이면 태그 제거", example = "1") Long tagId) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
@@ -15,9 +15,7 @@ public record RoutineUpdateRequestDto(
             requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "제목은 필수입니다.")
         String title,
-    @Schema(
-            description = "반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거",
-            example = "2025-12-31T00:00:00")
+    @Schema(description = "반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거", example = "2025-12-31T00:00:00")
         LocalDateTime dueDate,
     @Schema(
             description = "반복 시각 (HH:mm:ss). 반복되는 날의 마감 시각. null이면 23:59:59로 처리",

--- a/src/main/java/plana/replan/domain/routine/entity/Routine.java
+++ b/src/main/java/plana/replan/domain/routine/entity/Routine.java
@@ -79,8 +79,14 @@ public class Routine extends BaseTimeEntity {
   }
 
   public void update(
-      String title, RoutineType routineType, Integer routineDate, LocalTime routineTime, Tag tag) {
+      String title,
+      LocalDateTime dueDate,
+      RoutineType routineType,
+      Integer routineDate,
+      LocalTime routineTime,
+      Tag tag) {
     this.title = requireNonBlank(title);
+    this.dueDate = dueDate;
     this.routineType = routineType;
     this.routineDate = routineDate;
     this.routineTime = routineTime;

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -141,8 +141,7 @@ public class RoutineService {
               .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
     }
 
-    Integer routineDate =
-        request.routineType() == RoutineType.DAILY ? null : request.routineDate();
+    Integer routineDate = request.routineType() == RoutineType.DAILY ? null : request.routineDate();
     routine.update(
         request.title(),
         request.dueDate(),

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -16,6 +16,7 @@ import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
@@ -120,6 +121,36 @@ public class RoutineService {
     motherTodo.ifPresent(mt -> attachChildTodoUnder(mt, child));
 
     return SubRoutineResponseDto.from(child);
+  }
+
+  /** 엄마 루틴 전체 수정. 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). goalId는 수정 불가. */
+  @Transactional
+  public RoutineResponseDto updateMotherRoutine(
+      Long userId, Long routineId, RoutineUpdateRequestDto request) {
+    Routine routine = findOwnedRoutine(userId, routineId);
+    if (routine.isChild()) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
+    }
+    validateRoutineDate(request.routineType(), request.routineDate());
+
+    Tag tag = null;
+    if (request.tagId() != null) {
+      tag =
+          tagRepository
+              .findById(request.tagId())
+              .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
+    }
+
+    Integer routineDate =
+        request.routineType() == RoutineType.DAILY ? null : request.routineDate();
+    routine.update(
+        request.title(),
+        request.dueDate(),
+        request.routineType(),
+        routineDate,
+        request.routineTime(),
+        tag);
+    return RoutineResponseDto.from(routine);
   }
 
   /** 하위 루틴 title 수정. 엄마 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -728,19 +728,22 @@ public interface TodoControllerDocs {
           | title | ❌ 선택 | string | 투두 제목. null이면 변경하지 않음. 빈 문자열 불가 | `"토익 단어 50개 외우기"` |
           | dueDate | ❌ 선택 | string | 마감 일시 (ISO 8601 형식). null이면 마감일 제거 | `"2025-12-31T23:59:59"` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `3` |
-          | routineType | ❌ 선택 | string | 반복 유형 (`DAILY`/`WEEKLY`/`MONTHLY`). null이면 반복 없음 | `"WEEKLY"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31). DAILY는 null | `5` |
+          | routineType | ❌ 선택 | string | 반복 유형 (`DAILY`/`WEEKLY`/`MONTHLY`). **이미 반복에 연결된 투두에는 무시됨** | `"WEEKLY"` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
+          | routineTime | ❌ 선택 | string | 반복 마감 시각 (HH:mm:ss). **이미 반복에 연결된 투두에는 무시됨** | `"09:00:00"` |
 
           ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
 
           **반복(routine) 처리 규칙**
 
+          `routineType`/`routineDate`/`routineTime`은 **해당 투두에 아직 연결된 Routine이 없을 때만** 새 Routine을 생성해 연결합니다.
+          이미 Routine이 연결되어 있다면 이 필드들은 무시됩니다 — 반복 시리즈 전체를 수정하려면 `PUT /api/routines/{id}`를 사용하세요.
+
           | 기존 상태 | routineType 값 | 동작 |
           |----------|---------------|------|
-          | 반복 있음 | `null` | 기존 루틴 삭제, 투두를 일반 투두로 변경 |
-          | 반복 있음 | 유형 값 | 기존 루틴의 유형·날짜·제목·태그 업데이트 |
           | 반복 없음 | `null` | 변경 없음 |
           | 반복 없음 | 유형 값 | 새 루틴 생성 후 투두에 연결 |
+          | 반복 있음 | 어떤 값이든 | **무시됨** — 기존 루틴 유지 (루틴 수정/삭제는 `PUT /api/routines/{id}` 또는 `DELETE /api/routines/{id}` 사용) |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -18,7 +18,6 @@ import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
 import plana.replan.domain.routine.repository.RoutineRepository;
-import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -50,7 +49,6 @@ public class TodoService {
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
   private final RoutineRepository routineRepository;
-  private final RoutineService routineService;
   private final GoalRepository goalRepository;
 
   @Transactional
@@ -267,10 +265,6 @@ public class TodoService {
       throw new CustomException(GlobalErrorCode.INVALID_INPUT);
     }
 
-    if (request.getRoutineType() != null) {
-      validateRoutineDate(request.getRoutineType(), request.getRoutineDate());
-    }
-
     if (request.getTitle() != null) {
       todo.updateTitle(request.getTitle());
     }
@@ -282,35 +276,25 @@ public class TodoService {
   }
 
   private void handleRoutineUpdate(Todo todo, TodoUpdateRequestDto request, Tag tag) {
-    Routine existingRoutine = todo.getRoutine();
-
-    if (request.getRoutineType() == null) {
-      if (existingRoutine != null) {
-        routineService.cascadeSoftDelete(existingRoutine);
-        todo.updateRoutine(null);
-      }
+    // 이미 반복에 연결된 Todo의 루틴 속성은 이 API에서 건드리지 않음.
+    // 반복 스케줄 전체를 바꾸려면 PUT /api/routines/{id} 사용.
+    if (todo.getRoutine() != null || request.getRoutineType() == null) {
       return;
     }
-
+    validateRoutineDate(request.getRoutineType(), request.getRoutineDate());
     Integer routineDate =
         request.getRoutineType() == RoutineType.DAILY ? null : request.getRoutineDate();
-
-    if (existingRoutine != null) {
-      existingRoutine.update(
-          todo.getTitle(), request.getRoutineType(), routineDate, request.getRoutineTime(), tag);
-    } else {
-      Routine newRoutine =
-          routineRepository.save(
-              Routine.builder()
-                  .title(todo.getTitle())
-                  .routineType(request.getRoutineType())
-                  .routineDate(routineDate)
-                  .routineTime(request.getRoutineTime())
-                  .user(todo.getUser())
-                  .tag(tag)
-                  .build());
-      todo.updateRoutine(newRoutine);
-    }
+    Routine newRoutine =
+        routineRepository.save(
+            Routine.builder()
+                .title(todo.getTitle())
+                .routineType(request.getRoutineType())
+                .routineDate(routineDate)
+                .routineTime(request.getRoutineTime())
+                .user(todo.getUser())
+                .tag(tag)
+                .build());
+    todo.updateRoutine(newRoutine);
   }
 
   private void validateRoutineDate(RoutineType routineType, Integer routineDate) {

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -355,7 +355,13 @@ class ReplanServiceTest {
 
     then(routine)
         .should()
-        .update(eq("영단어 50개 암기"), any(), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
+        .update(
+            eq("영단어 50개 암기"),
+            any(),
+            eq(RoutineType.WEEKLY),
+            eq(62),
+            eq(LocalTime.of(11, 15)),
+            any());
     then(routine).should().linkReplan(any(Replan.class));
     then(todo).should().linkReplan(any(Replan.class));
   }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -355,7 +355,7 @@ class ReplanServiceTest {
 
     then(routine)
         .should()
-        .update(eq("영단어 50개 암기"), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
+        .update(eq("영단어 50개 암기"), any(), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
     then(routine).should().linkReplan(any(Replan.class));
     then(todo).should().linkReplan(any(Replan.class));
   }
@@ -386,6 +386,7 @@ class ReplanServiceTest {
         .should()
         .update(
             eq("새 제목"),
+            any(),
             eq(RoutineType.DAILY),
             org.mockito.ArgumentMatchers.isNull(),
             eq(LocalTime.of(7, 30)),

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -296,5 +297,135 @@ class RoutineControllerTest {
                     """))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("USER_NOT_FOUND"));
+  }
+
+  // ========== updateMotherRoutine (PUT /api/routines/{id}) ==========
+
+  @Test
+  @DisplayName("인증 없이 엄마 루틴 수정 호출: 401 반환")
+  void updateMotherRoutine_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/routines/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "수정", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error.code").value("EMPTY_TOKEN"));
+  }
+
+  @Test
+  @DisplayName("엄마 루틴 수정 성공: status=200, 수정된 필드 반환")
+  void updateMotherRoutine_success() throws Exception {
+    LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
+    given(routineService.updateMotherRoutine(any(), any(), any()))
+        .willReturn(
+            new RoutineResponseDto(
+                1L, "수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L, "영어", "BLUE", null));
+
+    mockMvc
+        .perform(
+            put("/api/routines/1")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "title": "수정된 루틴",
+                      "dueDate": "2025-12-31T00:00:00",
+                      "routineType": "WEEKLY",
+                      "routineDate": 21,
+                      "tagId": 5
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.title").value("수정된 루틴"))
+        .andExpect(jsonPath("$.data.routineType").value("WEEKLY"))
+        .andExpect(jsonPath("$.data.routineDate").value(21))
+        .andExpect(jsonPath("$.data.tagId").value(5))
+        .andExpect(jsonPath("$.error").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("하위 루틴 ID로 수정 시도: status=400, error.code=ROUTINE_INVALID_TARGET")
+  void updateMotherRoutine_childRoutine_throws() throws Exception {
+    willThrow(new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET))
+        .given(routineService)
+        .updateMotherRoutine(any(), any(), any());
+
+    mockMvc
+        .perform(
+            put("/api/routines/11")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "수정", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("ROUTINE_INVALID_TARGET"));
+  }
+
+  @Test
+  @DisplayName("routineDate 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
+  void updateMotherRoutine_invalidRoutineDate() throws Exception {
+    willThrow(new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE))
+        .given(routineService)
+        .updateMotherRoutine(any(), any(), any());
+
+    mockMvc
+        .perform(
+            put("/api/routines/1")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "수정", "routineType": "WEEKLY", "routineDate": 128 }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("ROUTINE_INVALID_DATE"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 tagId: status=404, error.code=TAG_NOT_FOUND")
+  void updateMotherRoutine_tagNotFound() throws Exception {
+    willThrow(new CustomException(TagErrorCode.TAG_NOT_FOUND))
+        .given(routineService)
+        .updateMotherRoutine(any(), any(), any());
+
+    mockMvc
+        .perform(
+            put("/api/routines/1")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "수정", "routineType": "DAILY", "tagId": 999 }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("TAG_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("루틴을 찾을 수 없음: status=404, error.code=ROUTINE_NOT_FOUND")
+  void updateMotherRoutine_routineNotFound() throws Exception {
+    willThrow(new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND))
+        .given(routineService)
+        .updateMotherRoutine(any(), any(), any());
+
+    mockMvc
+        .perform(
+            put("/api/routines/999")
+                .with(authentication(authToken(1L)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    { "title": "수정", "routineType": "DAILY" }
+                    """))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("ROUTINE_NOT_FOUND"));
   }
 }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -27,6 +27,7 @@ import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
+import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
@@ -583,6 +584,124 @@ class RoutineServiceTest {
     verify(todoRepository).saveAndFlush(captor.capture());
     assertThat(captor.getValue().getDueDate())
         .isEqualTo(LocalDate.of(2024, 1, 16).atTime(23, 59, 59));
+  }
+
+  // ========== updateMotherRoutine ==========
+
+  private Routine motherRoutine() {
+    Routine r = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(r, "id", 10L);
+    return r;
+  }
+
+  @Test
+  void 엄마루틴_수정_DAILY_성공_필수필드만() {
+    Routine routine = motherRoutine();
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+
+    RoutineResponseDto result =
+        routineService.updateMotherRoutine(
+            1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
+
+    assertThat(result.getTitle()).isEqualTo("수정된 루틴");
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
+    assertThat(result.getRoutineDate()).isNull();
+    assertThat(result.getDueDate()).isNull();
+    assertThat(result.getTagId()).isNull();
+  }
+
+  @Test
+  void 엄마루틴_수정_WEEKLY_전체필드() {
+    Routine routine = motherRoutine();
+    LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+    given(tagRepository.findById(5L)).willReturn(Optional.of(testTag(5L)));
+
+    RoutineResponseDto result =
+        routineService.updateMotherRoutine(
+            1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L));
+
+    assertThat(result.getTitle()).isEqualTo("수정된 루틴");
+    assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
+    assertThat(result.getRoutineDate()).isEqualTo(21);
+    assertThat(result.getDueDate()).isEqualTo(dueDate);
+    assertThat(result.getTagId()).isEqualTo(5L);
+  }
+
+  @Test
+  void 엄마루틴_수정_하위루틴_ID_전달_400() {
+    User user = testUser();
+    Routine parent = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(parent, "id", 10L);
+    Routine child = Routine.builder().title("하위").user(user).parent(parent).build();
+    ReflectionTestUtils.setField(child, "id", 11L);
+    given(routineRepository.findById(11L)).willReturn(Optional.of(child));
+
+    assertThatThrownBy(
+            () ->
+                routineService.updateMotherRoutine(
+                    1L,
+                    11L,
+                    new RoutineUpdateRequestDto("수정", null, null, RoutineType.DAILY, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_TARGET));
+  }
+
+  @Test
+  void 엄마루틴_수정_routineDate_범위오류_400() {
+    Routine routine = motherRoutine();
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+
+    assertThatThrownBy(
+            () ->
+                routineService.updateMotherRoutine(
+                    1L,
+                    10L,
+                    new RoutineUpdateRequestDto("수정", null, null, RoutineType.WEEKLY, 128, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
+  }
+
+  @Test
+  void 엄마루틴_수정_존재하지않는_tagId_404() {
+    Routine routine = motherRoutine();
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+    given(tagRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                routineService.updateMotherRoutine(
+                    1L,
+                    10L,
+                    new RoutineUpdateRequestDto("수정", null, null, RoutineType.DAILY, null, 999L)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TagErrorCode.TAG_NOT_FOUND));
+  }
+
+  @Test
+  void 엄마루틴_수정_루틴없음_404() {
+    given(routineRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                routineService.updateMotherRoutine(
+                    1L,
+                    999L,
+                    new RoutineUpdateRequestDto("수정", null, null, RoutineType.DAILY, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -601,7 +601,9 @@ class RoutineServiceTest {
 
     RoutineResponseDto result =
         routineService.updateMotherRoutine(
-            1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
+            1L,
+            10L,
+            new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
 
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
@@ -619,7 +621,9 @@ class RoutineServiceTest {
 
     RoutineResponseDto result =
         routineService.updateMotherRoutine(
-            1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L));
+            1L,
+            10L,
+            new RoutineUpdateRequestDto("수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L));
 
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -58,7 +58,6 @@ class TodoServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private TagRepository tagRepository;
   @Mock private RoutineRepository routineRepository;
-  @Mock private plana.replan.domain.routine.service.RoutineService routineService;
 
   @InjectMocks private TodoService todoService;
 
@@ -1632,8 +1631,8 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음 + routineType=null: 루틴 soft delete, todo.routine=null")
-  void updateTodo_success_removeRoutine() {
+  @DisplayName("updateTodo - 루틴 있음 + routineType=null: 루틴 무시, 기존 routine 연결 그대로 유지")
+  void updateTodo_success_existingRoutine_nullTypeIgnored() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
     Routine routine = testRoutine(user, RoutineType.DAILY);
@@ -1644,13 +1643,13 @@ class TodoServiceTest {
     TodoDetailResponseDto result =
         todoService.updateTodo(1L, 1L, updateTodoRequest("제목", null, null, null, null));
 
-    verify(routineService).cascadeSoftDelete(routine);
-    assertThat(result.getRoutineType()).isNull();
+    assertThat(result.getRoutineType()).isEqualTo("DAILY");
+    verify(routineRepository, never()).save(any());
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음 + 유형 변경 (DAILY→WEEKLY): 기존 루틴 업데이트")
-  void updateTodo_success_changeRoutineType() {
+  @DisplayName("updateTodo - 루틴 있음 + routineType 변경 시도: 무시, 기존 루틴 그대로 유지")
+  void updateTodo_success_existingRoutine_typeChangeIgnored() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
     Routine routine = testRoutine(user, RoutineType.DAILY);
@@ -1662,10 +1661,10 @@ class TodoServiceTest {
         todoService.updateTodo(
             1L, 1L, updateTodoRequest("수정된 제목", null, null, RoutineType.WEEKLY, 5));
 
-    assertThat(routine.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
-    assertThat(routine.getRoutineDate()).isEqualTo(5);
-    assertThat(routine.getTitle()).isEqualTo("수정된 제목");
-    assertThat(result.getRoutineType()).isEqualTo("WEEKLY");
+    assertThat(routine.getRoutineType()).isEqualTo(RoutineType.DAILY);
+    assertThat(routine.getRoutineDate()).isNull();
+    assertThat(routine.getTitle()).isEqualTo("루틴");
+    assertThat(result.getRoutineType()).isEqualTo("DAILY");
     verify(routineRepository, never()).save(any());
   }
 


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #192


## 변경 사항
> 
- PUT /api/routines/{id} 신규 엔드포인트 추가 (부모 루틴 수정)
- TodoService.updateTodo: 이미 루틴이 연결된 Todo는 routine 필드를 무시하도록 변경 (루틴 없는 Todo에 routineType 전달 시 새 루틴 생성·연결 기능은 유지)


## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 루틴 수정 API가 추가되어, 제목·마감일·반복 설정·태그를 한 번에 변경할 수 있습니다.
  * API 문서가 함께 보강되어 요청/응답 예시와 오류 코드가 안내됩니다.

* **Bug Fixes**
  * 루틴 수정 시 마감일이 누락되지 않도록 반영되었습니다.
  * 투두에 이미 연결된 루틴은 수정 요청의 반복 정보에 의해 변경되지 않도록 동작이 정리되었습니다.

* **Tests**
  * 루틴 및 투두 수정 관련 성공/실패 시나리오 검증이 추가·갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->