### PR TITLE
Feat: routine override 기능 구현 (per-date 재정의 및 건너뜀)

### DIFF
--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
@@ -1,0 +1,92 @@
+package plana.replan.domain.routine.controller;
+
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.routine.dto.RoutineOverrideCompleteRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideContentRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideOrderRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverridePinRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideResponseDto;
+import plana.replan.domain.routine.service.RoutineOverrideService;
+import plana.replan.global.common.ApiResult;
+
+@RestController
+@RequestMapping("/api/routines")
+@RequiredArgsConstructor
+public class RoutineOverrideController implements RoutineOverrideControllerDocs {
+
+  private final RoutineOverrideService routineOverrideService;
+
+  @Override
+  @PatchMapping("/{routineId}/overrides/{date}")
+  public ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateContent(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date,
+      @RequestBody RoutineOverrideContentRequestDto request) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineOverrideService.updateContent(userId, routineId, date, request)));
+  }
+
+  @Override
+  @PatchMapping("/{routineId}/overrides/{date}/order")
+  public ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateOrder(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date,
+      @Valid @RequestBody RoutineOverrideOrderRequestDto request) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineOverrideService.updateOrder(userId, routineId, date, request)));
+  }
+
+  @Override
+  @PatchMapping("/{routineId}/overrides/{date}/complete")
+  public ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateComplete(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date,
+      @Valid @RequestBody RoutineOverrideCompleteRequestDto request) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineOverrideService.updateComplete(userId, routineId, date, request)));
+  }
+
+  @Override
+  @PatchMapping("/{routineId}/overrides/{date}/pin")
+  public ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updatePin(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date,
+      @Valid @RequestBody RoutineOverridePinRequestDto request) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineOverrideService.updatePin(userId, routineId, date, request)));
+  }
+
+  @Override
+  @DeleteMapping("/{routineId}/overrides/{date}")
+  public ResponseEntity<ApiResult<Void>> skip(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date) {
+    routineOverrideService.skip(userId, routineId, date);
+    return ResponseEntity.ok(ApiResult.ok(null));
+  }
+
+  @Override
+  @PatchMapping("/{routineId}/overrides/{date}/unskip")
+  public ResponseEntity<ApiResult<Void>> unskip(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date) {
+    routineOverrideService.unskip(userId, routineId, date);
+    return ResponseEntity.ok(ApiResult.ok(null));
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
@@ -331,7 +331,7 @@ public interface RoutineOverrideControllerDocs {
 
           - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo를 soft delete 한다.
           - 이미 완료된 Todo가 있는 날짜는 건너뜀 처리할 수 없다 (400).
-          - 건너뜀을 취소하려면 `PATCH /api/routines/{routineId}/overrides/{date}`로 override를 수정한다.
+          - 건너뜀을 취소하려면 `PATCH /api/routines/{routineId}/overrides/{date}/unskip`을 호출한다.
 
           ### Path Variables
 
@@ -379,7 +379,7 @@ public interface RoutineOverrideControllerDocs {
           건너뜀 처리된 날짜를 다시 활성화한다.
 
           - override의 `isSkipped`를 `false`로 되돌린다.
-          - 이미 soft-delete된 Todo는 복구되지 않는다. 당일이라면 다음 배치(자정)에 재생성된다.
+          - 이미 soft-delete된 Todo는 복구되지 않는다. 새 배치 실행 시 해당 날짜가 발생일이면 재생성된다.
           - 건너뜀 상태가 아닌 날짜에 호출해도 에러 없이 idempotent하게 처리된다.
 
           ### Path Variables

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
@@ -1,0 +1,403 @@
+package plana.replan.domain.routine.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import plana.replan.domain.routine.dto.RoutineOverrideCompleteRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideContentRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideOrderRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverridePinRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideResponseDto;
+import plana.replan.global.common.ApiResult;
+
+@Tag(name = "RoutineOverride", description = "루틴 인스턴스 단건 수정 API. 반복 todo의 특정 날짜 인스턴스만 변경한다.")
+public interface RoutineOverrideControllerDocs {
+
+  @Operation(
+      summary = "루틴 인스턴스 내용 수정",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스 제목/태그를 수정한다 (단건).
+          전체 루틴을 수정하려면 `PUT /api/routines/{id}` 사용.
+
+          - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo에도 즉시 반영된다.
+          - 전체 루틴 수정(`PUT /api/routines/{id}`) 시 오늘 이후 override는 일괄 삭제된다.
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+          | Content-Type | ✅ 필수 | string | `application/json` |
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 수정할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | title | ❌ 선택 | string | 제목 override. null이면 루틴 기본 제목 유지 | `"아침 스트레칭 (특별)"` |
+          | tagId | ❌ 선택 | integer | 태그 ID override. null이면 루틴 기본 태그 유지 | `5` |
+
+          > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "수정 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "routineId": 1,
+                                "overrideDate": "2026-07-01",
+                                "effectiveTitle": "아침 스트레칭 (특별)",
+                                "effectiveTagId": 5,
+                                "effectiveTagTitle": "운동",
+                                "effectiveTagColor": "GREEN",
+                                "effectiveSortOrder": 10000.0,
+                                "isSkipped": false,
+                                "isPinned": false,
+                                "isCompleted": false,
+                                "hasOverride": true,
+                                "todoId": null
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {"status":401,"success":false,"data":null,"error":{"code":"EMPTY_TOKEN","message":"토큰이 없습니다.","detail":null}}
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {"status":401,"success":false,"data":null,"error":{"code":"EXPIRED_TOKEN","message":"만료된 토큰입니다.","detail":null}}
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "루틴 또는 태그를 찾을 수 없음",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "루틴 없음",
+                      value =
+                          """
+                          {"status":404,"success":false,"data":null,"error":{"code":"ROUTINE_NOT_FOUND","message":"루틴을 찾을 수 없습니다.","detail":null}}
+                          """),
+                  @ExampleObject(
+                      name = "태그 없음",
+                      value =
+                          """
+                          {"status":404,"success":false,"data":null,"error":{"code":"TAG_NOT_FOUND","message":"태그를 찾을 수 없습니다.","detail":null}}
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateContent(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "수정할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date,
+      @RequestBody RoutineOverrideContentRequestDto request);
+
+  @Operation(
+      summary = "루틴 인스턴스 정렬 변경",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스 정렬 순서를 변경한다.
+
+          - `sortOrder`는 프론트가 인접 항목의 값을 기반으로 계산해서 전달한다.
+          - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo의 sortOrder에도 즉시 반영된다.
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 변경할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | sortOrder | ✅ 필수 | number | 정렬 순서 | `5000.0` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "정렬 변경 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "routineId": 1,
+                                "overrideDate": "2026-07-01",
+                                "effectiveTitle": "아침 스트레칭",
+                                "effectiveTagId": null,
+                                "effectiveTagTitle": null,
+                                "effectiveTagColor": null,
+                                "effectiveSortOrder": 5000.0,
+                                "isSkipped": false,
+                                "isPinned": false,
+                                "isCompleted": false,
+                                "hasOverride": true,
+                                "todoId": null
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(responseCode = "400", description = "sortOrder 누락"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+  })
+  ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateOrder(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "변경할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date,
+      @Valid @RequestBody RoutineOverrideOrderRequestDto request);
+
+  @Operation(
+      summary = "루틴 인스턴스 완료/미완료 처리",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스를 완료 또는 미완료 처리한다.
+
+          - `isCompleted: true` 시 서버에서 `completedTime`을 현재 시각으로 자동 기록한다.
+          - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo에도 즉시 반영된다.
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 처리할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | isCompleted | ✅ 필수 | boolean | `true`면 완료, `false`면 미완료 | `true` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "완료/미완료 처리 성공",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "완료",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "routineId": 1,
+                              "overrideDate": "2026-07-01",
+                              "effectiveTitle": "아침 스트레칭",
+                              "effectiveTagId": null,
+                              "effectiveTagTitle": null,
+                              "effectiveTagColor": null,
+                              "effectiveSortOrder": 10000.0,
+                              "isSkipped": false,
+                              "isPinned": false,
+                              "isCompleted": true,
+                              "hasOverride": true,
+                              "todoId": null
+                            },
+                            "error": null
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "미완료",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "routineId": 1,
+                              "overrideDate": "2026-07-01",
+                              "effectiveTitle": "아침 스트레칭",
+                              "effectiveTagId": null,
+                              "effectiveTagTitle": null,
+                              "effectiveTagColor": null,
+                              "effectiveSortOrder": 10000.0,
+                              "isSkipped": false,
+                              "isPinned": false,
+                              "isCompleted": false,
+                              "hasOverride": true,
+                              "todoId": null
+                            },
+                            "error": null
+                          }
+                          """)
+                })),
+    @ApiResponse(responseCode = "400", description = "isCompleted 누락"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+  })
+  ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updateComplete(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "처리할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date,
+      @Valid @RequestBody RoutineOverrideCompleteRequestDto request);
+
+  @Operation(
+      summary = "루틴 인스턴스 핀/언핀",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스를 핀 또는 언핀 처리한다.
+
+          - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo에도 즉시 반영된다.
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 처리할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+
+          ### Request Body
+
+          | 필드명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |--------|-----------|------|------|------|
+          | isPinned | ✅ 필수 | boolean | `true`면 핀, `false`면 언핀 | `true` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "핀/언핀 성공"),
+    @ApiResponse(responseCode = "400", description = "isPinned 누락"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+  })
+  ResponseEntity<ApiResult<RoutineOverrideResponseDto>> updatePin(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "처리할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date,
+      @Valid @RequestBody RoutineOverridePinRequestDto request);
+
+  @Operation(
+      summary = "루틴 인스턴스 건너뜀 (삭제)",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스를 건너뜀 처리한다. 해당 날짜에 Todo가 생성되지 않는다.
+
+          - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo를 soft delete 한다.
+          - 이미 완료된 Todo가 있는 날짜는 건너뜀 처리할 수 없다 (400).
+          - 건너뜀을 취소하려면 `PATCH /api/routines/{routineId}/overrides/{date}`로 override를 수정한다.
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 건너뜀 처리할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "건너뜀 처리 성공"),
+    @ApiResponse(
+        responseCode = "400",
+        description = "이미 완료된 Todo가 있는 날짜",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_OVERRIDE_CANNOT_SKIP_COMPLETED",
+                                "message": "이미 완료된 Todo가 있는 날짜는 건너뜀 처리할 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+  })
+  ResponseEntity<ApiResult<Void>> skip(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "건너뜀 처리할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date);
+
+  @Operation(
+      summary = "루틴 인스턴스 건너뜀 취소",
+      description =
+          """
+          건너뜀 처리된 날짜를 다시 활성화한다.
+
+          - override의 `isSkipped`를 `false`로 되돌린다.
+          - 이미 soft-delete된 Todo는 복구되지 않는다. 당일이라면 다음 배치(자정)에 재생성된다.
+          - 건너뜀 상태가 아닌 날짜에 호출해도 에러 없이 idempotent하게 처리된다.
+
+          ### Path Variables
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 취소할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "건너뜀 취소 성공"),
+    @ApiResponse(responseCode = "401", description = "인증 실패"),
+    @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+  })
+  ResponseEntity<ApiResult<Void>> unskip(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "건너뜀을 취소할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date);
+}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
@@ -25,4 +25,16 @@ public interface RoutineDateProjection {
   Long getGoalId();
 
   Long getTodoId();
+
+  Double getOverrideSortOrder();
+
+  Double getDefaultSortOrder();
+
+  Boolean getIsSkipped();
+
+  Boolean getIsPinned();
+
+  Boolean getIsCompleted();
+
+  Boolean getHasOverride();
 }

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideCompleteRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideCompleteRequestDto.java
@@ -1,0 +1,9 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "루틴 인스턴스 완료 처리 요청")
+public record RoutineOverrideCompleteRequestDto(
+    @Schema(description = "true면 완료, false면 미완료 처리", example = "true") @NotNull
+        Boolean isCompleted) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideContentRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideContentRequestDto.java
@@ -1,0 +1,8 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "루틴 인스턴스 내용 수정 요청")
+public record RoutineOverrideContentRequestDto(
+    @Schema(description = "제목 override. null이면 루틴 기본 제목 유지", example = "아침 스트레칭 (특별)") String title,
+    @Schema(description = "태그 ID override. null이면 루틴 기본 태그 유지", example = "5") Long tagId) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideOrderRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideOrderRequestDto.java
@@ -1,0 +1,9 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "루틴 인스턴스 정렬 변경 요청")
+public record RoutineOverrideOrderRequestDto(
+    @Schema(description = "정렬 순서 (인접 항목의 sortOrder 기반으로 프론트가 계산)", example = "5000.0") @NotNull
+        Double sortOrder) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverridePinRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverridePinRequestDto.java
@@ -1,0 +1,8 @@
+package plana.replan.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "루틴 인스턴스 핀 요청")
+public record RoutineOverridePinRequestDto(
+    @Schema(description = "true면 핀, false면 언핀", example = "true") @NotNull Boolean isPinned) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideResponseDto.java
@@ -1,0 +1,49 @@
+package plana.replan.domain.routine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineOverride;
+import plana.replan.domain.tag.entity.Tag;
+
+@Schema(description = "루틴 인스턴스 override 응답")
+public record RoutineOverrideResponseDto(
+    @Schema(description = "루틴 ID", example = "1") Long routineId,
+    @Schema(description = "override 적용 날짜 (yyyy-MM-dd 형식)", example = "2026-07-01")
+        LocalDate overrideDate,
+    @Schema(description = "실제 적용될 제목", example = "아침 스트레칭 (특별)") String effectiveTitle,
+    @Schema(description = "실제 적용될 태그 ID. 없으면 null", example = "5") Long effectiveTagId,
+    @Schema(description = "실제 적용될 태그 제목. 없으면 null", example = "운동") String effectiveTagTitle,
+    @Schema(description = "실제 적용될 태그 색상. 없으면 null", example = "GREEN") String effectiveTagColor,
+    @Schema(description = "실제 적용될 정렬 순서", example = "5000.0") double effectiveSortOrder,
+    @JsonProperty("isSkipped") @Schema(description = "건너뜀 여부", example = "false") boolean isSkipped,
+    @JsonProperty("isPinned") @Schema(description = "핀 여부", example = "false") boolean isPinned,
+    @JsonProperty("isCompleted") @Schema(description = "완료 여부", example = "false")
+        boolean isCompleted,
+    @JsonProperty("hasOverride") @Schema(description = "override 존재 여부", example = "true")
+        boolean hasOverride,
+    @Schema(description = "이미 배치로 생성된 Todo ID. 없으면 null", example = "42") Long todoId) {
+
+  public static RoutineOverrideResponseDto of(
+      Routine routine, RoutineOverride override, Long todoId) {
+    Tag effectiveTag = override.getTag() != null ? override.getTag() : routine.getTag();
+    String effectiveTitle = override.getTitle() != null ? override.getTitle() : routine.getTitle();
+    double effectiveSortOrder =
+        override.getSortOrder() != null ? override.getSortOrder() : routine.getDefaultSortOrder();
+
+    return new RoutineOverrideResponseDto(
+        routine.getId(),
+        override.getOverrideDate(),
+        effectiveTitle,
+        effectiveTag != null ? effectiveTag.getId() : null,
+        effectiveTag != null ? effectiveTag.getTitle() : null,
+        effectiveTag != null ? effectiveTag.getColor() : null,
+        effectiveSortOrder,
+        override.isSkipped(),
+        Boolean.TRUE.equals(override.getIsPinned()),
+        Boolean.TRUE.equals(override.getIsCompleted()),
+        true,
+        todoId);
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -1,5 +1,7 @@
 package plana.replan.domain.routine.dto;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -7,21 +9,62 @@ import lombok.Getter;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 
+@Schema(description = "루틴 조회 응답")
 @Getter
 @AllArgsConstructor
+@JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 public class RoutineResponseDto {
 
+  @Schema(description = "루틴 ID", example = "1")
   private Long routineId;
+
+  @Schema(description = "제목 (override 적용값)", example = "아침 스트레칭")
   private String title;
+
+  @Schema(description = "반복 종료 마감일 (ISO 8601 형식). 없으면 null", example = "2025-12-31T00:00:00")
   private LocalDateTime dueDate;
+
+  @Schema(description = "마감 시각 (HH:mm:ss 형식). 없으면 null", example = "08:00:00")
   private LocalTime routineTime;
+
+  @Schema(description = "반복 유형", example = "DAILY")
   private RoutineType routineType;
+
+  @Schema(description = "반복 날짜 설정값. DAILY=null, WEEKLY=요일 비트마스크, MONTHLY=일자", example = "21")
   private Integer routineDate;
+
+  @Schema(description = "태그 ID (override 적용값). 없으면 null", example = "3")
   private Long tagId;
+
+  @Schema(description = "태그 제목. 없으면 null", example = "운동")
   private String tagTitle;
+
+  @Schema(description = "태그 색상. 없으면 null", example = "GREEN")
   private String tagColor;
+
+  @Schema(description = "목표 ID. 없으면 null", example = "2")
   private Long goalId;
+
+  @Schema(description = "해당 날짜에 생성된 Todo ID. 아직 생성 안 됐으면 null", example = "42")
   private Long todoId;
+
+  @Schema(description = "해당 날짜 인스턴스의 정렬 순서", example = "10000.0")
+  private double effectiveSortOrder;
+
+  @Schema(description = "해당 날짜 건너뜀 여부", example = "false")
+  private boolean isSkipped;
+
+  @Schema(description = "해당 날짜 핀 여부", example = "false")
+  private boolean isPinned;
+
+  @Schema(description = "해당 날짜 완료 여부", example = "false")
+  private boolean isCompleted;
+
+  @Schema(description = "해당 날짜에 override 존재 여부", example = "false")
+  private boolean hasOverride;
 
   public static RoutineResponseDto from(Routine routine) {
     return new RoutineResponseDto(
@@ -35,10 +78,17 @@ public class RoutineResponseDto {
         routine.getTag() != null ? routine.getTag().getTitle() : null,
         routine.getTag() != null ? routine.getTag().getColor() : null,
         routine.getGoal() != null ? routine.getGoal().getId() : null,
-        null);
+        null,
+        routine.getDefaultSortOrder(),
+        false,
+        false,
+        false,
+        false);
   }
 
   public static RoutineResponseDto from(RoutineDateProjection p) {
+    double effectiveSortOrder =
+        p.getOverrideSortOrder() != null ? p.getOverrideSortOrder() : p.getDefaultSortOrder();
     return new RoutineResponseDto(
         p.getRoutineId(),
         p.getTitle(),
@@ -50,6 +100,11 @@ public class RoutineResponseDto {
         p.getTagTitle(),
         p.getTagColor(),
         p.getGoalId(),
-        p.getTodoId());
+        p.getTodoId(),
+        effectiveSortOrder,
+        Boolean.TRUE.equals(p.getIsSkipped()),
+        Boolean.TRUE.equals(p.getIsPinned()),
+        Boolean.TRUE.equals(p.getIsCompleted()),
+        Boolean.TRUE.equals(p.getHasOverride()));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/entity/Routine.java
+++ b/src/main/java/plana/replan/domain/routine/entity/Routine.java
@@ -67,8 +67,15 @@ public class Routine extends BaseTimeEntity {
   @JoinColumn(name = "replan_id")
   private Replan replan;
 
+  @Column(name = "default_sort_order", nullable = false)
+  private double defaultSortOrder = 10000.0;
+
   @Column(name = "is_active", nullable = false)
   private boolean isActive = true;
+
+  public void updateDefaultSortOrder(double defaultSortOrder) {
+    this.defaultSortOrder = defaultSortOrder;
+  }
 
   public void deactivate() {
     this.isActive = false;

--- a/src/main/java/plana/replan/domain/routine/entity/RoutineOverride.java
+++ b/src/main/java/plana/replan/domain/routine/entity/RoutineOverride.java
@@ -1,0 +1,94 @@
+package plana.replan.domain.routine.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import plana.replan.domain.tag.entity.Tag;
+
+@Entity
+@Table(
+    name = "routine_override",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"routine_id", "override_date"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoutineOverride {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "routine_id", nullable = false)
+  private Routine routine;
+
+  @Column(name = "override_date", nullable = false)
+  private LocalDate overrideDate;
+
+  @Column(nullable = true)
+  private String title;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_id")
+  private Tag tag;
+
+  @Column(name = "sort_order")
+  private Double sortOrder;
+
+  @Column(name = "is_skipped", nullable = false)
+  private boolean isSkipped = false;
+
+  @Column(name = "is_pinned")
+  private Boolean isPinned;
+
+  @Column(name = "is_completed")
+  private Boolean isCompleted;
+
+  @Column(name = "completed_time")
+  private LocalDateTime completedTime;
+
+  @CreationTimestamp
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public RoutineOverride(Routine routine, LocalDate overrideDate) {
+    this.routine = routine;
+    this.overrideDate = overrideDate;
+  }
+
+  public void updateContent(String title, Tag tag) {
+    this.title = title;
+    this.tag = tag;
+  }
+
+  public void updateOrder(double sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  public void updateComplete(boolean isCompleted, LocalDateTime now) {
+    this.isCompleted = isCompleted;
+    this.completedTime = isCompleted ? now : null;
+  }
+
+  public void updatePin(boolean isPinned) {
+    this.isPinned = isPinned;
+  }
+
+  public void skip() {
+    this.isSkipped = true;
+  }
+
+  public void unskip() {
+    this.isSkipped = false;
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
+++ b/src/main/java/plana/replan/domain/routine/exception/RoutineErrorCode.java
@@ -9,7 +9,8 @@ import plana.replan.global.exception.ErrorCode;
 public enum RoutineErrorCode implements ErrorCode {
   ROUTINE_INVALID_DATE(400, "유효하지 않은 반복 날짜입니다."),
   ROUTINE_NOT_FOUND(404, "루틴을 찾을 수 없습니다."),
-  ROUTINE_INVALID_TARGET(400, "이 API는 해당 루틴 종류(엄마/하위)에만 사용할 수 있습니다.");
+  ROUTINE_INVALID_TARGET(400, "이 API는 해당 루틴 종류(엄마/하위)에만 사용할 수 있습니다."),
+  ROUTINE_OVERRIDE_CANNOT_SKIP_COMPLETED(400, "이미 완료된 Todo가 있는 날짜는 건너뜀 처리할 수 없습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
@@ -1,0 +1,18 @@
+package plana.replan.domain.routine.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineOverride;
+
+public interface RoutineOverrideRepository extends JpaRepository<RoutineOverride, Long> {
+
+  Optional<RoutineOverride> findByRoutineAndOverrideDate(Routine routine, LocalDate overrideDate);
+
+  List<RoutineOverride> findByRoutineIdInAndOverrideDate(
+      List<Long> routineIds, LocalDate overrideDate);
+
+  void deleteByRoutineAndOverrideDateGreaterThanEqual(Routine routine, LocalDate date);
+}

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -34,19 +34,27 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
       nativeQuery = true,
       value =
           """
-          SELECT r.id           AS routineId,
-                 r.title,
-                 r.due_date     AS dueDate,
-                 r.routine_time AS routineTime,
-                 r.routine_type AS routineType,
-                 r.routine_date AS routineDate,
-                 t.id           AS tagId,
-                 t.title        AS tagTitle,
-                 t.color        AS tagColor,
-                 r.goal_id      AS goalId,
-                 td.id          AS todoId
+          SELECT r.id                                    AS routineId,
+                 COALESCE(ro.title, r.title)             AS title,
+                 r.due_date                              AS dueDate,
+                 r.routine_time                          AS routineTime,
+                 r.routine_type                          AS routineType,
+                 r.routine_date                          AS routineDate,
+                 COALESCE(ro.tag_id, r.tag_id)           AS tagId,
+                 t.title                                 AS tagTitle,
+                 t.color                                 AS tagColor,
+                 r.goal_id                               AS goalId,
+                 td.id                                   AS todoId,
+                 ro.sort_order                           AS overrideSortOrder,
+                 r.default_sort_order                    AS defaultSortOrder,
+                 COALESCE(ro.is_skipped,   FALSE)        AS isSkipped,
+                 COALESCE(ro.is_pinned,    FALSE)        AS isPinned,
+                 COALESCE(ro.is_completed, FALSE)        AS isCompleted,
+                 (ro.id IS NOT NULL)                     AS hasOverride
           FROM routine r
-          LEFT JOIN tag t ON r.tag_id = t.id AND t.deleted_at IS NULL
+          LEFT JOIN routine_override ro
+                 ON ro.routine_id = r.id AND ro.override_date = :targetDate
+          LEFT JOIN tag t ON COALESCE(ro.tag_id, r.tag_id) = t.id AND t.deleted_at IS NULL
           LEFT JOIN todo td ON td.routine_id = r.id
                             AND td.deleted_at IS NULL
                             AND td.parent_id IS NULL

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -1,0 +1,177 @@
+package plana.replan.domain.routine.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.routine.dto.RoutineOverrideCompleteRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideContentRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideOrderRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverridePinRequestDto;
+import plana.replan.domain.routine.dto.RoutineOverrideResponseDto;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineOverride;
+import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
+import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.exception.TagErrorCode;
+import plana.replan.domain.tag.repository.TagRepository;
+import plana.replan.domain.todo.entity.Todo;
+import plana.replan.domain.todo.repository.TodoRepository;
+import plana.replan.domain.user.exception.UserErrorCode;
+import plana.replan.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineOverrideService {
+
+  private final Clock clock;
+  private final RoutineRepository routineRepository;
+  private final RoutineOverrideRepository routineOverrideRepository;
+  private final TagRepository tagRepository;
+  private final TodoRepository todoRepository;
+
+  @Transactional
+  public RoutineOverrideResponseDto updateContent(
+      Long userId, Long routineId, LocalDate date, RoutineOverrideContentRequestDto request) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    final Tag tag;
+    if (request.tagId() != null) {
+      tag =
+          tagRepository
+              .findById(request.tagId())
+              .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
+      if (!tag.getUser().getId().equals(userId)) {
+        throw new CustomException(TagErrorCode.TAG_NOT_FOUND);
+      }
+    } else {
+      tag = null;
+    }
+
+    RoutineOverride override = upsert(routine, date);
+    override.updateContent(request.title(), tag);
+
+    // override의 null 필드는 "루틴 기본값 사용" 의미이므로, todo에는 실제 유효한 값을 세팅한다.
+    String effectiveTitle = request.title() != null ? request.title() : routine.getTitle();
+    Tag effectiveTag = tag != null ? tag : routine.getTag();
+    Optional<Todo> existingTodo = findExistingTodo(routine, date);
+    existingTodo.ifPresent(
+        todo -> {
+          todo.updateTitle(effectiveTitle);
+          todo.updateTag(effectiveTag);
+        });
+
+    return RoutineOverrideResponseDto.of(
+        routine, override, existingTodo.map(Todo::getId).orElse(null));
+  }
+
+  @Transactional
+  public RoutineOverrideResponseDto updateOrder(
+      Long userId, Long routineId, LocalDate date, RoutineOverrideOrderRequestDto request) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    RoutineOverride override = upsert(routine, date);
+    override.updateOrder(request.sortOrder());
+
+    Optional<Todo> existingTodo = findExistingTodo(routine, date);
+    existingTodo.ifPresent(todo -> todo.updateSortOrder(request.sortOrder()));
+
+    return RoutineOverrideResponseDto.of(
+        routine, override, existingTodo.map(Todo::getId).orElse(null));
+  }
+
+  @Transactional
+  public RoutineOverrideResponseDto updateComplete(
+      Long userId, Long routineId, LocalDate date, RoutineOverrideCompleteRequestDto request) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+    LocalDateTime now = LocalDateTime.now(clock);
+
+    RoutineOverride override = upsert(routine, date);
+    override.updateComplete(request.isCompleted(), now);
+
+    Optional<Todo> existingTodo = findExistingTodo(routine, date);
+    existingTodo.ifPresent(todo -> todo.updateCompleted(request.isCompleted(), now));
+
+    return RoutineOverrideResponseDto.of(
+        routine, override, existingTodo.map(Todo::getId).orElse(null));
+  }
+
+  @Transactional
+  public RoutineOverrideResponseDto updatePin(
+      Long userId, Long routineId, LocalDate date, RoutineOverridePinRequestDto request) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    RoutineOverride override = upsert(routine, date);
+    override.updatePin(request.isPinned());
+
+    Optional<Todo> existingTodo = findExistingTodo(routine, date);
+    existingTodo.ifPresent(todo -> todo.updatePinned(request.isPinned()));
+
+    return RoutineOverrideResponseDto.of(
+        routine, override, existingTodo.map(Todo::getId).orElse(null));
+  }
+
+  @Transactional
+  public void skip(Long userId, Long routineId, LocalDate date) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    findExistingTodo(routine, date)
+        .ifPresent(
+            todo -> {
+              if (todo.isCompleted()) {
+                throw new CustomException(RoutineErrorCode.ROUTINE_OVERRIDE_CANNOT_SKIP_COMPLETED);
+              }
+              todo.getChildren().forEach(Todo::softDelete);
+              todo.softDelete();
+            });
+
+    RoutineOverride override = upsert(routine, date);
+    override.skip();
+  }
+
+  @Transactional
+  public void unskip(Long userId, Long routineId, LocalDate date) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    RoutineOverride override = upsert(routine, date);
+    override.unskip();
+  }
+
+  private Routine findOwnedMotherRoutine(Long userId, Long routineId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    Routine routine =
+        routineRepository
+            .findById(routineId)
+            .orElseThrow(() -> new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+    if (!routine.getUser().getId().equals(userId)) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_NOT_FOUND);
+    }
+    if (routine.isChild()) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
+    }
+    return routine;
+  }
+
+  private RoutineOverride upsert(Routine routine, LocalDate date) {
+    return routineOverrideRepository
+        .findByRoutineAndOverrideDate(routine, date)
+        .orElseGet(
+            () ->
+                routineOverrideRepository.save(
+                    RoutineOverride.builder().routine(routine).overrideDate(date).build()));
+  }
+
+  private Optional<Todo> findExistingTodo(Routine routine, LocalDate date) {
+    LocalDateTime start = date.atStartOfDay();
+    LocalDateTime end = date.atTime(LocalTime.MAX);
+    return todoRepository.findMotherTodoByRoutineAndDate(routine, start, end);
+  }
+}

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plana.replan.domain.routine.dto.RoutineOverrideCompleteRequestDto;
@@ -25,6 +26,7 @@ import plana.replan.domain.todo.entity.Todo;
 import plana.replan.domain.todo.repository.TodoRepository;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +42,10 @@ public class RoutineOverrideService {
   public RoutineOverrideResponseDto updateContent(
       Long userId, Long routineId, LocalDate date, RoutineOverrideContentRequestDto request) {
     Routine routine = findOwnedMotherRoutine(userId, routineId);
+
+    if (request.title() != null && request.title().isBlank()) {
+      throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+    }
 
     final Tag tag;
     if (request.tagId() != null) {
@@ -164,9 +170,16 @@ public class RoutineOverrideService {
     return routineOverrideRepository
         .findByRoutineAndOverrideDate(routine, date)
         .orElseGet(
-            () ->
-                routineOverrideRepository.save(
-                    RoutineOverride.builder().routine(routine).overrideDate(date).build()));
+            () -> {
+              try {
+                return routineOverrideRepository.saveAndFlush(
+                    RoutineOverride.builder().routine(routine).overrideDate(date).build());
+              } catch (DataIntegrityViolationException e) {
+                return routineOverrideRepository
+                    .findByRoutineAndOverrideDate(routine, date)
+                    .orElseThrow(() -> e);
+              }
+            });
   }
 
   private Optional<Todo> findExistingTodo(Routine routine, LocalDate date) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plana.replan.domain.goal.entity.Goal;
@@ -23,8 +22,10 @@ import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineResponseDto;
 import plana.replan.domain.routine.dto.SubRoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineOverride;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
@@ -43,6 +44,7 @@ public class RoutineService {
 
   private final Clock clock;
   private final RoutineRepository routineRepository;
+  private final RoutineOverrideRepository routineOverrideRepository;
   private final UserRepository userRepository;
   private final TagRepository tagRepository;
   private final GoalRepository goalRepository;
@@ -152,6 +154,20 @@ public class RoutineService {
         routineDate,
         request.routineTime(),
         tag);
+
+    LocalDate today = LocalDate.now(clock);
+    routineOverrideRepository.deleteByRoutineAndOverrideDateGreaterThanEqual(routine, today);
+
+    // 오늘 이미 배치로 생성된 todo가 있으면 새 루틴 값으로 즉시 반영
+    todoRepository
+        .findMotherTodoByRoutineAndDate(routine, today.atStartOfDay(), today.atTime(LocalTime.MAX))
+        .ifPresent(
+            motherTodo -> {
+              motherTodo.updateTitle(routine.getTitle());
+              motherTodo.updateTag(routine.getTag());
+              motherTodo.getChildren().forEach(child -> child.updateTag(routine.getTag()));
+            });
+
     return RoutineResponseDto.from(routine);
   }
 
@@ -255,9 +271,22 @@ public class RoutineService {
   @Transactional
   public void generateDailyTodos() {
     LocalDate today = LocalDate.now(clock);
-    routineRepository.findAllActiveMotherRoutines().stream()
-        .filter(r -> isOccurrenceDay(r, today))
-        .forEach(this::createTodoTreeFromMother);
+    List<Routine> routines =
+        routineRepository.findAllActiveMotherRoutines().stream()
+            .filter(r -> isOccurrenceDay(r, today))
+            .collect(Collectors.toList());
+
+    List<Long> routineIds = routines.stream().map(Routine::getId).collect(Collectors.toList());
+    Map<Long, RoutineOverride> overrideMap =
+        routineOverrideRepository.findByRoutineIdInAndOverrideDate(routineIds, today).stream()
+            .collect(Collectors.toMap(o -> o.getRoutine().getId(), o -> o));
+
+    routines.forEach(
+        r -> {
+          RoutineOverride override = overrideMap.get(r.getId());
+          if (override != null && override.isSkipped()) return;
+          createTodoTreeFromMother(r, override);
+        });
   }
 
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {
@@ -274,6 +303,10 @@ public class RoutineService {
    * 상속한다.
    */
   public void createTodoTreeFromMother(Routine motherRoutine) {
+    createTodoTreeFromMother(motherRoutine, null);
+  }
+
+  public void createTodoTreeFromMother(Routine motherRoutine, RoutineOverride override) {
     if (motherRoutine.isChild()) {
       throw new IllegalStateException("createTodoTreeFromMother는 엄마 루틴에만 호출 가능합니다.");
     }
@@ -292,11 +325,11 @@ public class RoutineService {
       return;
     }
 
-    Todo motherTodo = saveRoutineTodo(motherRoutine, dueDate, null);
+    Todo motherTodo = saveRoutineTodo(motherRoutine, dueDate, null, override);
     if (motherTodo == null) {
       return;
     }
-    motherRoutine.getChildren().forEach(child -> saveRoutineTodo(child, dueDate, motherTodo));
+    motherRoutine.getChildren().forEach(child -> saveRoutineTodo(child, dueDate, motherTodo, null));
   }
 
   /** 기존 엄마 Todo에 하위 Todo 1개를 매단다. 하위 루틴 추가 API에서 호출. dueDate/tag/goal/user는 엄마 Todo에서 상속한다. */
@@ -304,34 +337,55 @@ public class RoutineService {
     if (!childRoutine.isChild()) {
       throw new IllegalStateException("attachChildTodoUnder는 하위 루틴에만 호출 가능합니다.");
     }
-    saveRoutineTodo(childRoutine, motherTodo.getDueDate(), motherTodo);
+    saveRoutineTodo(childRoutine, motherTodo.getDueDate(), motherTodo, null);
   }
 
-  private Todo saveRoutineTodo(Routine routine, LocalDateTime dueDate, Todo parentTodo) {
+  private Todo saveRoutineTodo(
+      Routine routine, LocalDateTime dueDate, Todo parentTodo, RoutineOverride override) {
     if (todoRepository.existsByRoutineAndDueDate(routine, dueDate)) {
       return null;
     }
-    try {
-      Routine motherForInherit = routine.isChild() ? routine.getParent() : routine;
-      return todoRepository.saveAndFlush(
-          Todo.builder()
-              .title(routine.getTitle())
-              .dueDate(dueDate)
-              .isPinned(false)
-              .user(motherForInherit.getUser())
-              .tag(motherForInherit.getTag())
-              .goal(motherForInherit.getGoal())
-              .routine(routine)
-              .parent(parentTodo)
-              .build());
-    } catch (DataIntegrityViolationException e) {
-      String msg = e.getMostSpecificCause().getMessage();
-      if (msg == null || !msg.contains("uq_todo_routine_duedate")) {
-        throw e;
-      }
-      // uq_todo_routine_duedate 충돌 — 동시 INSERT로 이미 생성된 것으로 간주
-      return null;
+
+    Routine motherForInherit = routine.isChild() ? routine.getParent() : routine;
+
+    String title =
+        (override != null && override.getTitle() != null)
+            ? override.getTitle()
+            : routine.getTitle();
+    Tag tag =
+        (override != null && override.getTag() != null)
+            ? override.getTag()
+            : motherForInherit.getTag();
+    double sortOrder =
+        (override != null && override.getSortOrder() != null)
+            ? override.getSortOrder()
+            : motherForInherit.getDefaultSortOrder();
+    boolean isPinned = override != null && Boolean.TRUE.equals(override.getIsPinned());
+    boolean isCompleted = override != null && Boolean.TRUE.equals(override.getIsCompleted());
+
+    Todo todo =
+        todoRepository.saveAndFlush(
+            Todo.builder()
+                .title(title)
+                .dueDate(dueDate)
+                .sortOrder(sortOrder)
+                .isPinned(isPinned)
+                .user(motherForInherit.getUser())
+                .tag(tag)
+                .goal(motherForInherit.getGoal())
+                .routine(routine)
+                .parent(parentTodo)
+                .build());
+
+    if (isCompleted) {
+      LocalDateTime completedTime =
+          override.getCompletedTime() != null
+              ? override.getCompletedTime()
+              : LocalDateTime.now(clock);
+      todo.updateCompleted(true, completedTime);
     }
+
+    return todo;
   }
 
   private LocalDate nextOccurrence(Routine routine, LocalDate today) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plana.replan.domain.goal.entity.Goal;
@@ -363,19 +364,25 @@ public class RoutineService {
     boolean isPinned = override != null && Boolean.TRUE.equals(override.getIsPinned());
     boolean isCompleted = override != null && Boolean.TRUE.equals(override.getIsCompleted());
 
-    Todo todo =
-        todoRepository.saveAndFlush(
-            Todo.builder()
-                .title(title)
-                .dueDate(dueDate)
-                .sortOrder(sortOrder)
-                .isPinned(isPinned)
-                .user(motherForInherit.getUser())
-                .tag(tag)
-                .goal(motherForInherit.getGoal())
-                .routine(routine)
-                .parent(parentTodo)
-                .build());
+    Todo todo;
+    try {
+      todo =
+          todoRepository.saveAndFlush(
+              Todo.builder()
+                  .title(title)
+                  .dueDate(dueDate)
+                  .sortOrder(sortOrder)
+                  .isPinned(isPinned)
+                  .user(motherForInherit.getUser())
+                  .tag(tag)
+                  .goal(motherForInherit.getGoal())
+                  .routine(routine)
+                  .parent(parentTodo)
+                  .build());
+    } catch (DataIntegrityViolationException e) {
+      // 스케줄러 중복 실행 등으로 unique(routine_id, due_date) 충돌 시 no-op
+      return null;
+    }
 
     if (isCompleted) {
       LocalDateTime completedTime =

--- a/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
@@ -9,7 +9,8 @@ import plana.replan.global.exception.ErrorCode;
 public enum TodoErrorCode implements ErrorCode {
   TODO_NOT_FOUND(404, "투두를 찾을 수 없습니다."),
   INVALID_FILTER(400, "유효하지 않은 필터 값입니다. (all, day, week, month 중 하나)"),
-  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)");
+  INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)"),
+  ROUTINE_TODO_USE_ROUTINE_API(400, "반복 todo는 루틴 API를 통해 수정해주세요.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -30,7 +30,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
-          + " AND t.dueDate >= :start AND t.dueDate < :end")
+          + " AND t.dueDate >= :start AND t.dueDate < :end AND t.deletedAt IS NULL")
   Optional<Todo> findMotherTodoByRoutineAndDate(
       @Param("routine") Routine routine,
       @Param("start") LocalDateTime start,

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -29,6 +29,14 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   List<Todo> findAllByRoutine(Routine routine);
 
   @Query(
+      "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
+          + " AND t.dueDate >= :start AND t.dueDate < :end")
+  Optional<Todo> findMotherTodoByRoutineAndDate(
+      @Param("routine") Routine routine,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  @Query(
       "SELECT t FROM Todo t"
           + " WHERE t.routine = :routine"
           + " AND t.parent IS NULL"

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -254,6 +254,10 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
     }
 
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
     Tag tag = null;
     if (request.getTagId() != null) {
       tag =
@@ -263,10 +267,6 @@ public class TodoService {
       if (!tag.getUser().getId().equals(userId)) {
         throw new CustomException(TagErrorCode.TAG_NOT_FOUND);
       }
-    }
-
-    if (todo.getRoutine() != null) {
-      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
     }
 
     if (request.getTitle() != null && request.getTitle().isBlank()) {

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -265,6 +265,10 @@ public class TodoService {
       }
     }
 
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
     if (request.getTitle() != null && request.getTitle().isBlank()) {
       throw new CustomException(GlobalErrorCode.INVALID_INPUT);
     }
@@ -347,6 +351,10 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
     }
 
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
     if (request.getPrevTodoId() == null && request.getNextTodoId() == null) {
       throw new CustomException(GlobalErrorCode.INVALID_INPUT);
     }
@@ -398,6 +406,10 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
     }
 
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
     todo.updateCompleted(request.getIsCompleted(), LocalDateTime.now(clock));
     return TodoListResponseDto.from(todo, clock);
   }
@@ -420,6 +432,10 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
     }
 
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
     todo.updatePinned(request.getIsPinned());
     return TodoListResponseDto.from(todo, clock);
   }
@@ -440,6 +456,10 @@ public class TodoService {
 
     if (todo.getParent() != null) {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
     }
 
     todo.getChildren().forEach(child -> child.softDelete());

--- a/src/main/java/plana/replan/global/admin/AdminController.java
+++ b/src/main/java/plana/replan/global/admin/AdminController.java
@@ -1,0 +1,26 @@
+package plana.replan.global.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plana.replan.domain.routine.service.RoutineService;
+import plana.replan.global.common.ApiResult;
+
+/** local/dev 환경 전용 내부 테스트용 컨트롤러. prod에서는 빈 등록 안 됨. */
+@RestController
+@RequestMapping("/internal/admin")
+@RequiredArgsConstructor
+@Profile("!prod")
+public class AdminController {
+
+  private final RoutineService routineService;
+
+  @PostMapping("/batch/daily-todos")
+  public ResponseEntity<ApiResult<String>> runDailyTodoBatch() {
+    routineService.generateDailyTodos();
+    return ResponseEntity.ok(ApiResult.ok("generateDailyTodos 완료"));
+  }
+}

--- a/src/main/java/plana/replan/global/admin/AdminController.java
+++ b/src/main/java/plana/replan/global/admin/AdminController.java
@@ -9,11 +9,11 @@ import org.springframework.web.bind.annotation.RestController;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.global.common.ApiResult;
 
-/** local/dev 환경 전용 내부 테스트용 컨트롤러. prod에서는 빈 등록 안 됨. */
+/** local/dev 환경 전용 내부 테스트용 컨트롤러. */
 @RestController
 @RequestMapping("/internal/admin")
 @RequiredArgsConstructor
-@Profile("!prod")
+@Profile({"local", "dev"})
 public class AdminController {
 
   private final RoutineService routineService;

--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         "/v3/api-docs",
                         "/swagger-ui.html",
                         "/actuator/health",
+                        "/internal/**", // 로컬/dev 전용 내부 테스트 엔드포인트
                         "/api/auth/**", // 로그인, 회원가입은 인증 없이 허용
                         "/api/s3/**", // tempToken 검증은 서비스 레이어에서 수동으로
                         "/fcm-test.html", // 로컬 FCM 토큰 테스트용 정적 파일

--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -53,7 +53,6 @@ public class SecurityConfig {
                         "/v3/api-docs",
                         "/swagger-ui.html",
                         "/actuator/health",
-                        "/internal/**", // 로컬/dev 전용 내부 테스트 엔드포인트
                         "/api/auth/**", // 로그인, 회원가입은 인증 없이 허용
                         "/api/s3/**", // tempToken 검증은 서비스 레이어에서 수동으로
                         "/fcm-test.html", // 로컬 FCM 토큰 테스트용 정적 파일

--- a/src/main/resources/db/migration/V17__add_routine_override.sql
+++ b/src/main/resources/db/migration/V17__add_routine_override.sql
@@ -1,0 +1,18 @@
+ALTER TABLE routine
+  ADD COLUMN default_sort_order DOUBLE PRECISION NOT NULL DEFAULT 10000.0;
+
+CREATE TABLE routine_override (
+  id             BIGSERIAL    PRIMARY KEY,
+  routine_id     BIGINT       NOT NULL REFERENCES routine(id),
+  override_date  DATE         NOT NULL,
+  title          VARCHAR(255),
+  tag_id         BIGINT       REFERENCES tag(id),
+  sort_order     DOUBLE PRECISION,
+  is_skipped     BOOLEAN      NOT NULL DEFAULT FALSE,
+  is_pinned      BOOLEAN,
+  is_completed   BOOLEAN,
+  completed_time TIMESTAMP,
+  created_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+  UNIQUE (routine_id, override_date)
+);

--- a/src/main/resources/db/migration/V18__fix_unique_index_todo_routine_duedate_partial.sql
+++ b/src/main/resources/db/migration/V18__fix_unique_index_todo_routine_duedate_partial.sql
@@ -1,0 +1,6 @@
+-- soft-delete된 todo도 unique index에 포함되어 skip→unskip 후 배치가 실패하는 문제 수정.
+-- 전체 unique index → soft-delete 제외 partial unique index로 교체.
+DROP INDEX uq_todo_routine_duedate;
+CREATE UNIQUE INDEX uq_todo_routine_duedate
+    ON todo (routine_id, due_date)
+    WHERE deleted_at IS NULL;

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -71,7 +71,22 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                1L, "아침 스트레칭", null, null, RoutineType.DAILY, null, null, null, null, null, null));
+                1L,
+                "아침 스트레칭",
+                null,
+                null,
+                RoutineType.DAILY,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                10000.0,
+                false,
+                false,
+                false,
+                false));
 
     mockMvc
         .perform(
@@ -100,7 +115,22 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                2L, "영어 단어", dueDate, null, RoutineType.WEEKLY, 21, 5L, null, null, 2L, null));
+                2L,
+                "영어 단어",
+                dueDate,
+                null,
+                RoutineType.WEEKLY,
+                21,
+                5L,
+                null,
+                null,
+                2L,
+                null,
+                10000.0,
+                false,
+                false,
+                false,
+                false));
 
     mockMvc
         .perform(
@@ -134,7 +164,22 @@ class RoutineControllerTest {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                3L, "월간 회고", null, null, RoutineType.MONTHLY, 15, null, null, null, null, null));
+                3L,
+                "월간 회고",
+                null,
+                null,
+                RoutineType.MONTHLY,
+                15,
+                null,
+                null,
+                null,
+                null,
+                null,
+                10000.0,
+                false,
+                false,
+                false,
+                false));
 
     mockMvc
         .perform(
@@ -323,7 +368,22 @@ class RoutineControllerTest {
     given(routineService.updateMotherRoutine(any(), any(), any()))
         .willReturn(
             new RoutineResponseDto(
-                1L, "수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L, "영어", "BLUE", null, null));
+                1L,
+                "수정된 루틴",
+                dueDate,
+                null,
+                RoutineType.WEEKLY,
+                21,
+                5L,
+                "영어",
+                "BLUE",
+                null,
+                null,
+                10000.0,
+                false,
+                false,
+                false,
+                false));
 
     mockMvc
         .perform(

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -30,6 +30,7 @@ import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.RoutineResponseDto;
 import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineOverride;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
 import plana.replan.domain.routine.repository.RoutineOverrideRepository;
@@ -743,5 +744,76 @@ class RoutineServiceTest {
             e ->
                 assertThat(((CustomException) e).getErrorCode())
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
+  }
+
+  // ========== generateDailyTodos with override ==========
+
+  @Test
+  void generateDailyTodos_override_제목_태그_반영됨() {
+    Tag tag = testTag(5L);
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+
+    RoutineOverride override =
+        RoutineOverride.builder().routine(routine).overrideDate(TEST_DATE).build();
+    override.updateContent("오버라이드 제목", tag);
+
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+    given(routineOverrideRepository.findByRoutineIdInAndOverrideDate(any(), any()))
+        .willReturn(List.of(override));
+
+    routineService.generateDailyTodos();
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getTitle()).isEqualTo("오버라이드 제목");
+    assertThat(captor.getValue().getTag()).isEqualTo(tag);
+  }
+
+  @Test
+  void generateDailyTodos_override_skip_이면_생성_안됨() {
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+
+    RoutineOverride override =
+        RoutineOverride.builder().routine(routine).overrideDate(TEST_DATE).build();
+    override.skip();
+
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+    given(routineOverrideRepository.findByRoutineIdInAndOverrideDate(any(), any()))
+        .willReturn(List.of(override));
+
+    routineService.generateDailyTodos();
+
+    verify(todoRepository, never()).saveAndFlush(any(Todo.class));
+  }
+
+  // ========== updateMotherRoutine — override 정리 및 오늘 todo 동기화 ==========
+
+  @Test
+  void 엄마루틴_수정_오늘_이후_override_삭제됨() {
+    Routine routine = motherRoutine();
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+
+    routineService.updateMotherRoutine(
+        1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
+
+    verify(routineOverrideRepository)
+        .deleteByRoutineAndOverrideDateGreaterThanEqual(routine, TEST_DATE);
+  }
+
+  @Test
+  void 엄마루틴_수정_오늘_todo_존재시_제목_태그_즉시_반영() {
+    Routine routine = motherRoutine();
+    Todo existingTodo =
+        Todo.builder().title("기존 제목").user(testUser()).isPinned(false).routine(routine).build();
+    ReflectionTestUtils.setField(existingTodo, "id", 100L);
+
+    given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
+    given(todoRepository.findMotherTodoByRoutineAndDate(any(), any(), any()))
+        .willReturn(Optional.of(existingTodo));
+
+    routineService.updateMotherRoutine(
+        1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
+
+    assertThat(existingTodo.getTitle()).isEqualTo("수정된 루틴");
   }
 }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -12,6 +12,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ import plana.replan.domain.routine.dto.RoutineUpdateRequestDto;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
@@ -53,6 +55,7 @@ class RoutineServiceTest {
 
   @Mock private Clock clock;
   @Mock private RoutineRepository routineRepository;
+  @Mock private RoutineOverrideRepository routineOverrideRepository;
   @Mock private UserRepository userRepository;
   @Mock private TagRepository tagRepository;
   @Mock private GoalRepository goalRepository;
@@ -65,6 +68,9 @@ class RoutineServiceTest {
     // 예외 발생 테스트에서는 clock이 호출되지 않으므로 lenient 처리
     lenient().when(clock.instant()).thenReturn(TEST_DATE.atStartOfDay(KST).toInstant());
     lenient().when(clock.getZone()).thenReturn(KST);
+    lenient()
+        .when(routineOverrideRepository.findByRoutineIdInAndOverrideDate(any(), any()))
+        .thenReturn(Collections.emptyList());
   }
 
   private User testUser() {

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1103,8 +1103,8 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("deleteTodo - 성공 (루틴 있음): 루틴은 삭제하지 않음")
-  void deleteTodo_success_routineNotDeleted() {
+  @DisplayName("deleteTodo - 루틴 있는 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void deleteTodo_routineTodo_throws() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
     Routine routine = testRoutine(user, RoutineType.DAILY);
@@ -1112,10 +1112,12 @@ class TodoServiceTest {
 
     given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
 
-    todoService.deleteTodo(1L, 1L);
-
-    assertThat(ReflectionTestUtils.getField(todo, "deletedAt")).isNotNull();
-    assertThat(ReflectionTestUtils.getField(routine, "deletedAt")).isNull();
+    assertThatThrownBy(() -> todoService.deleteTodo(1L, 1L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
   }
 
   // ── reorderTodo ──────────────────────────────────────────────────────────────
@@ -1661,8 +1663,8 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음 + routineType=null: 루틴 무시, 기존 routine 연결 그대로 유지")
-  void updateTodo_success_existingRoutine_nullTypeIgnored() {
+  @DisplayName("updateTodo - 루틴 있음: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void updateTodo_routineTodo_throws() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
     Routine routine = testRoutine(user, RoutineType.DAILY);
@@ -1670,32 +1672,13 @@ class TodoServiceTest {
 
     given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
 
-    TodoDetailResponseDto result =
-        todoService.updateTodo(1L, 1L, updateTodoRequest("제목", null, null, null, null));
-
-    assertThat(result.getRoutineType()).isEqualTo("DAILY");
-    verify(routineRepository, never()).save(any());
-  }
-
-  @Test
-  @DisplayName("updateTodo - 루틴 있음 + routineType 변경 시도: 무시, 기존 루틴 그대로 유지")
-  void updateTodo_success_existingRoutine_typeChangeIgnored() {
-    User user = testUser();
-    Todo todo = testTodo(1L, user);
-    Routine routine = testRoutine(user, RoutineType.DAILY);
-    ReflectionTestUtils.setField(todo, "routine", routine);
-
-    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
-
-    TodoDetailResponseDto result =
-        todoService.updateTodo(
-            1L, 1L, updateTodoRequest("수정된 제목", null, null, RoutineType.WEEKLY, 5));
-
-    assertThat(routine.getRoutineType()).isEqualTo(RoutineType.DAILY);
-    assertThat(routine.getRoutineDate()).isNull();
-    assertThat(routine.getTitle()).isEqualTo("루틴");
-    assertThat(result.getRoutineType()).isEqualTo("DAILY");
-    verify(routineRepository, never()).save(any());
+    assertThatThrownBy(
+            () -> todoService.updateTodo(1L, 1L, updateTodoRequest("제목", null, null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
   }
 
   @Test
@@ -1732,8 +1715,8 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - 루틴 있음: dueDate 요청값(non-null) 무시, 기존 마감일 보존")
-  void updateTodo_routineTodo_dueDateIgnored_preservesExisting() {
+  @DisplayName("updateTodo - 루틴 있음: dueDate 요청 시 ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void updateTodo_routineTodo_dueDateIgnored_throws() {
     User user = testUser();
     Todo todo = testTodo(1L, user);
     LocalDateTime originalDueDate = LocalDateTime.of(2026, 6, 25, 23, 59, 59);
@@ -1743,30 +1726,17 @@ class TodoServiceTest {
 
     given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
 
-    TodoDetailResponseDto result =
-        todoService.updateTodo(
-            1L,
-            1L,
-            updateTodoRequest("제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null));
-
-    assertThat(result.getDueDate()).isEqualTo(originalDueDate);
-  }
-
-  @Test
-  @DisplayName("updateTodo - 루틴 있음: dueDate=null 요청도 무시, 기존 마감일 보존")
-  void updateTodo_routineTodo_nullDueDateIgnored_preservesExisting() {
-    User user = testUser();
-    Todo todo = testTodo(1L, user);
-    LocalDateTime originalDueDate = LocalDateTime.of(2026, 6, 25, 23, 59, 59);
-    ReflectionTestUtils.setField(todo, "dueDate", originalDueDate);
-    Routine routine = testRoutine(user, RoutineType.DAILY);
-    ReflectionTestUtils.setField(todo, "routine", routine);
-
-    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
-
-    TodoDetailResponseDto result =
-        todoService.updateTodo(1L, 1L, updateTodoRequest("수정된 제목", null, null, null, null));
-
-    assertThat(result.getDueDate()).isEqualTo(originalDueDate);
+    assertThatThrownBy(
+            () ->
+                todoService.updateTodo(
+                    1L,
+                    1L,
+                    updateTodoRequest(
+                        "제목", LocalDateTime.of(2026, 6, 27, 23, 59), null, null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
   }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1715,6 +1715,60 @@ class TodoServiceTest {
   }
 
   @Test
+  @DisplayName("reorderTodo - 루틴 있는 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void reorderTodo_routineTodo_throws() {
+    User user = testUser();
+    Todo todo = testTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(() -> todoService.reorderTodo(1L, 1L, orderRequest(null, 2L)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
+  }
+
+  @Test
+  @DisplayName("completeTodo - 루틴 있는 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void completeTodo_routineTodo_throws() {
+    User user = testUser();
+    Todo todo = testTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(() -> todoService.completeTodo(1L, 1L, completeRequest(true)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
+  }
+
+  @Test
+  @DisplayName("pinTodo - 루틴 있는 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void pinTodo_routineTodo_throws() {
+    User user = testUser();
+    Todo todo = testTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(() -> todoService.pinTodo(1L, 1L, pinRequest(true)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
+  }
+
+  @Test
   @DisplayName("updateTodo - 루틴 있음: dueDate 요청 시 ROUTINE_TODO_USE_ROUTINE_API 예외")
   void updateTodo_routineTodo_dueDateIgnored_throws() {
     User user = testUser();


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #211 


## 변경 사항
> 반복 루틴의 특정 날짜만 재정의(override)할 수 있는 기능을 구현. 루틴 전체를 수정하지 않고도 하루치 제목·태그·순서·완료 상태·건너뜀을 별도로 저장하고, 배치 todo 생성 시 override 값이 자동 반영된다.
- routine_override 테이블 추가 (V17 마이그레이션)
- RoutineOverride 엔티티 및 CRUD 서비스/컨트롤러 구현
  - 내용(제목·태그), 순서, 완료, 고정, 건너뜀/건너뜀취소 API
- 배치 생성 시 override 값 반영 (제목·태그·sortOrder·완료 상태)
- 루틴 todo를 일반 todo API로 수정/삭제 시 400 반환 (ROUTINE_TODO_USE_ROUTINE_API)
- 루틴 전체 수정 시 오늘 이미 생성된 todo 즉시 갱신
- skip→unskip 후 배치 재생성을 위해 partial unique index 적용 (V18)
- AdminController: local/dev 전용 배치 수동 트리거 엔드포인트 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 루틴별 날짜 오버라이드 수정 기능이 추가되어 내용, 순서, 완료 여부, 고정 상태를 변경할 수 있습니다.
  * 루틴을 건너뛰거나 다시 복원하는 동작이 추가되었습니다.
  * 일일 루틴 생성과 조회 응답에 오버라이드 상태 및 적용된 정렬 정보가 반영됩니다.

* **Bug Fixes**
  * 반복 루틴과 일반 할 일의 수정 경로를 분리해, 루틴 연동 항목은 루틴 관련 경로만 사용하도록 정리했습니다.
  * 건너뜀/복원 시 중복 제약 문제를 줄이도록 저장 구조가 개선되었습니다.

* **Chores**
  * 내부 전용 배치 실행 경로가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->