### PR TITLE
v0.16.3

### DIFF
--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -27,6 +27,9 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
   @EntityGraph(attributePaths = "children")
   Optional<Routine> findWithChildrenById(Long id);
 
+  @Query("SELECT r FROM Routine r WHERE r.parent IS NULL")
+  List<Routine> findAllActiveMotherRoutines();
+
   @Query(
       nativeQuery = true,
       value =

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -27,7 +27,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
   @EntityGraph(attributePaths = "children")
   Optional<Routine> findWithChildrenById(Long id);
 
-  @Query("SELECT r FROM Routine r WHERE r.parent IS NULL")
+  @Query("SELECT r FROM Routine r WHERE r.parent IS NULL AND r.deletedAt IS NULL")
   List<Routine> findAllActiveMotherRoutines();
 
   @Query(

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -263,8 +263,7 @@ public class RoutineService {
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {
     return switch (routine.getRoutineType()) {
       case DAILY -> true;
-      case WEEKLY ->
-          (routine.getRoutineDate() & (1 << (today.getDayOfWeek().getValue() - 1))) != 0;
+      case WEEKLY -> (routine.getRoutineDate() & (1 << (today.getDayOfWeek().getValue() - 1))) != 0;
       case MONTHLY -> routine.getRoutineDate().equals(today.getDayOfMonth());
     };
   }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -254,12 +254,19 @@ public class RoutineService {
 
   @Transactional
   public void generateDailyTodos() {
-    LocalDate yesterday = LocalDate.now(clock).minusDays(1);
-    LocalDateTime start = yesterday.atStartOfDay();
-    LocalDateTime end = yesterday.atTime(23, 59, 59);
-    todoRepository
-        .findMotherRoutineTodosForRollover(start, end)
-        .forEach(todo -> createTodoTreeFromMother(todo.getRoutine()));
+    LocalDate today = LocalDate.now(clock);
+    routineRepository.findAllActiveMotherRoutines().stream()
+        .filter(r -> isOccurrenceDay(r, today))
+        .forEach(this::createTodoTreeFromMother);
+  }
+
+  private boolean isOccurrenceDay(Routine routine, LocalDate today) {
+    return switch (routine.getRoutineType()) {
+      case DAILY -> true;
+      case WEEKLY ->
+          (routine.getRoutineDate() & (1 << (today.getDayOfWeek().getValue() - 1))) != 0;
+      case MONTHLY -> routine.getRoutineDate().equals(today.getDayOfMonth());
+    };
   }
 
   /**

--- a/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
@@ -9,7 +9,8 @@ import plana.replan.global.exception.ErrorCode;
 public enum TodoErrorCode implements ErrorCode {
   TODO_NOT_FOUND(404, "투두를 찾을 수 없습니다."),
   INVALID_FILTER(400, "유효하지 않은 필터 값입니다. (all, day, week, month 중 하나)"),
-  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)");
+  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)"),
+  ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED(400, "루틴 투두의 마감일은 변경할 수 없습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
@@ -9,8 +9,7 @@ import plana.replan.global.exception.ErrorCode;
 public enum TodoErrorCode implements ErrorCode {
   TODO_NOT_FOUND(404, "투두를 찾을 수 없습니다."),
   INVALID_FILTER(400, "유효하지 않은 필터 값입니다. (all, day, week, month 중 하나)"),
-  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)"),
-  ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED(400, "루틴 투두의 마감일은 변경할 수 없습니다.");
+  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -29,14 +29,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   List<Todo> findAllByRoutine(Routine routine);
 
   @Query(
-      "SELECT t FROM Todo t JOIN t.routine r"
-          + " WHERE t.parent IS NULL"
-          + " AND t.dueDate BETWEEN :start AND :end"
-          + " AND r.deletedAt IS NULL")
-  List<Todo> findMotherRoutineTodosForRollover(
-      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
-
-  @Query(
       "SELECT t FROM Todo t"
           + " WHERE t.routine = :routine"
           + " AND t.parent IS NULL"

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -268,10 +268,9 @@ public class TodoService {
     if (request.getTitle() != null) {
       todo.updateTitle(request.getTitle());
     }
-    if (todo.getRoutine() != null && request.getDueDate() != null) {
-      throw new CustomException(TodoErrorCode.ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED);
+    if (todo.getRoutine() == null) {
+      todo.updateDueDate(request.getDueDate());
     }
-    todo.updateDueDate(request.getDueDate());
     todo.updateTag(tag);
     handleRoutineUpdate(todo, request, tag);
 

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -268,6 +268,9 @@ public class TodoService {
     if (request.getTitle() != null) {
       todo.updateTitle(request.getTitle());
     }
+    if (todo.getRoutine() != null && request.getDueDate() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED);
+    }
     todo.updateDueDate(request.getDueDate());
     todo.updateTag(tag);
     handleRoutineUpdate(todo, request, tag);

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -738,5 +738,4 @@ class RoutineServiceTest {
                 assertThat(((CustomException) e).getErrorCode())
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
-
 }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -505,7 +505,7 @@ class RoutineServiceTest {
 
   // ========== generateDailyTodos (배치) ==========
 
-  // TEST_DATE = 2024-01-15 (월요일), 어제 = 2024-01-14 (일요일)
+  // TEST_DATE = 2024-01-15 (월요일, DayOfWeek=1, bit=1), day of month = 15
 
   private Routine buildRoutine(RoutineType type, Integer routineDate) {
     return Routine.builder()
@@ -516,19 +516,9 @@ class RoutineServiceTest {
         .build();
   }
 
-  private Todo buildTodoWithRoutine(Routine routine, LocalDateTime dueDate) {
-    return Todo.builder()
-        .title(routine.getTitle())
-        .dueDate(dueDate)
-        .isPinned(false)
-        .user(routine.getUser())
-        .routine(routine)
-        .build();
-  }
-
   @Test
-  void generateDailyTodos_어제_마감_반복Todo_없으면_생성_안됨() {
-    given(todoRepository.findMotherRoutineTodosForRollover(any(), any())).willReturn(List.of());
+  void generateDailyTodos_활성루틴_없으면_생성_안됨() {
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of());
 
     routineService.generateDailyTodos();
 
@@ -536,13 +526,10 @@ class RoutineServiceTest {
   }
 
   @Test
-  void generateDailyTodos_DAILY_어제_마감_반복Todo_있으면_오늘_dueDate로_생성됨() {
-    // 어제(2024-01-14) dueDate DAILY 반복 Todo → nextOccurrence(오늘=2024-01-15) = 2024-01-15
+  void generateDailyTodos_DAILY_오늘_투두_생성됨() {
+    // DAILY → isOccurrenceDay = 항상 true → 오늘(2024-01-15) 투두 생성
     Routine routine = buildRoutine(RoutineType.DAILY, null);
-    Todo yesterdayTodo =
-        buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atTime(23, 59, 59));
-    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
-        .willReturn(List.of(yesterdayTodo));
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
 
     routineService.generateDailyTodos();
 
@@ -553,37 +540,81 @@ class RoutineServiceTest {
   }
 
   @Test
-  void generateDailyTodos_WEEKLY_어제_마감_반복Todo_있으면_다음_반복일_dueDate로_생성됨() {
-    // 어제(2024-01-14, 일) dueDate WEEKLY(화=2) → nextOccurrence(오늘=월) = 2024-01-16(화)
-    Routine routine = buildRoutine(RoutineType.WEEKLY, 2);
-    Todo yesterdayTodo =
-        buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atTime(23, 59, 59));
-    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
-        .willReturn(List.of(yesterdayTodo));
+  void generateDailyTodos_WEEKLY_오늘이_해당요일_투두_생성됨() {
+    // 오늘=월요일(bit=1), WEEKLY(mask=1) → isOccurrenceDay = true → 오늘 투두 생성
+    Routine routine = buildRoutine(RoutineType.WEEKLY, 1);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
 
     routineService.generateDailyTodos();
 
     ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
     verify(todoRepository).saveAndFlush(captor.capture());
     assertThat(captor.getValue().getDueDate())
-        .isEqualTo(LocalDate.of(2024, 1, 16).atTime(23, 59, 59));
+        .isEqualTo(LocalDate.of(2024, 1, 15).atTime(23, 59, 59));
   }
 
   @Test
-  void generateDailyTodos_MONTHLY_어제_마감_반복Todo_있으면_다음_반복일_dueDate로_생성됨() {
-    // 어제(2024-01-14) dueDate MONTHLY(16일) → nextOccurrence(오늘=15일) = 2024-01-16
-    Routine routine = buildRoutine(RoutineType.MONTHLY, 16);
-    Todo yesterdayTodo =
-        buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atTime(23, 59, 59));
-    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
-        .willReturn(List.of(yesterdayTodo));
+  void generateDailyTodos_WEEKLY_오늘이_해당요일_아님_생성_안됨() {
+    // 오늘=월요일(bit=1), WEEKLY(mask=2, 화요일) → isOccurrenceDay = false
+    Routine routine = buildRoutine(RoutineType.WEEKLY, 2);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_MONTHLY_오늘이_해당일_투두_생성됨() {
+    // 오늘=15일, MONTHLY(15일) → isOccurrenceDay = true → 오늘 투두 생성
+    Routine routine = buildRoutine(RoutineType.MONTHLY, 15);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
 
     routineService.generateDailyTodos();
 
     ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
     verify(todoRepository).saveAndFlush(captor.capture());
     assertThat(captor.getValue().getDueDate())
-        .isEqualTo(LocalDate.of(2024, 1, 16).atTime(23, 59, 59));
+        .isEqualTo(LocalDate.of(2024, 1, 15).atTime(23, 59, 59));
+  }
+
+  @Test
+  void generateDailyTodos_MONTHLY_오늘이_해당일_아님_생성_안됨() {
+    // 오늘=15일, MONTHLY(16일) → isOccurrenceDay = false
+    Routine routine = buildRoutine(RoutineType.MONTHLY, 16);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_종료일_지난_루틴_생성_안됨() {
+    // DAILY, 종료일 = 2024-01-14 → 오늘(Jan 15)이 종료일 이후 → 생성 안 함
+    Routine routine =
+        Routine.builder()
+            .title("테스트 루틴")
+            .routineType(RoutineType.DAILY)
+            .dueDate(LocalDate.of(2024, 1, 14).atStartOfDay())
+            .user(testUser())
+            .build();
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+  }
+
+  @Test
+  void generateDailyTodos_오늘_투두_이미_존재시_중복_생성_안됨() {
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+    given(todoRepository.existsByRoutineAndDueDate(any(), any())).willReturn(true);
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
   }
 
   // ========== updateMotherRoutine ==========
@@ -708,17 +739,4 @@ class RoutineServiceTest {
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
-  @Test
-  void generateDailyTodos_다음_반복일_Todo_이미_존재시_중복_생성_안됨() {
-    Routine routine = buildRoutine(RoutineType.DAILY, null);
-    Todo yesterdayTodo =
-        buildTodoWithRoutine(routine, LocalDate.of(2024, 1, 14).atTime(23, 59, 59));
-    given(todoRepository.findMotherRoutineTodosForRollover(any(), any()))
-        .willReturn(List.of(yesterdayTodo));
-    given(todoRepository.existsByRoutineAndDueDate(any(), any())).willReturn(true);
-
-    routineService.generateDailyTodos();
-
-    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
-  }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1700,4 +1700,45 @@ class TodoServiceTest {
 
     verify(routineRepository, never()).save(any());
   }
+
+  @Test
+  @DisplayName("updateTodo - 루틴 있음 + dueDate 변경 시도: ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED 예외")
+  void updateTodo_routineTodo_dueDateChange_throws() {
+    User user = testUser();
+    Todo todo = testTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(
+            () ->
+                todoService.updateTodo(
+                    1L,
+                    1L,
+                    updateTodoRequest(
+                        "제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED));
+  }
+
+  @Test
+  @DisplayName("updateTodo - 루틴 있음 + dueDate=null: 마감일 변경 없이 성공")
+  void updateTodo_routineTodo_nullDueDate_success() {
+    User user = testUser();
+    Todo todo = testTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
+
+    assertThatCode(
+            () ->
+                todoService.updateTodo(
+                    1L, 1L, updateTodoRequest("수정된 제목", null, null, null, null)))
+        .doesNotThrowAnyException();
+  }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1702,43 +1702,39 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음 + dueDate 변경 시도: ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED 예외")
-  void updateTodo_routineTodo_dueDateChange_throws() {
+  @DisplayName("updateTodo - 루틴 있음: dueDate 요청값(non-null) 무시, 기존 마감일 보존")
+  void updateTodo_routineTodo_dueDateIgnored_preservesExisting() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
+    LocalDateTime originalDueDate = LocalDateTime.of(2026, 6, 25, 23, 59, 59);
+    ReflectionTestUtils.setField(todo, "dueDate", originalDueDate);
     Routine routine = testRoutine(user, RoutineType.DAILY);
     ReflectionTestUtils.setField(todo, "routine", routine);
 
     given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
 
-    assertThatThrownBy(
-            () ->
-                todoService.updateTodo(
-                    1L,
-                    1L,
-                    updateTodoRequest(
-                        "제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null)))
-        .isInstanceOf(CustomException.class)
-        .satisfies(
-            e ->
-                assertThat(((CustomException) e).getErrorCode())
-                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_DUE_DATE_CHANGE_NOT_ALLOWED));
+    TodoDetailResponseDto result =
+        todoService.updateTodo(
+            1L, 1L, updateTodoRequest("제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null));
+
+    assertThat(result.getDueDate()).isEqualTo(originalDueDate);
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음 + dueDate=null: 마감일 변경 없이 성공")
-  void updateTodo_routineTodo_nullDueDate_success() {
+  @DisplayName("updateTodo - 루틴 있음: dueDate=null 요청도 무시, 기존 마감일 보존")
+  void updateTodo_routineTodo_nullDueDateIgnored_preservesExisting() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
+    LocalDateTime originalDueDate = LocalDateTime.of(2026, 6, 25, 23, 59, 59);
+    ReflectionTestUtils.setField(todo, "dueDate", originalDueDate);
     Routine routine = testRoutine(user, RoutineType.DAILY);
     ReflectionTestUtils.setField(todo, "routine", routine);
 
     given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
 
-    assertThatCode(
-            () ->
-                todoService.updateTodo(
-                    1L, 1L, updateTodoRequest("수정된 제목", null, null, null, null)))
-        .doesNotThrowAnyException();
+    TodoDetailResponseDto result =
+        todoService.updateTodo(1L, 1L, updateTodoRequest("수정된 제목", null, null, null, null));
+
+    assertThat(result.getDueDate()).isEqualTo(originalDueDate);
   }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1715,7 +1715,9 @@ class TodoServiceTest {
 
     TodoDetailResponseDto result =
         todoService.updateTodo(
-            1L, 1L, updateTodoRequest("제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null));
+            1L,
+            1L,
+            updateTodoRequest("제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null));
 
     assertThat(result.getDueDate()).isEqualTo(originalDueDate);
   }


### PR DESCRIPTION
## 변경 사항
> 
1. 루틴 투두 dueDate 수정 차단 (TodoService)

루틴에 연결된 투두는 updateTodo 요청의 dueDate를 무시하고 기존 값을 보존합니다.
non-null 변경과 null(생략) 양쪽 모두 건너뜁니다.

2. 배치 방식을 루틴 직접 스캔으로 교체 (RoutineService)

체인 반응 방식(어제 투두 → 오늘 투두)은 링크 하나가 끊기면 이후 전체가 누락됩니다.
루틴 테이블을 직접 스캔해 오늘 발화 여부를 판단하는 방식으로 교체했습니다.

변경 전: 어제 dueDate인 투두 탐색 → createTodoTreeFromMother
변경 후: 전체 활성 엄마 루틴 스캔 → isOccurrenceDay 필터 → createTodoTreeFromMother

DAILY   → 항상 생성
WEEKLY  → bitmask & (1 << 오늘_요일_비트) != 0
MONTHLY → routineDate == 오늘_day

기존 existsByRoutineAndDueDate 중복 체크가 그대로 유지되어 멱등성 보장됩니다.

3. 정리

- TodoRepository.findMotherRoutineTodosForRollover 제거 (미사용)
- RoutineRepository.findAllActiveMotherRoutines 추가 (parent IS NULL AND deletedAt IS NULL)
