### PR TITLE
Chore: 구글 iOS/Android 로그인용 클라이언트 ID 주입 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,11 @@ jobs:
             aws ssm get-parameter --name /replan/prod/AWS_S3_BUCKET --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "AWS_S3_BUCKET={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/AWS_CLOUDFRONT_DOMAIN --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "AWS_CLOUDFRONT_DOMAIN={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GOOGLE_WEB_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GOOGLE_WEB_CLIENT_ID={}" >> /home/ubuntu/app/.env
+            # 구글 iOS/Android 클라이언트 ID는 아직 없을 수 있으므로(없으면 빈 값으로 두고 배포 계속)
+            GOOGLE_IOS_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_IOS_CLIENT_ID --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
+            echo "GOOGLE_IOS_CLIENT_ID=${GOOGLE_IOS_CLIENT_ID}" >> /home/ubuntu/app/.env
+            GOOGLE_ANDROID_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_ANDROID_CLIENT_ID --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
+            echo "GOOGLE_ANDROID_CLIENT_ID=${GOOGLE_ANDROID_CLIENT_ID}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_HOST --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_HOST={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,11 +68,29 @@ jobs:
             aws ssm get-parameter --name /replan/prod/AWS_S3_BUCKET --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "AWS_S3_BUCKET={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/AWS_CLOUDFRONT_DOMAIN --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "AWS_CLOUDFRONT_DOMAIN={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GOOGLE_WEB_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GOOGLE_WEB_CLIENT_ID={}" >> /home/ubuntu/app/.env
+            # 파라미터가 "없을 때(ParameterNotFound)"만 빈 값으로 허용하고,
+            # 권한 오류·경로 오타·AWS 장애 등 다른 실패는 배포를 중단한다.
+            get_optional_ssm() {
+              local name="$1"
+              local value
+              local err
+              err="$(mktemp)"
+              if value="$(aws ssm get-parameter --name "$name" --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>"$err")"; then
+                printf '%s' "$value"
+              elif grep -q 'ParameterNotFound' "$err"; then
+                printf ''
+              else
+                cat "$err" >&2
+                rm -f "$err"
+                exit 1
+              fi
+              rm -f "$err"
+            }
             # 구글 iOS/Android 클라이언트 ID는 아직 없을 수 있으므로(없으면 빈 값으로 두고 배포 계속)
-            GOOGLE_IOS_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_IOS_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
-            echo "GOOGLE_IOS_CLIENT_ID=${GOOGLE_IOS_CLIENT_ID}" >> /home/ubuntu/app/.env
-            GOOGLE_ANDROID_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_ANDROID_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
-            echo "GOOGLE_ANDROID_CLIENT_ID=${GOOGLE_ANDROID_CLIENT_ID}" >> /home/ubuntu/app/.env
+            GOOGLE_IOS_CLIENT_ID="$(get_optional_ssm /replan/prod/GOOGLE_IOS_CLIENT_ID)"
+            printf 'GOOGLE_IOS_CLIENT_ID=%s\n' "$GOOGLE_IOS_CLIENT_ID" >> /home/ubuntu/app/.env
+            GOOGLE_ANDROID_CLIENT_ID="$(get_optional_ssm /replan/prod/GOOGLE_ANDROID_CLIENT_ID)"
+            printf 'GOOGLE_ANDROID_CLIENT_ID=%s\n' "$GOOGLE_ANDROID_CLIENT_ID" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_HOST --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_HOST={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GEMINI_API_KEY --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GEMINI_API_KEY={}" >> /home/ubuntu/app/.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,9 +69,9 @@ jobs:
             aws ssm get-parameter --name /replan/prod/AWS_CLOUDFRONT_DOMAIN --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "AWS_CLOUDFRONT_DOMAIN={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/GOOGLE_WEB_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "GOOGLE_WEB_CLIENT_ID={}" >> /home/ubuntu/app/.env
             # 구글 iOS/Android 클라이언트 ID는 아직 없을 수 있으므로(없으면 빈 값으로 두고 배포 계속)
-            GOOGLE_IOS_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_IOS_CLIENT_ID --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
+            GOOGLE_IOS_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_IOS_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
             echo "GOOGLE_IOS_CLIENT_ID=${GOOGLE_IOS_CLIENT_ID}" >> /home/ubuntu/app/.env
-            GOOGLE_ANDROID_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_ANDROID_CLIENT_ID --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
+            GOOGLE_ANDROID_CLIENT_ID="$(aws ssm get-parameter --name /replan/prod/GOOGLE_ANDROID_CLIENT_ID --with-decryption --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} 2>/dev/null || true)"
             echo "GOOGLE_ANDROID_CLIENT_ID=${GOOGLE_ANDROID_CLIENT_ID}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_HOST --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_HOST={}" >> /home/ubuntu/app/.env
             aws ssm get-parameter --name /replan/prod/REDIS_PORT --query Parameter.Value --output text --region ${{ secrets.AWS_REGION }} | xargs -I{} echo "REDIS_PORT={}" >> /home/ubuntu/app/.env

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,6 +43,8 @@ jwt:
 google:
   client-ids:
     web: ${GOOGLE_WEB_CLIENT_ID}
+    ios: ${GOOGLE_IOS_CLIENT_ID:}
+    android: ${GOOGLE_ANDROID_CLIENT_ID:}
 
 apple:
   client-ids: ${APPLE_CLIENT_IDS:}


### PR DESCRIPTION
## 변경 사항
구글 로그인을 iOS/Android(스토어 배포 앱)에서도 지원하기 위해, 백엔드가 각 플랫폼 클라이언트 ID로 발급된 구글 토큰을 허용하도록 설정을 추가합니다.

- `application.yaml`의 `google.client-ids`에 `ios`/`android` 자리표시자 추가 (값은 환경변수에서 주입, 없으면 빈 값)
- `deploy.yml`에서 `GOOGLE_IOS_CLIENT_ID`, `GOOGLE_ANDROID_CLIENT_ID`를 파라미터 스토어에서 `.env`로 주입
  - 아직 등록 안 된 값이 있을 수 있어, 조회 실패 시 빈 값으로 두고 배포를 계속합니다.
  - SecureString으로 저장돼 있어도 정상 동작하도록 `--with-decryption`으로 조회합니다.

## 비고
- 실제 클라이언트 ID 값은 파라미터 스토어에서 관리하며 코드에는 비밀값이 포함되지 않습니다.
- Android 클라이언트 ID는 토큰 검증(aud)에 직접 쓰이지 않아 선택값입니다.

close #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Google 로그인 설정에 iOS 및 Android용 클라이언트 ID를 추가해 다양한 플랫폼 지원을 확장했습니다.

* **개선 사항**
  * 배포 과정에서 관련 환경값이 없어도 배포가 중단되지 않도록 처리해, 설정 누락 상황에 더 유연하게 대응합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->