### PR TITLE
Feat: 투두 상세 조회 응답에 routineDate 필드 추가

### DIFF
--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -768,6 +768,7 @@ public interface TodoControllerDocs {
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
                                 "routineType": "WEEKLY",
+                                "routineDate": 5,
                                 "subTodos": []
                               },
                               "error": null
@@ -933,6 +934,7 @@ public interface TodoControllerDocs {
 
           **반환 필드**
           - `routineType`: 루틴에 연결된 투두인 경우 `DAILY` / `WEEKLY` / `MONTHLY`, 일반 투두는 `null`
+          - `routineDate`: WEEKLY이면 요일 비트마스크(1-127), MONTHLY이면 일자(1-31), DAILY 또는 루틴 없으면 `null`
           - `tagId`, `tagTitle`, `tagColor`: 태그가 없으면 모두 `null`
           - `subTodos`: 하위 투두 목록 (없으면 빈 배열)
           """,
@@ -959,6 +961,7 @@ public interface TodoControllerDocs {
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
                                 "routineType": "DAILY",
+                                "routineDate": null,
                                 "subTodos": [
                                   {
                                     "todoId": 10,

--- a/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
@@ -41,8 +41,7 @@ public class TodoDetailResponseDto {
   private String routineType;
 
   @Schema(
-      description =
-          "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31 일자, DAILY 또는 반복 없으면 null)",
+      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31 일자, DAILY 또는 반복 없으면 null)",
       example = "5")
   private Integer routineDate;
 

--- a/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
@@ -40,6 +40,12 @@ public class TodoDetailResponseDto {
   @Schema(description = "반복 유형 (DAILY/WEEKLY/MONTHLY, 반복 아니면 null)", example = "DAILY")
   private String routineType;
 
+  @Schema(
+      description =
+          "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31 일자, DAILY 또는 반복 없으면 null)",
+      example = "5")
+  private Integer routineDate;
+
   @Schema(description = "하위 투두 목록")
   private List<SubTodoDto> subTodos;
 
@@ -78,6 +84,7 @@ public class TodoDetailResponseDto {
         routine != null && routine.getRoutineType() != null
             ? routine.getRoutineType().name()
             : null,
+        routine != null ? routine.getRoutineDate() : null,
         subTodos);
   }
 }

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -548,6 +548,7 @@ class TodoControllerTest {
             "영어",
             "BLUE",
             "DAILY",
+            null,
             List.of(new SubTodoDto(10L, "챕터 1 읽기", false)));
 
     given(todoService.getTodoDetail(any(), any())).willReturn(response);
@@ -978,7 +979,7 @@ class TodoControllerTest {
   @DisplayName("투두 수정 성공: status=200, TodoDetailResponseDto 반환")
   void updateTodo_success() throws Exception {
     TodoDetailResponseDto response =
-        new TodoDetailResponseDto(1L, "수정된 제목", null, false, 3L, "영어", "BLUE", "WEEKLY", List.of());
+        new TodoDetailResponseDto(1L, "수정된 제목", null, false, 3L, "영어", "BLUE", "WEEKLY", 5, List.of());
 
     given(todoService.updateTodo(any(), any(), any())).willReturn(response);
 
@@ -1008,7 +1009,7 @@ class TodoControllerTest {
   @DisplayName("title 생략: status=200 (title은 선택 필드)")
   void updateTodo_omitTitle_ok() throws Exception {
     TodoDetailResponseDto response =
-        new TodoDetailResponseDto(1L, "기존 제목", null, false, null, null, null, null, List.of());
+        new TodoDetailResponseDto(1L, "기존 제목", null, false, null, null, null, null, null, List.of());
     given(todoService.updateTodo(any(), any(), any())).willReturn(response);
 
     mockMvc

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -979,7 +979,8 @@ class TodoControllerTest {
   @DisplayName("투두 수정 성공: status=200, TodoDetailResponseDto 반환")
   void updateTodo_success() throws Exception {
     TodoDetailResponseDto response =
-        new TodoDetailResponseDto(1L, "수정된 제목", null, false, 3L, "영어", "BLUE", "WEEKLY", 5, List.of());
+        new TodoDetailResponseDto(
+            1L, "수정된 제목", null, false, 3L, "영어", "BLUE", "WEEKLY", 5, List.of());
 
     given(todoService.updateTodo(any(), any(), any())).willReturn(response);
 
@@ -1009,7 +1010,8 @@ class TodoControllerTest {
   @DisplayName("title 생략: status=200 (title은 선택 필드)")
   void updateTodo_omitTitle_ok() throws Exception {
     TodoDetailResponseDto response =
-        new TodoDetailResponseDto(1L, "기존 제목", null, false, null, null, null, null, null, List.of());
+        new TodoDetailResponseDto(
+            1L, "기존 제목", null, false, null, null, null, null, null, List.of());
     given(todoService.updateTodo(any(), any(), any())).willReturn(response);
 
     mockMvc


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #202 


## 변경 사항
>
TodoDetailResponseDto.java
- routineDate (Integer) 필드 추가 — @Schema description 포함
- from() 팩토리 메서드에서 routine != null ? routine.getRoutineDate() : null 로 값 채움

TodoControllerDocs.java
- getTodoDetail description에 routineDate 반환 필드 설명 추가
- getTodoDetail 200 response example에 "routineDate": null 추가 (DAILY 예시이므로 null)
- updateTodo 200 response example에 "routineDate": 5 추가 (WEEKLY 예시이므로 비트마스크 값)
