### PR TITLE
Feat: 루틴 날짜 조회 filter 지원 및 todoId 응답 추가

### DIFF
--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -3,6 +3,7 @@ package plana.replan.domain.routine.controller;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,9 +36,12 @@ public class RoutineController implements RoutineControllerDocs {
 
   @Override
   @GetMapping
-  public ResponseEntity<ApiResult<List<RoutineResponseDto>>> getRoutinesByDate(
-      @AuthenticationPrincipal Long userId, @RequestParam LocalDate date) {
-    return ResponseEntity.ok(ApiResult.ok(routineService.getRoutinesByDate(userId, date)));
+  public ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getRoutinesByFilter(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(defaultValue = "day") String filter,
+      @RequestParam LocalDate date) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineService.getRoutinesByFilter(userId, filter, date)));
   }
 
   @Override

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -59,7 +59,7 @@ public interface RoutineControllerDocs {
           **filter 범위 기준**
           - `day`: date 당일 1일치
           - `week`: date 포함 7일 (date ~ date+6)
-          - `month`: date 포함 ~30일 (date ~ date+1개월-1일)
+          - `month`: date부터 정확히 1개월 전날까지 (28~31일, 시작 월에 따라 다름)
 
           ---
 

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,16 +28,16 @@ import plana.replan.global.common.ApiResult;
 public interface RoutineControllerDocs {
 
   @Operation(
-      summary = "날짜별 루틴 조회",
+      summary = "루틴 조회 (날짜 / 주간 / 월간)",
       description =
           """
-          특정 날짜에 해당하는 루틴 목록을 반환합니다.
+          `filter`와 `date`를 기준으로 해당 기간의 루틴 목록을 날짜별로 묶어 반환합니다.
 
-          - `DAILY` 루틴: 항상 포함
-          - `WEEKLY` 루틴: 해당 날짜의 요일이 `routineDate` 비트마스크에 포함된 경우 반환
-          - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDate`와 일치하는 경우 반환
+          - `DAILY` 루틴: 기간 내 모든 날짜에 포함
+          - `WEEKLY` 루틴: 해당 날짜의 요일이 `routineDate` 비트마스크에 포함된 날짜에만 포함
+          - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDate`와 일치하는 날짜에만 포함
 
-          미래 날짜도 조회 가능합니다. 오늘 이후 날짜는 아직 Todo가 생성되지 않았을 수 있으므로, 이 API로 루틴 정보를 확인하세요.
+          각 루틴에 해당 날짜의 Todo가 이미 생성되어 있으면 `todoId`가 포함되고, 아직 없으면 `null`입니다.
 
           ---
 
@@ -50,13 +51,21 @@ public interface RoutineControllerDocs {
 
           ### Query Parameters
 
-          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
-          |-----------|-----------|------|------|------|
-          | date | ✅ 필수 | string | 조회할 날짜 (yyyy-MM-dd 형식) | `2025-06-20` |
+          | 파라미터명 | 필수 여부 | 타입 | 기본값 | 설명 | 예시 |
+          |-----------|-----------|------|--------|------|------|
+          | filter | ❌ 선택 | string | `day` | 조회 범위 (`day` / `week` / `month`) | `week` |
+          | date | ✅ 필수 | string | 없음 | 기준 시작 날짜 (yyyy-MM-dd 형식) | `2025-06-20` |
+
+          **filter 범위 기준**
+          - `day`: date 당일 1일치
+          - `week`: date 포함 7일 (date ~ date+6)
+          - `month`: date 포함 ~30일 (date ~ date+1개월-1일)
 
           ---
 
           ### Response Elements
+
+          응답 `data`는 날짜(yyyy-MM-dd)를 키로 하는 객체이며, 값은 해당 날짜의 루틴 배열입니다.
 
           | 필드명 | 타입 | 설명 |
           |--------|------|------|
@@ -70,6 +79,7 @@ public interface RoutineControllerDocs {
           | tagTitle | string | 태그 제목. 없으면 null |
           | tagColor | string | 태그 색상. 없으면 null |
           | goalId | integer | 목표 ID. 없으면 null |
+          | todoId | integer | 해당 날짜에 생성된 Todo ID. 아직 생성 안 됐으면 null |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
@@ -85,38 +95,57 @@ public interface RoutineControllerDocs {
                             {
                               "status": 200,
                               "success": true,
-                              "data": [
-                                {
-                                  "routineId": 1,
-                                  "title": "아침 스트레칭",
-                                  "dueDate": null,
-                                  "routineTime": "08:00:00",
-                                  "routineType": "DAILY",
-                                  "routineDate": null,
-                                  "tagId": null,
-                                  "tagTitle": null,
-                                  "tagColor": null,
-                                  "goalId": null
-                                },
-                                {
-                                  "routineId": 2,
-                                  "title": "영어 단어 외우기",
-                                  "dueDate": "2025-12-31T00:00:00",
-                                  "routineTime": "09:00:00",
-                                  "routineType": "WEEKLY",
-                                  "routineDate": 21,
-                                  "tagId": 3,
-                                  "tagTitle": "영어",
-                                  "tagColor": "BLUE",
-                                  "goalId": 2
-                                }
-                              ],
+                              "data": {
+                                "2025-06-20": [
+                                  {
+                                    "routineId": 1,
+                                    "title": "아침 스트레칭",
+                                    "dueDate": null,
+                                    "routineTime": "08:00:00",
+                                    "routineType": "DAILY",
+                                    "routineDate": null,
+                                    "tagId": null,
+                                    "tagTitle": null,
+                                    "tagColor": null,
+                                    "goalId": null,
+                                    "todoId": 42
+                                  }
+                                ],
+                                "2025-06-21": [
+                                  {
+                                    "routineId": 1,
+                                    "title": "아침 스트레칭",
+                                    "dueDate": null,
+                                    "routineTime": "08:00:00",
+                                    "routineType": "DAILY",
+                                    "routineDate": null,
+                                    "tagId": null,
+                                    "tagTitle": null,
+                                    "tagColor": null,
+                                    "goalId": null,
+                                    "todoId": null
+                                  },
+                                  {
+                                    "routineId": 2,
+                                    "title": "영어 단어 외우기",
+                                    "dueDate": "2025-12-31T00:00:00",
+                                    "routineTime": "09:00:00",
+                                    "routineType": "WEEKLY",
+                                    "routineDate": 21,
+                                    "tagId": 3,
+                                    "tagTitle": "영어",
+                                    "tagColor": "BLUE",
+                                    "goalId": 2,
+                                    "todoId": 43
+                                  }
+                                ]
+                              },
                               "error": null
                             }
                             """))),
     @ApiResponse(
         responseCode = "400",
-        description = "date 파라미터 누락 또는 형식 오류",
+        description = "date 파라미터 누락·형식 오류 또는 filter 값 오류",
         content =
             @Content(
                 examples =
@@ -192,9 +221,12 @@ public interface RoutineControllerDocs {
                             }
                             """)))
   })
-  ResponseEntity<ApiResult<List<RoutineResponseDto>>> getRoutinesByDate(
+  ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getRoutinesByFilter(
       @AuthenticationPrincipal Long userId,
-      @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-06-20") @RequestParam
+      @Parameter(description = "조회 범위 (day / week / month)", example = "week")
+          @RequestParam(defaultValue = "day")
+          String filter,
+      @Parameter(description = "기준 시작 날짜 (yyyy-MM-dd)", example = "2025-06-20") @RequestParam
           LocalDate date);
 
   @Operation(

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
@@ -23,4 +23,6 @@ public interface RoutineDateProjection {
   String getTagColor();
 
   Long getGoalId();
+
+  Long getTodoId();
 }

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -21,6 +21,7 @@ public class RoutineResponseDto {
   private String tagTitle;
   private String tagColor;
   private Long goalId;
+  private Long todoId;
 
   public static RoutineResponseDto from(Routine routine) {
     return new RoutineResponseDto(
@@ -33,7 +34,8 @@ public class RoutineResponseDto {
         routine.getTag() != null ? routine.getTag().getId() : null,
         routine.getTag() != null ? routine.getTag().getTitle() : null,
         routine.getTag() != null ? routine.getTag().getColor() : null,
-        routine.getGoal() != null ? routine.getGoal().getId() : null);
+        routine.getGoal() != null ? routine.getGoal().getId() : null,
+        null);
   }
 
   public static RoutineResponseDto from(RoutineDateProjection p) {
@@ -47,6 +49,7 @@ public class RoutineResponseDto {
         p.getTagId(),
         p.getTagTitle(),
         p.getTagColor(),
-        p.getGoalId());
+        p.getGoalId(),
+        p.getTodoId());
   }
 }

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -1,5 +1,6 @@
 package plana.replan.domain.routine.repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -39,9 +40,14 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
                  t.id           AS tagId,
                  t.title        AS tagTitle,
                  t.color        AS tagColor,
-                 r.goal_id      AS goalId
+                 r.goal_id      AS goalId,
+                 td.id          AS todoId
           FROM routine r
           LEFT JOIN tag t ON r.tag_id = t.id AND t.deleted_at IS NULL
+          LEFT JOIN todo td ON td.routine_id = r.id
+                            AND td.deleted_at IS NULL
+                            AND td.parent_id IS NULL
+                            AND CAST(td.due_date AS date) = :targetDate
           WHERE r.user_id = :userId
             AND r.deleted_at IS NULL
             AND r.parent_id IS NULL
@@ -54,5 +60,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
   List<RoutineDateProjection> findMotherRoutinesByDate(
       @Param("userId") Long userId,
       @Param("dayBit") int dayBit,
-      @Param("dayOfMonth") int dayOfMonth);
+      @Param("dayOfMonth") int dayOfMonth,
+      @Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -4,7 +4,9 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.global.exception.GlobalErrorCode;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
@@ -165,7 +168,8 @@ public class RoutineService {
   }
 
   @Transactional(readOnly = true)
-  public List<RoutineResponseDto> getRoutinesByDate(Long userId, LocalDate date) {
+  public Map<String, List<RoutineResponseDto>> getRoutinesByFilter(
+      Long userId, String filter, LocalDate date) {
     if (userId == null) {
       throw new CustomException(UserErrorCode.USER_NOT_FOUND);
     }
@@ -173,11 +177,26 @@ public class RoutineService {
         .findById(userId)
         .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
+    List<LocalDate> dates =
+        switch (filter.toLowerCase()) {
+          case "day" -> List.of(date);
+          case "week" -> date.datesUntil(date.plusWeeks(1)).collect(Collectors.toList());
+          case "month" -> date.datesUntil(date.plusMonths(1)).collect(Collectors.toList());
+          default -> throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+        };
+
+    Map<String, List<RoutineResponseDto>> result = new LinkedHashMap<>();
+    for (LocalDate d : dates) {
+      result.put(d.toString(), getRoutinesForDate(userId, d));
+    }
+    return result;
+  }
+
+  private List<RoutineResponseDto> getRoutinesForDate(Long userId, LocalDate date) {
     int dayBit = 1 << (date.getDayOfWeek().getValue() - 1);
     int dayOfMonth = date.getDayOfMonth();
-
-    return routineRepository.findMotherRoutinesByDate(userId, dayBit, dayOfMonth).stream()
-        .map(p -> RoutineResponseDto.from(p))
+    return routineRepository.findMotherRoutinesByDate(userId, dayBit, dayOfMonth, date).stream()
+        .map(RoutineResponseDto::from)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -25,7 +25,6 @@ import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
-import plana.replan.global.exception.GlobalErrorCode;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
@@ -36,6 +35,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -323,7 +323,7 @@ class RoutineControllerTest {
     given(routineService.updateMotherRoutine(any(), any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                1L, "수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L, "영어", "BLUE", null));
+                1L, "수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L, "영어", "BLUE", null, null));
 
     mockMvc
         .perform(

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -71,7 +71,7 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                1L, "아침 스트레칭", null, null, RoutineType.DAILY, null, null, null, null, null));
+                1L, "아침 스트레칭", null, null, RoutineType.DAILY, null, null, null, null, null, null));
 
     mockMvc
         .perform(
@@ -100,7 +100,7 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                2L, "영어 단어", dueDate, null, RoutineType.WEEKLY, 21, 5L, null, null, 2L));
+                2L, "영어 단어", dueDate, null, RoutineType.WEEKLY, 21, 5L, null, null, 2L, null));
 
     mockMvc
         .perform(
@@ -134,7 +134,7 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                3L, "월간 회고", null, null, RoutineType.MONTHLY, 15, null, null, null, null));
+                3L, "월간 회고", null, null, RoutineType.MONTHLY, 15, null, null, null, null, null));
 
     mockMvc
         .perform(


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #200


## 변경 사항
>
- GET /api/routines에 filter=day|week|month 파라미터 추가 단일 날짜 대신 기간별 조회로 클라이언트 API 호출 횟수 감소
- 응답 구조를 날짜 키 Map<String, List<RoutineResponseDto>>로 변경
- 루틴 조회 시 해당 날짜에 생성된 Todo가 있으면 todoId 반환, 없으면 null



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 루틴 조회가 날짜별 단일 목록에서 **일/주/월 기준 묶음 응답**으로 확장되었습니다.
  * 응답에 **날짜 키별 루틴 목록**과 함께 **추가 식별 정보(todoId)**가 포함됩니다.
* **Bug Fixes**
  * 선택한 기준(일/주/월)에 맞춰 조회 범위가 더 정확하게 반영됩니다.
  * 지원하지 않는 조회 필터 입력 시 오류가 반환됩니다.
* **Documentation**
  * 루틴 조회 API 안내가 **filter(day/week/month)** 및 **응답 형식(날짜 키 기반 맵)**에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->