### PR TITLE
v0.16.4

### DIFF
--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -92,6 +92,11 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
       @Param("end") LocalDateTime end);
 
   @Query(
+      "SELECT MAX(t.sortOrder) FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
+          + " AND t.deletedAt IS NULL")
+  Optional<Double> findMaxSortOrderByUser(@Param("user") User user);
+
+  @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.replan IS NOT NULL"
           + " AND ((t.dueDate >= :start AND t.dueDate < :end)"
           + " OR (t.dueDate IS NULL AND t.completedTime >= :start AND t.completedTime < :end))")

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -80,11 +80,18 @@ public class TodoService {
               .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
     }
 
+    double newSortOrder =
+        todoRepository
+            .findMaxSortOrderByUser(user)
+            .map(max -> max + 10000.0)
+            .orElse(10000.0);
+
     Todo todo =
         Todo.builder()
             .title(request.getTitle())
             .dueDate(request.getDueDate())
             .isPinned(false)
+            .sortOrder(newSortOrder)
             .user(user)
             .tag(tag)
             .goal(goal)

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -81,10 +81,7 @@ public class TodoService {
     }
 
     double newSortOrder =
-        todoRepository
-            .findMaxSortOrderByUser(user)
-            .map(max -> max + 10000.0)
-            .orElse(10000.0);
+        todoRepository.findMaxSortOrderByUser(user).map(max -> max + 10000.0).orElse(10000.0);
 
     Todo todo =
         Todo.builder()

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -135,6 +135,7 @@ class TodoServiceTest {
   @DisplayName("성공 (tagId 없음): 올바른 DTO 반환, isPinned=false, tagId=null, tagRepository 미호출")
   void createTodo_success_withoutTag() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(todoRepository.findMaxSortOrderByUser(any())).willReturn(Optional.empty());
     given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
 
     TodoResponseDto result = todoService.createTodo(1L, request("제목", null, null));
@@ -156,6 +157,7 @@ class TodoServiceTest {
     LocalDateTime dueDate = LocalDateTime.of(2026, 5, 10, 12, 30);
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(tagRepository.findById(5L)).willReturn(Optional.of(testTag(5L)));
+    given(todoRepository.findMaxSortOrderByUser(any())).willReturn(Optional.empty());
     given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
 
     TodoResponseDto result = todoService.createTodo(1L, request("제목", dueDate, 5L));
@@ -163,6 +165,34 @@ class TodoServiceTest {
     assertThat(result.getTitle()).isEqualTo("제목");
     assertThat(result.getDueDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
+  }
+
+  @Test
+  @DisplayName("첫 번째 todo 생성: sortOrder = 10000.0 (기본값)")
+  void createTodo_firstTodo_sortOrderIsDefault() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(todoRepository.findMaxSortOrderByUser(any())).willReturn(Optional.empty());
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    todoService.createTodo(1L, request("첫 번째 할일", null, null));
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).save(captor.capture());
+    assertThat(captor.getValue().getSortOrder()).isEqualTo(10000.0);
+  }
+
+  @Test
+  @DisplayName("기존 todo가 있을 때 새 todo 생성: sortOrder = maxSortOrder + 10000")
+  void createTodo_withExistingTodos_sortOrderIsMaxPlusTenThousand() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(todoRepository.findMaxSortOrderByUser(any())).willReturn(Optional.of(25000.0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    todoService.createTodo(1L, request("새 할일", null, null));
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).save(captor.capture());
+    assertThat(captor.getValue().getSortOrder()).isEqualTo(35000.0);
   }
 
   private SubTodoCreateRequestDto subRequest(String title) {


### PR DESCRIPTION
## 변경 사항
>
todo 생성 시 sortOrder를 max+10000으로 설정하여 사용자 정렬 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 새 할 일 생성 시, 사용자별 현재 정렬 순서를 기준으로 다음 `sortOrder`가 자동으로 설정됩니다.
  * 기존 항목이 없으면 기본값이 적용되고, 있으면 그 다음 순서로 배치됩니다.

* **버그 수정**
  * 새 할 일 생성 시 정렬 순서가 비어 있던 문제를 개선했습니다.
  * 생성 로직이 사용자별 최댓값을 반영하도록 보완되었습니다.

* **테스트**
  * 기본 정렬 순서와 기존 항목이 있는 경우의 정렬 순서 계산을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->