### PR TITLE
Fix: 리플랜으로 투두를 옮길 때 지난 달 통계가 왜곡되던 문제 수정

### DIFF
--- a/src/main/java/plana/replan/domain/replan/entity/Replan.java
+++ b/src/main/java/plana/replan/domain/replan/entity/Replan.java
@@ -41,4 +41,13 @@ public class Replan extends BaseTimeEntity {
     this.failureReason2 = failureReason2;
     this.failureReason3 = failureReason3;
   }
+
+  /**
+   * 리플랜이 가리키는 투두를 바꾼다. 리플랜이 "수정"한 원본 투두를 소프트 삭제(통계 제외)할 때, 삭제된 투두는
+   * {@code @SQLRestriction(deleted_at IS NULL)}으로 모든 조회에서 빠지므로 이 리플랜 자체가 월간 통계 집계에서 사라진다. 그래서 살아있는
+   * 새 투두로 옮겨 달아 리플랜이 정상 집계되게 한다.
+   */
+  public void relinkTodo(Todo todo) {
+    this.todo = Objects.requireNonNull(todo, "투두는 필수입니다.");
+  }
 }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -199,31 +199,28 @@ public class ReplanService {
       return;
     }
 
-    boolean anyAdd = false;
-    boolean anchorModifiedInPlace = false;
-
+    boolean anchorHandled = false;
     for (ReplanOperation op : req.acceptedOperations()) {
       validateOperation(op);
       switch (op.action()) {
-        case ADD -> {
-          applyAdd(op, anchor, replan);
-          anyAdd = true;
-        }
+        case ADD -> applyAdd(op, anchor, replan);
         case MODIFY_TODO -> {
           applyModifyTodo(op, anchor, replan);
           if (op.targetTodoId() != null && op.targetTodoId().equals(anchor.getId())) {
-            anchorModifiedInPlace = true;
+            anchorHandled = true;
           }
         }
-        case MODIFY_ROUTINE -> applyModifyRoutine(op, anchor, replan);
+        case MODIFY_ROUTINE -> {
+          applyModifyRoutine(op, anchor, replan);
+          anchorHandled = true;
+        }
         case CREATE_ROUTINE -> applyCreateRoutine(op, anchor, replan);
       }
     }
 
-    // 마감 지난 일반 투두(앵커)를 ADD로 대체한 경우에만 한 번 숨긴다.
-    // MODIFY_TODO로 앵커 자체를 수정했다면 숨기지 않는다.
-    if (anchor.getRoutine() == null && isOverdue(anchor) && anyAdd && !anchorModifiedInPlace) {
-      anchor.deactivate();
+    // 어떤 작업도 앵커를 직접 치우지 않았고, 새로 만든 결과가 있으면(=앵커가 대체됨) 앵커를 치운다.
+    if (!req.acceptedOperations().isEmpty() && !anchorHandled) {
+      retire(anchor);
     }
   }
 

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -304,21 +304,44 @@ public class ReplanService {
         todoRepository
             .findById(op.targetTodoId())
             .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND));
-    // 우선순위 등으로 앵커 외 다른 투두를 수정할 수 있으나, 반드시 같은 사용자 소유여야 한다
     if (!target.getUser().getId().equals(anchor.getUser().getId())) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
-    if (op.title() != null) {
-      target.updateTitle(op.title());
+    retire(target);
+    recreateFromModify(target, op, replan);
+  }
+
+  /** 기존 투두를 사용자 화면에서 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). */
+  private void retire(Todo target) {
+    if (isOverdue(target)) {
+      target.deactivate();
+    } else {
+      target.getChildren().forEach(Todo::softDelete);
+      target.softDelete();
     }
-    // dueDate/dueTime 중 하나라도 지정된 경우에만 업데이트한다 — 제목만 바꾸는 op이면 기존 마감일을 보존
-    if (op.dueDate() != null || op.dueTime() != null) {
-      target.updateDueDate(resolveModifiedDueDate(target, op));
-    }
-    if (op.tagId() != null) {
-      target.updateTag(resolveTag(op.tagId(), target.getUser().getId()));
-    }
-    target.linkReplan(replan);
+  }
+
+  /** op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다(루틴 연결 없음). */
+  private Todo recreateFromModify(Todo target, ReplanOperation op, Replan replan) {
+    String title = op.title() != null ? op.title() : target.getTitle();
+    LocalDateTime dueDate =
+        (op.dueDate() != null || op.dueTime() != null)
+            ? resolveModifiedDueDate(target, op)
+            : target.getDueDate();
+    Tag tag =
+        op.tagId() != null ? resolveTag(op.tagId(), target.getUser().getId()) : target.getTag();
+    Todo created =
+        Todo.builder()
+            .title(title)
+            .dueDate(dueDate)
+            .sortOrder(target.getSortOrder())
+            .isPinned(target.isPinned())
+            .user(target.getUser())
+            .tag(tag)
+            .goal(target.getGoal())
+            .build();
+    created.linkReplan(replan);
+    return todoRepository.save(created);
   }
 
   /** 앵커의 마감이 지났는지 확인한다. */

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -440,6 +440,12 @@ public class ReplanService {
     if (routine == null) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
+    // 하위 루틴 회차는 규칙(반복 유형/요일/시각/태그)을 따로 가지지 않고 엄마 루틴을 그대로 따른다.
+    // 따라서 루틴 규칙 변경(MODIFY_ROUTINE)은 엄마 루틴 회차에만 의미가 있으므로 하위 루틴 회차는 거부한다.
+    // (엄마 루틴 수정 API·루틴 오버라이드도 동일하게 하위 루틴을 거부한다.)
+    if (routine.isChild()) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+    }
     Tag tag =
         op.tagId() != null ? resolveTag(op.tagId(), anchor.getUser().getId()) : routine.getTag();
     RoutineType effectiveType =
@@ -474,19 +480,16 @@ public class ReplanService {
     // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
     // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
     boolean failedBefore = !isOverdue(anchor);
-    // 하위 루틴 회차면 회차 생성/조회는 엄마 루틴 기준으로 한다. createTodoTreeFromMother는 엄마 루틴만 받기 때문이다.
-    Routine motherRoutine = routine.isChild() ? routine.getParent() : routine;
-    if (failedBefore && routineService.willCreateUpcomingOccurrence(motherRoutine)) {
+    if (failedBefore && routineService.willCreateUpcomingOccurrence(routine)) {
       // 실패 전 + 새 규칙의 다음 회차가 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고,
       // 새 규칙의 다음 회차(오늘 또는 가까운 미래)를 곧바로 만들어 리플랜을 그 회차로 옮긴다.
       retire(anchor);
-      routineService.createTodoTreeFromMother(motherRoutine);
-      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다(엄마 회차가 이미 있으면 그대로 쓴다).
+      routineService.createTodoTreeFromMother(routine);
+      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다.
       // 만에 하나 못 찾으면 옛 회차를 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
       Todo instance =
           todoRepository
-              .findFirstUpcomingMotherTodoByRoutine(
-                  motherRoutine, LocalDate.now(clock).atStartOfDay())
+              .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
               .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION));
       instance.linkReplan(replan);
       replan.relinkTodo(instance);

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -314,6 +314,12 @@ public class ReplanService {
     if (!target.getUser().getId().equals(anchor.getUser().getId())) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
+    // 루틴 회차는 MODIFY_TODO로 고치지 않는다(루틴 변경은 MODIFY_ROUTINE 담당).
+    // 같은 (routine_id, due_date) 슬롯에 새 행을 만들면 partial unique index와 충돌하고,
+    // 분리 후 슬롯이 비면 스케줄러가 회차를 중복 생성하므로 거부한다.
+    if (target.getRoutine() != null) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+    }
     // 하위 투두를 미리 스냅샷해두고 새 부모로 옮긴 뒤 부모만 치운다.
     // retire(target)을 그대로 쓰면 하위 투두까지 소프트 삭제돼 사용자의 서브태스크가 모두 사라진다.
     List<Todo> children = new ArrayList<>(target.getChildren());
@@ -345,8 +351,8 @@ public class ReplanService {
   }
 
   /**
-   * op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다. 루틴 회차의 경우 루틴 연결을 그대로 유지해 스케줄러가 같은 날짜에 회차를 중복 생성하지
-   * 않도록 한다.
+   * op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다. (루틴 회차는 applyModifyTodo에서 이미 거부되므로 여기서는 일반 투두만
+   * 다룬다.)
    */
   private Todo recreateFromModify(Todo target, ReplanOperation op, Replan replan) {
     String title = op.title() != null ? op.title() : target.getTitle();
@@ -366,7 +372,6 @@ public class ReplanService {
             .tag(tag)
             .goal(target.getGoal())
             .parent(target.getParent())
-            .routine(target.getRoutine())
             .build();
     created.linkReplan(replan);
     return todoRepository.save(created);

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -26,6 +26,7 @@ import plana.replan.domain.replan.exception.ReplanErrorCode;
 import plana.replan.domain.replan.repository.ReplanRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
@@ -53,6 +54,7 @@ public class ReplanService {
   private final Clock clock;
   private final RoutineRepository routineRepository;
   private final RoutineService routineService;
+  private final RoutineOverrideRepository routineOverrideRepository;
 
   /**
    * 2단계 선택(+선택적 추가질문 답변)을 받아, 추가 질문이 필요하면 질문을, 충분하면 추천을 반환한다. 질문이 필요한지는 {@link
@@ -419,18 +421,20 @@ public class ReplanService {
         tag);
     routine.linkReplan(replan);
 
-    // 이번 회차 투두(앵커)가 미완료면 새 규칙에 맞춰 동기화, 완료면 그대로 둔다
-    if (!anchor.isCompleted()) {
-      if (op.title() != null) {
-        anchor.updateTitle(op.title());
-      }
-      if (op.dueDate() != null || op.dueTime() != null) {
-        anchor.updateDueDate(resolveModifiedDueDate(anchor, op));
-      }
-      if (op.tagId() != null) {
-        anchor.updateTag(tag);
-      }
-      anchor.linkReplan(replan);
+    // 미래 회차 수정기록 폐기(옛 규칙 기준이라 의미 없어짐)
+    routineOverrideRepository.deleteByRoutineAndOverrideDateGreaterThanEqual(
+        routine, LocalDate.now(clock));
+
+    // 이번 회차(앵커) 치우기 — 실패 전 삭제 / 실패 후 비활성화
+    boolean failedBefore = !isOverdue(anchor);
+    retire(anchor);
+
+    // 실패 전 + 새 규칙에 오늘이 포함되면 오늘 회차를 새 규칙대로 재생성
+    if (failedBefore && routineService.occursToday(routine)) {
+      routineService.createTodoTreeFromMother(routine);
+      todoRepository
+          .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
+          .ifPresent(instance -> instance.linkReplan(replan));
     }
   }
 

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -344,7 +344,10 @@ public class ReplanService {
     }
   }
 
-  /** op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다(루틴 연결 없음). */
+  /**
+   * op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다. 루틴 회차의 경우 루틴 연결을 그대로 유지해 스케줄러가 같은 날짜에 회차를 중복 생성하지
+   * 않도록 한다.
+   */
   private Todo recreateFromModify(Todo target, ReplanOperation op, Replan replan) {
     String title = op.title() != null ? op.title() : target.getTitle();
     LocalDateTime dueDate =
@@ -363,6 +366,7 @@ public class ReplanService {
             .tag(tag)
             .goal(target.getGoal())
             .parent(target.getParent())
+            .routine(target.getRoutine())
             .build();
     created.linkReplan(replan);
     return todoRepository.save(created);

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -202,10 +202,14 @@ public class ReplanService {
     }
 
     boolean anchorHandled = false;
+    boolean replacementCreated = false;
     for (ReplanOperation op : req.acceptedOperations()) {
       validateOperation(op);
       switch (op.action()) {
-        case ADD -> applyAdd(op, anchor, replan);
+        case ADD -> {
+          applyAdd(op, anchor, replan);
+          replacementCreated = true;
+        }
         case MODIFY_TODO -> {
           applyModifyTodo(op, anchor, replan);
           if (op.targetTodoId() != null && op.targetTodoId().equals(anchor.getId())) {
@@ -216,12 +220,16 @@ public class ReplanService {
           applyModifyRoutine(op, anchor, replan);
           anchorHandled = true;
         }
-        case CREATE_ROUTINE -> applyCreateRoutine(op, anchor, replan);
+        case CREATE_ROUTINE -> {
+          applyCreateRoutine(op, anchor, replan);
+          replacementCreated = true;
+        }
       }
     }
 
-    // 어떤 작업도 앵커를 직접 치우지 않았고, 새로 만든 결과가 있으면(=앵커가 대체됨) 앵커를 치운다.
-    if (!req.acceptedOperations().isEmpty() && !anchorHandled) {
+    // 앵커를 직접 치우지 않았고 ADD/CREATE_ROUTINE으로 대체 투두가 생겼을 때만 앵커를 치운다.
+    // MODIFY_TODO가 앵커가 아닌 다른 투두만 수정한 경우 replacementCreated=false이므로 앵커는 그대로 둔다.
+    if (!anchorHandled && replacementCreated) {
       retire(anchor);
     }
   }
@@ -306,8 +314,12 @@ public class ReplanService {
     if (!target.getUser().getId().equals(anchor.getUser().getId())) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
-    retire(target);
-    recreateFromModify(target, op, replan);
+    // 하위 투두를 미리 스냅샷해두고 새 부모로 옮긴 뒤 부모만 치운다.
+    // retire(target)을 그대로 쓰면 하위 투두까지 소프트 삭제돼 사용자의 서브태스크가 모두 사라진다.
+    List<Todo> children = new ArrayList<>(target.getChildren());
+    Todo newTodo = recreateFromModify(target, op, replan);
+    children.forEach(child -> child.updateParent(newTodo));
+    retireWithoutChildren(target);
   }
 
   /** 기존 투두를 사용자 화면에서 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). */
@@ -316,6 +328,18 @@ public class ReplanService {
       target.deactivate();
     } else {
       target.getChildren().forEach(Todo::softDelete);
+      target.softDelete();
+    }
+  }
+
+  /**
+   * 투두 자신만 치운다(하위 투두는 건드리지 않음): 마감 지났으면 비활성화, 아니면 소프트 삭제. MODIFY_TODO에서 하위 투두를 새 부모로 옮긴 뒤 원래 부모를 치울
+   * 때 사용한다.
+   */
+  private void retireWithoutChildren(Todo target) {
+    if (isOverdue(target)) {
+      target.deactivate();
+    } else {
       target.softDelete();
     }
   }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -474,17 +474,18 @@ public class ReplanService {
     // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
     // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
     boolean failedBefore = !isOverdue(anchor);
-    if (failedBefore && routineService.occursToday(routine)) {
-      // 실패 전 + 오늘도 회차 → 옛 회차는 소프트 삭제(통계 제외)하고 오늘 회차를 새 규칙대로 재생성
+    if (failedBefore && routineService.willMaterializeToday(routine)) {
+      // 실패 전 + 오늘 회차가 실제로 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고 오늘 회차를 새 규칙대로 재생성한다.
       retire(anchor);
       routineService.createTodoTreeFromMother(routine);
-      todoRepository
-          .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
-          .ifPresent(
-              instance -> {
-                instance.linkReplan(replan);
-                replan.relinkTodo(instance);
-              });
+      // willMaterializeToday가 true면 위 호출이 반드시 회차를 만든다. 만에 하나 못 찾으면 옛 회차를
+      // 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 차라리 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
+      Todo instance =
+          todoRepository
+              .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
+              .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION));
+      instance.linkReplan(replan);
+      replan.relinkTodo(instance);
     } else if (failedBefore) {
       // 실패 전이지만 새 규칙에 오늘 회차가 없어 대체 투두가 없다.
       // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -474,16 +474,19 @@ public class ReplanService {
     // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
     // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
     boolean failedBefore = !isOverdue(anchor);
-    if (failedBefore && routineService.willCreateUpcomingOccurrence(routine)) {
+    // 하위 루틴 회차면 회차 생성/조회는 엄마 루틴 기준으로 한다. createTodoTreeFromMother는 엄마 루틴만 받기 때문이다.
+    Routine motherRoutine = routine.isChild() ? routine.getParent() : routine;
+    if (failedBefore && routineService.willCreateUpcomingOccurrence(motherRoutine)) {
       // 실패 전 + 새 규칙의 다음 회차가 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고,
       // 새 규칙의 다음 회차(오늘 또는 가까운 미래)를 곧바로 만들어 리플랜을 그 회차로 옮긴다.
       retire(anchor);
-      routineService.createTodoTreeFromMother(routine);
-      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다. 만에 하나 못 찾으면 옛 회차를
-      // 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 차라리 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
+      routineService.createTodoTreeFromMother(motherRoutine);
+      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다(엄마 회차가 이미 있으면 그대로 쓴다).
+      // 만에 하나 못 찾으면 옛 회차를 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
       Todo instance =
           todoRepository
-              .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
+              .findFirstUpcomingMotherTodoByRoutine(
+                  motherRoutine, LocalDate.now(clock).atStartOfDay())
               .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION));
       instance.linkReplan(replan);
       replan.relinkTodo(instance);

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -227,9 +227,9 @@ public class ReplanService {
       }
     }
 
-    // 앵커를 직접 치우지 않았고 ADD/CREATE_ROUTINE으로 대체 투두가 생겼을 때만 앵커를 치운다.
-    // MODIFY_TODO가 앵커가 아닌 다른 투두만 수정한 경우 replacementCreated=false이므로 앵커는 그대로 둔다.
-    if (!anchorHandled && replacementCreated) {
+    // 마감 지난(실패 후) 앵커를 ADD/CREATE_ROUTINE으로 대체한 경우에만 앵커를 치운다(비활성화).
+    // 미래(실패 전) 앵커의 ADD는 보조 투두 추가일 수 있으므로 앵커를 건드리지 않는다.
+    if (!anchorHandled && isOverdue(anchor) && replacementCreated) {
       retire(anchor);
     }
   }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -221,8 +222,9 @@ public class ReplanService {
           anchorHandled = true;
         }
         case CREATE_ROUTINE -> {
-          applyCreateRoutine(op, anchor, replan);
-          replacementCreated = true;
+          // 회차 투두가 실제로 만들어졌을 때만 "앵커를 치울 대체가 생겼다"고 본다.
+          // (루틴 종료일이 이미 지나 회차가 안 생기면 앵커를 비활성화하면 안 된다 — 원본까지 사라짐)
+          replacementCreated |= applyCreateRoutine(op, anchor, replan);
         }
       }
     }
@@ -494,7 +496,8 @@ public class ReplanService {
     }
   }
 
-  private void applyCreateRoutine(ReplanOperation op, Todo anchor, Replan replan) {
+  /** 새 루틴을 만들고 가까운 회차 투두를 리플랜에 연결한다. 회차 투두가 실제로 만들어졌으면 true. */
+  private boolean applyCreateRoutine(ReplanOperation op, Todo anchor, Replan replan) {
     if (op.routineType() == null) {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
@@ -517,9 +520,11 @@ public class ReplanService {
     routine.linkReplan(replan);
     routineRepository.save(routine);
     routineService.createTodoTreeFromMother(routine);
-    todoRepository
-        .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
-        .ifPresent(instanceTodo -> instanceTodo.linkReplan(replan));
+    Optional<Todo> instance =
+        todoRepository.findFirstUpcomingMotherTodoByRoutine(
+            routine, LocalDate.now(clock).atStartOfDay());
+    instance.ifPresent(instanceTodo -> instanceTodo.linkReplan(replan));
+    return instance.isPresent();
   }
 
   private void validateRecurrence(RoutineType type, Integer routineDate) {

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -362,6 +362,7 @@ public class ReplanService {
             .user(target.getUser())
             .tag(tag)
             .goal(target.getGoal())
+            .parent(target.getParent())
             .build();
     created.linkReplan(replan);
     return todoRepository.save(created);

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -326,6 +326,13 @@ public class ReplanService {
     Todo newTodo = recreateFromModify(target, op, replan);
     children.forEach(child -> child.updateParent(newTodo));
     retireWithoutChildren(target);
+    // 앵커 자신을 소프트 삭제하는 경우(실패 전), 위에서 만든 Replan이 가리키던 앵커가
+    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 사라진다.
+    // 리플랜을 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 정상 집계되게 한다.
+    // (앵커가 아닌 다른 투두 수정이나 실패 후 비활성화는 앵커가 살아있어 옮길 필요가 없다.)
+    if (target == anchor && !isOverdue(target)) {
+      replan.relinkTodo(newTodo);
+    }
   }
 
   /** 기존 투두를 사용자 화면에서 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). */
@@ -459,16 +466,31 @@ public class ReplanService {
     routineOverrideRepository.deleteByRoutineAndOverrideDateGreaterThanEqual(
         routine, LocalDate.now(clock));
 
-    // 이번 회차(앵커) 치우기 — 실패 전 삭제 / 실패 후 비활성화
+    // 이번 회차(앵커) 치우기.
+    // 주의: 위에서 만든 Replan은 anchor를 가리킨다. 실패 전이라고 anchor를 소프트 삭제하면
+    // @SQLRestriction(deleted_at IS NULL) 때문에 월간 리포트의 리플랜 조회에서 이 리플랜이 통째로
+    // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
+    // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
     boolean failedBefore = !isOverdue(anchor);
-    retire(anchor);
-
-    // 실패 전 + 새 규칙에 오늘이 포함되면 오늘 회차를 새 규칙대로 재생성
     if (failedBefore && routineService.occursToday(routine)) {
+      // 실패 전 + 오늘도 회차 → 옛 회차는 소프트 삭제(통계 제외)하고 오늘 회차를 새 규칙대로 재생성
+      retire(anchor);
       routineService.createTodoTreeFromMother(routine);
       todoRepository
           .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
-          .ifPresent(instance -> instance.linkReplan(replan));
+          .ifPresent(
+              instance -> {
+                instance.linkReplan(replan);
+                replan.relinkTodo(instance);
+              });
+    } else if (failedBefore) {
+      // 실패 전이지만 새 규칙에 오늘 회차가 없어 대체 투두가 없다.
+      // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.
+      anchor.getChildren().forEach(Todo::deactivate);
+      anchor.deactivate();
+    } else {
+      // 실패 후 → 비활성화(통계에 실패로 남김). 앵커가 살아있어 리플랜도 정상 집계된다.
+      retire(anchor);
     }
   }
 

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -337,9 +337,13 @@ public class ReplanService {
     }
   }
 
-  /** 기존 투두를 사용자 화면에서 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). */
+  /**
+   * 기존 투두를 (하위 투두까지 함께) 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). 부모만 치우고 자식을 두면 상태가
+   * 어긋나므로 두 경로 모두 자식을 함께 처리한다.
+   */
   private void retire(Todo target) {
     if (isOverdue(target)) {
+      target.getChildren().forEach(Todo::deactivate);
       target.deactivate();
     } else {
       target.getChildren().forEach(Todo::softDelete);
@@ -491,6 +495,11 @@ public class ReplanService {
           todoRepository
               .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
               .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION));
+      // 같은 슬롯에 회차가 이미 있어 createTodoTreeFromMother가 새로 만들지 않은 경우(no-op)에도
+      // 그 회차가 옛 규칙 내용으로 남지 않도록 제목·태그를 새 루틴 값으로 동기화한다(updateMotherRoutine과 동일).
+      instance.updateTitle(routine.getTitle());
+      instance.updateTag(routine.getTag());
+      instance.getChildren().forEach(child -> child.updateTag(routine.getTag()));
       instance.linkReplan(replan);
       replan.relinkTodo(instance);
     } else if (failedBefore) {

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -474,11 +474,12 @@ public class ReplanService {
     // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
     // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
     boolean failedBefore = !isOverdue(anchor);
-    if (failedBefore && routineService.willMaterializeToday(routine)) {
-      // 실패 전 + 오늘 회차가 실제로 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고 오늘 회차를 새 규칙대로 재생성한다.
+    if (failedBefore && routineService.willCreateUpcomingOccurrence(routine)) {
+      // 실패 전 + 새 규칙의 다음 회차가 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고,
+      // 새 규칙의 다음 회차(오늘 또는 가까운 미래)를 곧바로 만들어 리플랜을 그 회차로 옮긴다.
       retire(anchor);
       routineService.createTodoTreeFromMother(routine);
-      // willMaterializeToday가 true면 위 호출이 반드시 회차를 만든다. 만에 하나 못 찾으면 옛 회차를
+      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다. 만에 하나 못 찾으면 옛 회차를
       // 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 차라리 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
       Todo instance =
           todoRepository
@@ -487,7 +488,7 @@ public class ReplanService {
       instance.linkReplan(replan);
       replan.relinkTodo(instance);
     } else if (failedBefore) {
-      // 실패 전이지만 새 규칙에 오늘 회차가 없어 대체 투두가 없다.
+      // 실패 전이지만 반복 종료일이 지나 다음 회차가 더는 만들어지지 않는다(루틴이 사실상 끝남).
       // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.
       anchor.getChildren().forEach(Todo::deactivate);
       anchor.deactivate();

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -290,9 +290,18 @@ public class RoutineService {
         });
   }
 
-  /** 오늘이 이 루틴의 회차일인지. 리플랜에서 "오늘 회차를 재생성할지" 판단에 쓴다. */
-  public boolean occursToday(Routine routine) {
-    return isOccurrenceDay(routine, LocalDate.now(clock));
+  /**
+   * 오늘 이 루틴의 회차 투두가 실제로 만들어질지 판단한다. 오늘이 회차일이고(반복 요일/일자 일치), 반복 종료일이 지나지 않았어야 한다 — {@link
+   * #createTodoTreeFromMother(Routine)}가 실제로 회차를 만드는 조건과 동일하다. 리플랜에서 "옛 회차를 치우고 오늘 회차를 새로 만들지"를
+   * 결정하는 데 쓴다(만들 수 없으면 옛 회차를 삭제하면 안 된다).
+   */
+  public boolean willMaterializeToday(Routine routine) {
+    LocalDate today = LocalDate.now(clock);
+    if (!isOccurrenceDay(routine, today)) {
+      return false;
+    }
+    // 반복 종료일이 오늘보다 이전이면 회차를 만들지 않는다(createTodoTreeFromMother와 같은 규칙).
+    return routine.getDueDate() == null || !today.isAfter(routine.getDueDate().toLocalDate());
   }
 
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -291,17 +291,16 @@ public class RoutineService {
   }
 
   /**
-   * 오늘 이 루틴의 회차 투두가 실제로 만들어질지 판단한다. 오늘이 회차일이고(반복 요일/일자 일치), 반복 종료일이 지나지 않았어야 한다 — {@link
-   * #createTodoTreeFromMother(Routine)}가 실제로 회차를 만드는 조건과 동일하다. 리플랜에서 "옛 회차를 치우고 오늘 회차를 새로 만들지"를
-   * 결정하는 데 쓴다(만들 수 없으면 옛 회차를 삭제하면 안 된다).
+   * {@link #createTodoTreeFromMother(Routine)}가 이 루틴의 다음 회차 투두를 실제로 만들지 판단한다. 다음 회차(오늘 또는 가까운 미래)가
+   * 반복 종료일을 넘지 않으면 만든다 — createTodoTreeFromMother와 같은 규칙이다. 리플랜에서 "옛 회차를 치우고 새 회차로 옮길 수 있는지"를 결정하는
+   * 데 쓴다(만들 수 없으면 옛 회차를 삭제하면 안 된다).
    */
-  public boolean willMaterializeToday(Routine routine) {
-    LocalDate today = LocalDate.now(clock);
-    if (!isOccurrenceDay(routine, today)) {
-      return false;
+  public boolean willCreateUpcomingOccurrence(Routine routine) {
+    if (routine.getDueDate() == null) {
+      return true; // 무기한 반복 → 다음 회차를 항상 만든다
     }
-    // 반복 종료일이 오늘보다 이전이면 회차를 만들지 않는다(createTodoTreeFromMother와 같은 규칙).
-    return routine.getDueDate() == null || !today.isAfter(routine.getDueDate().toLocalDate());
+    LocalDate next = nextOccurrence(routine, LocalDate.now(clock));
+    return !next.isAfter(routine.getDueDate().toLocalDate());
   }
 
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -290,6 +290,11 @@ public class RoutineService {
         });
   }
 
+  /** 오늘이 이 루틴의 회차일인지. 리플랜에서 "오늘 회차를 재생성할지" 판단에 쓴다. */
+  public boolean occursToday(Routine routine) {
+    return isOccurrenceDay(routine, LocalDate.now(clock));
+  }
+
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {
     return switch (routine.getRoutineType()) {
       case DAILY -> true;

--- a/src/main/java/plana/replan/domain/todo/entity/Todo.java
+++ b/src/main/java/plana/replan/domain/todo/entity/Todo.java
@@ -100,6 +100,10 @@ public class Todo extends BaseTimeEntity {
     this.routine = routine;
   }
 
+  public void updateParent(Todo parent) {
+    this.parent = parent;
+  }
+
   public void updatePinned(boolean isPinned) {
     this.isPinned = isPinned;
   }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -377,7 +377,8 @@ class ReplanServiceTest {
     given(anchor.getRoutine()).willReturn(routine);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.willMaterializeToday(routine)).willReturn(false); // 오늘 회차 안 만들어짐
+    given(routineService.willCreateUpcomingOccurrence(routine))
+        .willReturn(false); // 종료일 경과 → 다음 회차 안 만들어짐
 
     ReplanOperation op =
         new ReplanOperation(
@@ -419,7 +420,7 @@ class ReplanServiceTest {
     given(routine.getTag()).willReturn(null);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.willMaterializeToday(routine)).willReturn(true);
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
     given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
         .willReturn(Optional.of(org.mockito.Mockito.mock(Todo.class)));
 
@@ -445,7 +446,7 @@ class ReplanServiceTest {
     given(routine.getTag()).willReturn(null);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.willMaterializeToday(routine)).willReturn(true);
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
     Todo newInstance = org.mockito.Mockito.mock(Todo.class);
     given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
         .willReturn(Optional.of(newInstance));

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -465,30 +465,28 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_ROUTINE_하위루틴_회차면_엄마루틴으로_재생성한다() {
-    // 하위 루틴 회차를 리플랜하면 재생성은 엄마 루틴 기준으로 해야 한다(createTodoTreeFromMother는 엄마 전용 — 하위로 부르면 500).
+  void MODIFY_ROUTINE_하위루틴_회차_대상이면_거부된다() {
+    // 하위 루틴 회차는 규칙을 따로 갖지 않고 엄마 루틴을 따른다 — 루틴 규칙 변경(MODIFY_ROUTINE)은 거부한다.
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);
-    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
-    given(anchor.getChildren()).willReturn(List.of());
     Routine child = org.mockito.Mockito.mock(Routine.class);
-    Routine mother = org.mockito.Mockito.mock(Routine.class);
     given(anchor.getRoutine()).willReturn(child);
     given(child.isChild()).willReturn(true);
-    given(child.getParent()).willReturn(mother);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.willCreateUpcomingOccurrence(mother)).willReturn(true);
-    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
-        .willReturn(Optional.of(org.mockito.Mockito.mock(Todo.class)));
 
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
-    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
-    then(routineService).should().createTodoTreeFromMother(mother); // 하위가 아니라 엄마 루틴으로 재생성
-    then(anchor).should().softDelete();
+    assertThatThrownBy(
+            () ->
+                replanService.save(
+                    1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op))))
+        .isInstanceOfSatisfying(
+            CustomException.class,
+            e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
+    then(routineService).should(never()).createTodoTreeFromMother(any());
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -566,19 +566,21 @@ class ReplanServiceTest {
   }
 
   @Test
-  void 앵커를_안건드린_ADD만이면_앵커도_치운다() {
+  void 미래_앵커에_보조_ADD만이면_앵커는_그대로_둔다() {
+    // 실패 전(미래) 앵커에 ADD는 보조 투두 추가일 수 있으므로 앵커를 치우면 안 된다
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 7, 1, 10, 0)); // 미래(실패 전)
-    given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation addOp =
         new ReplanOperation(
-            ReplanAction.ADD, null, "추가", "2026-07-02", null, null, null, null, List.of());
+            ReplanAction.ADD, null, "조용한 장소 세팅", "2026-07-02", null, null, null, null, List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(addOp)));
 
-    then(anchor).should().softDelete(); // 앵커는 실패 전이므로 삭제
+    then(anchor).should(never()).softDelete();
+    then(anchor).should(never()).deactivate();
+    then(todoRepository).should().save(any(Todo.class)); // 보조 투두는 생성됨
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -377,7 +377,7 @@ class ReplanServiceTest {
     given(anchor.getRoutine()).willReturn(routine);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.occursToday(routine)).willReturn(false); // 새 규칙에 오늘 없음 → 재생성 안 함
+    given(routineService.willMaterializeToday(routine)).willReturn(false); // 오늘 회차 안 만들어짐
 
     ReplanOperation op =
         new ReplanOperation(
@@ -419,9 +419,9 @@ class ReplanServiceTest {
     given(routine.getTag()).willReturn(null);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.occursToday(routine)).willReturn(true);
+    given(routineService.willMaterializeToday(routine)).willReturn(true);
     given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
-        .willReturn(Optional.empty());
+        .willReturn(Optional.of(org.mockito.Mockito.mock(Todo.class)));
 
     ReplanOperation op =
         new ReplanOperation(
@@ -445,7 +445,7 @@ class ReplanServiceTest {
     given(routine.getTag()).willReturn(null);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routineService.occursToday(routine)).willReturn(true);
+    given(routineService.willMaterializeToday(routine)).willReturn(true);
     Todo newInstance = org.mockito.Mockito.mock(Todo.class);
     given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
         .willReturn(Optional.of(newInstance));

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -582,6 +582,88 @@ class ReplanServiceTest {
   }
 
   @Test
+  void 우선순위_리플랜에서_앵커_아닌_투두만_수정하면_앵커는_건드리지_않는다() {
+    // Bug 1 회귀: ADD/CREATE_ROUTINE 없이 MODIFY_TODO만 있을 때 앵커를 오삭제하던 문제
+    Todo anchor = ownedTodo(42L, 1L);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+
+    User sameUser = org.mockito.Mockito.mock(User.class);
+    given(sameUser.getId()).willReturn(1L);
+    Todo target = org.mockito.Mockito.mock(Todo.class);
+    given(target.getUser()).willReturn(sameUser);
+    given(target.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(target.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(99L)).willReturn(Optional.of(target));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modifyOp =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            99L, // 앵커(42)가 아닌 다른 투두를 대상으로 한다
+            "[1] 데이터 분석 1~2강",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
+    ReplanSaveRequest req =
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp));
+
+    replanService.save(1L, req);
+
+    // 대체 투두(ADD)가 없으므로 앵커(42)는 건드리지 않아야 한다
+    then(anchor).should(never()).softDelete();
+    then(anchor).should(never()).deactivate();
+    // 대상(99)은 치우고 새 투두로 대체해야 한다
+    then(target).should().softDelete();
+    then(todoRepository).should().save(any(Todo.class));
+  }
+
+  @Test
+  void MODIFY_TODO_부모투두_수정시_하위투두는_새_부모로_옮기고_삭제하지_않는다() {
+    // Bug 2 회귀: 하위 투두가 있는 부모를 수정할 때 하위 투두까지 삭제되던 문제
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+
+    Todo child1 = org.mockito.Mockito.mock(Todo.class);
+    Todo child2 = org.mockito.Mockito.mock(Todo.class);
+    given(anchor.getChildren()).willReturn(List.of(child1, child2));
+
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "데이터 분석 1~2강",
+            "2026-07-02",
+            "23:59",
+            null,
+            null,
+            null,
+            List.of());
+    ReplanSaveRequest req =
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+
+    replanService.save(1L, req);
+
+    // 새로 만들어진 부모 투두를 캡처해서 각 하위 투두가 그걸 부모로 갱신했는지 확인한다
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(captor.capture());
+    Todo newParent = captor.getValue();
+
+    then(child1).should().updateParent(newParent);
+    then(child2).should().updateParent(newParent);
+    // 하위 투두는 삭제돼서는 안 된다
+    then(child1).should(never()).softDelete();
+    then(child2).should(never()).softDelete();
+  }
+
+  @Test
   void 잘못된_마감형식이면_400() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -1008,4 +1008,35 @@ class ReplanServiceTest {
             CustomException.class,
             e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
   }
+
+  @Test
+  void MODIFY_TODO_루틴회차_수정시_루틴연결을_유지한다() {
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    given(anchor.getRoutine()).willReturn(routine);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "가벼운 스트레칭",
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(todoRepository).should().save(captor.capture());
+    assertThat(captor.getValue().getRoutine()).isSameAs(routine);
+  }
 }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -218,6 +218,7 @@ class ReplanServiceTest {
   @Test
   void MODIFY_TODO는_기존투두를_치우고_새투두를_만든다() {
     Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
     // 마감 전(2026-06-25) → 실패 전 → softDelete
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0));
     given(anchor.getChildren()).willReturn(List.of());
@@ -282,6 +283,7 @@ class ReplanServiceTest {
   @Test
   void MODIFY_TODO_마감_지난_대상은_비활성화된다() {
     Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거(실패 후)
     given(anchor.getTitle()).willReturn("데이터 분석");
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
@@ -477,7 +479,6 @@ class ReplanServiceTest {
   @Test
   void 마감_지난_일반투두를_ADD로_대체하면_원본을_숨긴다() {
     Todo todo = ownedTodo(42L, 1L);
-    given(todo.getRoutine()).willReturn(null);
     given(todo.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
@@ -501,34 +502,39 @@ class ReplanServiceTest {
   }
 
   @Test
-  void 마감_지난_앵커를_MODIFY하고_ADD도_있으면_원본은_안숨긴다() {
+  void 앵커를_MODIFY로_치우면_post_loop에서_또_치우지_않는다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);
-    given(anchor.getRoutine()).willReturn(null);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation modifyOp =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO,
-            42L,
-            "수정된 제목",
-            "2026-06-25",
-            null,
-            null,
-            null,
-            null,
-            List.of());
+            ReplanAction.MODIFY_TODO, 42L, "수정", "2026-06-25", null, null, null, null, List.of());
     ReplanOperation addOp =
         new ReplanOperation(
-            ReplanAction.ADD, null, "추가 투두", "2026-06-26", null, null, null, null, List.of());
-    ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp, addOp));
+            ReplanAction.ADD, null, "추가", "2026-06-26", null, null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp, addOp)));
 
-    replanService.save(1L, req);
+    then(anchor).should(times(1)).deactivate(); // MODIFY에서 1번만
+  }
 
-    then(anchor).should(never()).deactivate();
+  @Test
+  void 앵커를_안건드린_ADD만이면_앵커도_치운다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 7, 1, 10, 0)); // 미래(실패 전)
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation addOp =
+        new ReplanOperation(
+            ReplanAction.ADD, null, "추가", "2026-07-02", null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(addOp)));
+
+    then(anchor).should().softDelete(); // 앵커는 실패 전이므로 삭제
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -216,9 +216,12 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_TODO는_기존_투두를_제자리_수정한다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
+  void MODIFY_TODO는_기존투두를_치우고_새투두를_만든다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    // 마감 전(2026-06-25) → 실패 전 → softDelete
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0));
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation modify =
@@ -226,7 +229,7 @@ class ReplanServiceTest {
             ReplanAction.MODIFY_TODO,
             42L,
             "데이터 분석 1~2강",
-            "2026-06-20",
+            "2026-07-02",
             "23:59",
             null,
             null,
@@ -237,39 +240,13 @@ class ReplanServiceTest {
 
     replanService.save(1L, req);
 
-    then(todo).should().updateTitle("데이터 분석 1~2강");
-    then(todo).should().linkReplan(any(Replan.class));
-    then(todoRepository).should(never()).save(any(Todo.class));
+    then(anchor).should().softDelete(); // 실패 전이므로 삭제
+    then(anchor).should(never()).deactivate();
+    then(todoRepository).should().save(any(Todo.class)); // 새 투두 생성
   }
 
   @Test
-  void MODIFY_TODO_제목만_바꾸면_마감일은_유지된다() {
-    Todo anchor = ownedTodo(42L, 1L);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
-    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-
-    ReplanOperation modify =
-        new ReplanOperation(
-            ReplanAction.MODIFY_TODO,
-            42L,
-            "새 제목",
-            null, // dueDate null
-            null, // dueTime null
-            null,
-            null,
-            null,
-            List.of());
-    ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
-
-    replanService.save(1L, req);
-
-    then(anchor).should().updateTitle("새 제목");
-    then(anchor).should(never()).updateDueDate(any());
-  }
-
-  @Test
-  void 우선순위_다른_투두도_같은_사용자면_수정된다() {
+  void 우선순위_다른_투두도_같은사용자면_치우고_새로만든다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
 
@@ -277,6 +254,8 @@ class ReplanServiceTest {
     given(sameUser.getId()).willReturn(1L);
     Todo target = org.mockito.Mockito.mock(Todo.class);
     given(target.getUser()).willReturn(sameUser);
+    given(target.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(target.getChildren()).willReturn(List.of());
     given(todoRepository.findById(99L)).willReturn(Optional.of(target));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -285,8 +264,8 @@ class ReplanServiceTest {
             ReplanAction.MODIFY_TODO,
             99L,
             "[1] 데이터 분석 1~2강",
-            "2026-06-20",
-            "23:59",
+            null,
+            null,
             null,
             null,
             null,
@@ -296,8 +275,29 @@ class ReplanServiceTest {
 
     replanService.save(1L, req);
 
-    then(target).should().updateTitle("[1] 데이터 분석 1~2강");
-    then(target).should().linkReplan(any(Replan.class));
+    then(target).should().softDelete();
+    then(todoRepository).should().save(any(Todo.class));
+  }
+
+  @Test
+  void MODIFY_TODO_마감_지난_대상은_비활성화된다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거(실패 후)
+    given(anchor.getTitle()).willReturn("데이터 분석");
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, null, "2026-07-02", null, null, null, null, List.of());
+    ReplanSaveRequest req =
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+
+    replanService.save(1L, req);
+
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
+    then(todoRepository).should().save(any(Todo.class));
   }
 
   @Test
@@ -589,31 +589,24 @@ class ReplanServiceTest {
             e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
   }
 
-  // Fix 2 — 시간만 바꾸면 기존 날짜 보존
   @Test
-  void MODIFY_TODO_시간만_바꾸면_기존_날짜는_유지된다() {
+  void MODIFY_TODO_시간만_바꾸면_새투두는_기존_날짜를_유지한다() {
     Todo anchor = ownedTodo(42L, 1L);
-    given(anchor.getDueDate()).willReturn(java.time.LocalDateTime.of(2026, 6, 20, 10, 0));
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 10, 0)); // 실패 전
+    given(anchor.getTitle()).willReturn("데이터 분석");
+    given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
 
     ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO,
-            42L,
-            null, // 제목 변경 없음
-            null, // dueDate null — 기존 날짜 유지
-            "15:30", // dueTime만 변경
-            null,
-            null,
-            null,
-            List.of());
-    ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+            ReplanAction.MODIFY_TODO, 42L, null, null, "15:30", null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
-    replanService.save(1L, req);
-
-    then(anchor).should().updateDueDate(java.time.LocalDateTime.of(2026, 6, 20, 15, 30));
+    then(todoRepository).should().save(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDateTime.of(2026, 6, 25, 15, 30));
   }
 
   // Fix 3 — 실패 이유 개수 검증

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -397,6 +397,32 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_ROUTINE_재생성된_오늘회차에_리플랜링크를_단다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.occursToday(routine)).willReturn(true);
+    Todo newInstance = org.mockito.Mockito.mock(Todo.class);
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(newInstance));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    then(newInstance).should().linkReplan(any(Replan.class));
+  }
+
+  @Test
   void MODIFY_ROUTINE_실패후면_회차를_비활성화하고_재생성안한다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -517,6 +517,35 @@ class ReplanServiceTest {
   }
 
   @Test
+  void CREATE_ROUTINE이_회차를_못만들면_마감지난_앵커를_치우지_않는다() {
+    // 루틴 종료일이 이미 지나 회차 투두가 안 생기는 경우, 앵커를 비활성화하면
+    // 원본도 대체도 없이 사라지므로 앵커를 건드리면 안 된다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거(실패 후)
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    // 회차 투두가 만들어지지 않음
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.empty());
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.CREATE_ROUTINE,
+            null,
+            "스트레칭",
+            "2020-01-01",
+            "20:00",
+            null,
+            "DAILY",
+            null,
+            List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("CONDITION_PAIN"), List.of(op)));
+
+    then(anchor).should(never()).deactivate();
+    then(anchor).should(never()).softDelete();
+  }
+
+  @Test
   void CREATE_ROUTINE은_종료일이_있으면_루틴_종료일로_저장한다() {
     Todo todo = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -666,6 +666,37 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_TODO_하위투두_수정시_부모를_유지한다() {
+    Todo parent = org.mockito.Mockito.mock(Todo.class);
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    given(anchor.getParent()).willReturn(parent);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "수정된 제목",
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(todoRepository).should().save(captor.capture());
+    assertThat(captor.getValue().getParent()).isSameAs(parent);
+  }
+
+  @Test
   void 잘못된_마감형식이면_400() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -465,6 +465,33 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_ROUTINE_하위루틴_회차면_엄마루틴으로_재생성한다() {
+    // 하위 루틴 회차를 리플랜하면 재생성은 엄마 루틴 기준으로 해야 한다(createTodoTreeFromMother는 엄마 전용 — 하위로 부르면 500).
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    Routine child = org.mockito.Mockito.mock(Routine.class);
+    Routine mother = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(child);
+    given(child.isChild()).willReturn(true);
+    given(child.getParent()).willReturn(mother);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(mother)).willReturn(true);
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(org.mockito.Mockito.mock(Todo.class)));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    then(routineService).should().createTodoTreeFromMother(mother); // 하위가 아니라 엄마 루틴으로 재생성
+    then(anchor).should().softDelete();
+  }
+
+  @Test
   void MODIFY_ROUTINE_실패후면_회차를_비활성화하고_재생성안한다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -33,6 +33,7 @@ import plana.replan.domain.replan.exception.ReplanErrorCode;
 import plana.replan.domain.replan.repository.ReplanRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
@@ -51,6 +52,7 @@ class ReplanServiceTest {
   @Mock private TagRepository tagRepository;
   @Mock private RoutineRepository routineRepository;
   @Mock private RoutineService routineService;
+  @Mock private RoutineOverrideRepository routineOverrideRepository;
 
   private final Clock clock = Clock.fixed(Instant.parse("2026-06-18T00:00:00Z"), ZoneId.of("UTC"));
 
@@ -66,7 +68,8 @@ class ReplanServiceTest {
             tagRepository,
             clock,
             routineRepository,
-            routineService);
+            routineService,
+            routineOverrideRepository);
   }
 
   private Todo ownedTodo(Long todoId, Long userId) {
@@ -331,74 +334,89 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_ROUTINE은_루틴_규칙을_수정한다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todo.getId()).willReturn(42L);
+  void MODIFY_ROUTINE은_규칙수정_미래override폐기_회차치우기를_한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
     Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(todo.getRoutine()).willReturn(routine);
-    given(todo.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
+    given(anchor.getRoutine()).willReturn(routine);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.occursToday(routine)).willReturn(false); // 새 규칙에 오늘 없음 → 재생성 안 함
 
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE,
             42L,
-            "영단어 50개 암기",
+            "영단어 50개",
             null,
             "11:15",
             null,
             "WEEKLY",
             62,
             List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("INTERRUPT_LATE_END"), List.of(op));
-
-    replanService.save(1L, req);
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("INTERRUPT_LATE_END"), List.of(op)));
 
     then(routine)
         .should()
         .update(
-            eq("영단어 50개 암기"),
-            any(),
-            eq(RoutineType.WEEKLY),
-            eq(62),
-            eq(LocalTime.of(11, 15)),
-            any());
+            eq("영단어 50개"), any(), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
     then(routine).should().linkReplan(any(Replan.class));
-    then(todo).should().linkReplan(any(Replan.class));
+    then(routineOverrideRepository)
+        .should()
+        .deleteByRoutineAndOverrideDateGreaterThanEqual(eq(routine), any());
+    then(anchor).should().softDelete(); // 실패 전 회차 삭제
+    then(routineService).should(never()).createTodoTreeFromMother(any()); // 오늘 회차 아님
   }
 
   @Test
-  void 루틴_수정_시_미지정_필드는_기존값_유지된다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todo.getId()).willReturn(42L);
+  void MODIFY_ROUTINE_실패전이고_오늘이_회차면_오늘회차를_재생성한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
     Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(todo.getRoutine()).willReturn(routine);
-    given(todo.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
-    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    // op에서 title만 지정, 나머지는 null → 기존 루틴 값으로 fallback
+    given(anchor.getRoutine()).willReturn(routine);
     given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
     given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
     given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.occursToday(routine)).willReturn(true);
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.empty());
 
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
-    replanService.save(1L, req);
+    then(anchor).should().softDelete();
+    then(routineService).should().createTodoTreeFromMother(routine);
+  }
 
-    // DAILY는 반복 날짜를 null로 정규화하므로 routineDate는 null로 들어간다
-    then(routine)
-        .should()
-        .update(
-            eq("새 제목"),
-            any(),
-            eq(RoutineType.DAILY),
-            org.mockito.ArgumentMatchers.isNull(),
-            eq(LocalTime.of(7, 30)),
-            any());
+  @Test
+  void MODIFY_ROUTINE_실패후면_회차를_비활성화하고_재생성안한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 11, 0)); // 과거(실패 후)
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(null);
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
+    then(routineService).should(never()).createTodoTreeFromMother(any());
   }
 
   @Test
@@ -848,44 +866,5 @@ class ReplanServiceTest {
         .isInstanceOfSatisfying(
             CustomException.class,
             e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
-  }
-
-  @Test
-  void MODIFY_ROUTINE_태그변경은_미완료_현재투두에도_반영된다() {
-    // ownedTodo가 내부적으로 User mock(getId()→1L)을 anchor.getUser()에 연결해 둔다
-    Todo anchor = ownedTodo(42L, 1L);
-    given(anchor.getId()).willReturn(42L);
-    Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(anchor.getRoutine()).willReturn(routine);
-    given(anchor.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
-    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
-    given(routine.getRoutineDate()).willReturn(null);
-    given(routine.getRoutineTime()).willReturn(null);
-
-    // tag의 소유자 id가 anchor와 동일한 1L이어야 resolveTag 통과
-    Tag tag = org.mockito.Mockito.mock(Tag.class);
-    User tagOwner = org.mockito.Mockito.mock(User.class);
-    given(tagOwner.getId()).willReturn(1L);
-    given(tag.getUser()).willReturn(tagOwner);
-    given(tagRepository.findById(10L)).willReturn(Optional.of(tag));
-
-    ReplanOperation op =
-        new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE,
-            42L,
-            null,
-            null,
-            null,
-            10L, // tagId 지정
-            null,
-            null,
-            List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
-
-    replanService.save(1L, req);
-
-    then(anchor).should().updateTag(tag);
   }
 }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -1010,17 +1010,12 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_TODO_루틴회차_수정시_루틴연결을_유지한다() {
-    Routine routine = org.mockito.Mockito.mock(Routine.class);
-    Todo anchor = ownedTodo(42L, 1L);
-    given(anchor.getId()).willReturn(42L);
-    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
-    given(anchor.getChildren()).willReturn(List.of());
-    given(anchor.getRoutine()).willReturn(routine);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+  void MODIFY_TODO_루틴회차_대상이면_거부된다() {
+    // 루틴 회차 변경은 MODIFY_ROUTINE 담당 — MODIFY_TODO로 오면 거부
+    Todo target = ownedTodo(42L, 1L);
+    given(target.getRoutine()).willReturn(org.mockito.Mockito.mock(Routine.class));
+    given(todoRepository.findById(42L)).willReturn(Optional.of(target));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
-    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
 
     ReplanOperation modify =
         new ReplanOperation(
@@ -1033,10 +1028,13 @@ class ReplanServiceTest {
             null,
             null,
             List.of());
-    replanService.save(
-        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
-    then(todoRepository).should().save(captor.capture());
-    assertThat(captor.getValue().getRoutine()).isSameAs(routine);
+    assertThatThrownBy(
+            () ->
+                replanService.save(
+                    1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify))))
+        .isInstanceOfSatisfying(
+            CustomException.class,
+            e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
   }
 }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -227,6 +227,7 @@ class ReplanServiceTest {
     given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation modify =
         new ReplanOperation(
@@ -247,6 +248,39 @@ class ReplanServiceTest {
     then(anchor).should().softDelete(); // 실패 전이므로 삭제
     then(anchor).should(never()).deactivate();
     then(todoRepository).should().save(any(Todo.class)); // 새 투두 생성
+  }
+
+  @Test
+  void MODIFY_TODO_실패전_앵커를_치우면_리플랜은_새_투두를_가리킨다() {
+    // 앵커를 소프트 삭제하면 리플랜이 통계 조회에서 사라지므로, 리플랜은 새 투두를 가리켜야 한다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Replan> replanCaptor =
+        org.mockito.ArgumentCaptor.forClass(Replan.class);
+    org.mockito.ArgumentCaptor<Todo> todoCaptor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "데이터 분석 1~2강",
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(replanRepository).should().save(replanCaptor.capture());
+    then(todoRepository).should().save(todoCaptor.capture());
+    assertThat(replanCaptor.getValue().getTodo()).isSameAs(todoCaptor.getValue());
   }
 
   @Test
@@ -366,7 +400,9 @@ class ReplanServiceTest {
     then(routineOverrideRepository)
         .should()
         .deleteByRoutineAndOverrideDateGreaterThanEqual(eq(routine), any());
-    then(anchor).should().softDelete(); // 실패 전 회차 삭제
+    // 새 규칙에 오늘 회차가 없어 대체 투두가 없다 → 소프트 삭제하면 리플랜이 통계에서 사라지므로 비활성화로 남긴다
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
     then(routineService).should(never()).createTodoTreeFromMother(any()); // 오늘 회차 아님
   }
 
@@ -413,6 +449,8 @@ class ReplanServiceTest {
     Todo newInstance = org.mockito.Mockito.mock(Todo.class);
     given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
         .willReturn(Optional.of(newInstance));
+    org.mockito.ArgumentCaptor<Replan> replanCaptor =
+        org.mockito.ArgumentCaptor.forClass(Replan.class);
 
     ReplanOperation op =
         new ReplanOperation(
@@ -420,6 +458,9 @@ class ReplanServiceTest {
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
     then(newInstance).should().linkReplan(any(Replan.class));
+    // 리플랜은 소프트 삭제된 앵커가 아니라 재생성된 새 회차를 가리켜야 한다
+    then(replanRepository).should().save(replanCaptor.capture());
+    assertThat(replanCaptor.getValue().getTodo()).isSameAs(newInstance);
   }
 
   @Test
@@ -757,11 +798,13 @@ class ReplanServiceTest {
   @Test
   void MODIFY_TODO_시간만_바꾸면_새투두는_기존_날짜를_유지한다() {
     Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 10, 0)); // 실패 전
     given(anchor.getTitle()).willReturn("데이터 분석");
     given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
     org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
 
     ReplanOperation modify =

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -247,7 +247,10 @@ class ReplanServiceTest {
 
     then(anchor).should().softDelete(); // 실패 전이므로 삭제
     then(anchor).should(never()).deactivate();
-    then(todoRepository).should().save(any(Todo.class)); // 새 투두 생성
+    // 원본 앵커가 아니라 "새로 만든" 투두를 저장해야 한다(같은 인스턴스를 다시 저장하면 안 됨)
+    org.mockito.ArgumentCaptor<Todo> savedTodo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(savedTodo.capture());
+    assertThat(savedTodo.getValue()).isNotSameAs(anchor);
   }
 
   @Test
@@ -314,7 +317,10 @@ class ReplanServiceTest {
     replanService.save(1L, req);
 
     then(target).should().softDelete();
-    then(todoRepository).should().save(any(Todo.class));
+    // 원본 대상이 아니라 새로 만든 투두를 저장해야 한다
+    org.mockito.ArgumentCaptor<Todo> savedTodo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(savedTodo.capture());
+    assertThat(savedTodo.getValue()).isNotSameAs(target);
   }
 
   @Test
@@ -398,9 +404,13 @@ class ReplanServiceTest {
         .update(
             eq("영단어 50개"), any(), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
     then(routine).should().linkReplan(any(Replan.class));
+    // 오늘 이후 override만 지워야 한다(과거/오늘 것을 같이 지우면 안 됨). 컷오프 = 오늘(clock=2026-06-18).
+    org.mockito.ArgumentCaptor<java.time.LocalDate> cutoff =
+        org.mockito.ArgumentCaptor.forClass(java.time.LocalDate.class);
     then(routineOverrideRepository)
         .should()
-        .deleteByRoutineAndOverrideDateGreaterThanEqual(eq(routine), any());
+        .deleteByRoutineAndOverrideDateGreaterThanEqual(eq(routine), cutoff.capture());
+    assertThat(cutoff.getValue()).isEqualTo(java.time.LocalDate.of(2026, 6, 18));
     // 새 규칙에 오늘 회차가 없어 대체 투두가 없다 → 소프트 삭제하면 리플랜이 통계에서 사라지므로 비활성화로 남긴다
     then(anchor).should().deactivate();
     then(anchor).should(never()).softDelete();
@@ -490,10 +500,12 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_ROUTINE_실패후면_회차를_비활성화하고_재생성안한다() {
+  void MODIFY_ROUTINE_실패후면_회차와_하위회차를_함께_비활성화하고_재생성안한다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 11, 0)); // 과거(실패 후)
+    Todo subOccurrence = org.mockito.Mockito.mock(Todo.class); // 루틴 회차의 하위 회차
+    given(anchor.getChildren()).willReturn(List.of(subOccurrence));
     Routine routine = org.mockito.Mockito.mock(Routine.class);
     given(anchor.getRoutine()).willReturn(routine);
     given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
@@ -509,6 +521,7 @@ class ReplanServiceTest {
 
     then(anchor).should().deactivate();
     then(anchor).should(never()).softDelete();
+    then(subOccurrence).should().deactivate(); // 하위 회차도 함께 비활성화돼 부모와 상태가 맞아야 한다
     then(routineService).should(never()).createTodoTreeFromMother(any());
   }
 

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -746,33 +746,31 @@ class RoutineServiceTest {
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
-  // ========== willMaterializeToday ==========
+  // ========== willCreateUpcomingOccurrence ==========
 
   @Test
-  void willMaterializeToday_DAILY_종료일없으면_참() {
+  void willCreateUpcomingOccurrence_종료일없으면_참() {
+    // 종료일이 없으면(무기한 반복) 다음 회차를 항상 만든다.
     Routine daily = org.mockito.Mockito.mock(Routine.class);
-    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
-    assertThat(routineService.willMaterializeToday(daily)).isTrue();
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isTrue();
   }
 
   @Test
-  void willMaterializeToday_WEEKLY는_오늘_요일_비트가_켜져야_참() {
-    Routine wk = org.mockito.Mockito.mock(Routine.class);
-    given(wk.getRoutineType()).willReturn(RoutineType.WEEKLY);
-    // TEST_DATE = 2024-01-15 = 월요일(getDayOfWeek().getValue()=1) → 비트 1<<0 = 1
-    given(wk.getRoutineDate()).willReturn(1);
-    assertThat(routineService.willMaterializeToday(wk)).isTrue();
-    given(wk.getRoutineDate()).willReturn(2); // 화요일 비트만 → 오늘(월) 아님
-    assertThat(routineService.willMaterializeToday(wk)).isFalse();
+  void willCreateUpcomingOccurrence_다음회차가_종료일_이내면_참() {
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
+    // TEST_DATE = 2024-01-15. DAILY의 다음 회차는 오늘. 종료일이 오늘이면 만든다.
+    given(daily.getDueDate()).willReturn(LocalDateTime.of(2024, 1, 15, 0, 0));
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isTrue();
   }
 
   @Test
-  void willMaterializeToday_반복종료일이_지났으면_거짓() {
+  void willCreateUpcomingOccurrence_다음회차가_종료일_지나면_거짓() {
     Routine daily = org.mockito.Mockito.mock(Routine.class);
     given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
-    // TEST_DATE = 2024-01-15. 종료일이 2024-01-10이면 이미 지나 회차를 만들지 않는다.
+    // TEST_DATE = 2024-01-15. 종료일이 2024-01-10이면 다음 회차(오늘)가 종료일을 넘어 만들지 않는다.
     given(daily.getDueDate()).willReturn(LocalDateTime.of(2024, 1, 10, 0, 0));
-    assertThat(routineService.willMaterializeToday(daily)).isFalse();
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isFalse();
   }
 
   // ========== generateDailyTodos with override ==========

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -746,24 +746,33 @@ class RoutineServiceTest {
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
-  // ========== occursToday ==========
+  // ========== willMaterializeToday ==========
 
   @Test
-  void occursToday_DAILY는_항상_참() {
+  void willMaterializeToday_DAILY_종료일없으면_참() {
     Routine daily = org.mockito.Mockito.mock(Routine.class);
     given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
-    assertThat(routineService.occursToday(daily)).isTrue();
+    assertThat(routineService.willMaterializeToday(daily)).isTrue();
   }
 
   @Test
-  void occursToday_WEEKLY는_오늘_요일_비트가_켜져야_참() {
+  void willMaterializeToday_WEEKLY는_오늘_요일_비트가_켜져야_참() {
     Routine wk = org.mockito.Mockito.mock(Routine.class);
     given(wk.getRoutineType()).willReturn(RoutineType.WEEKLY);
     // TEST_DATE = 2024-01-15 = 월요일(getDayOfWeek().getValue()=1) → 비트 1<<0 = 1
     given(wk.getRoutineDate()).willReturn(1);
-    assertThat(routineService.occursToday(wk)).isTrue();
+    assertThat(routineService.willMaterializeToday(wk)).isTrue();
     given(wk.getRoutineDate()).willReturn(2); // 화요일 비트만 → 오늘(월) 아님
-    assertThat(routineService.occursToday(wk)).isFalse();
+    assertThat(routineService.willMaterializeToday(wk)).isFalse();
+  }
+
+  @Test
+  void willMaterializeToday_반복종료일이_지났으면_거짓() {
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
+    // TEST_DATE = 2024-01-15. 종료일이 2024-01-10이면 이미 지나 회차를 만들지 않는다.
+    given(daily.getDueDate()).willReturn(LocalDateTime.of(2024, 1, 10, 0, 0));
+    assertThat(routineService.willMaterializeToday(daily)).isFalse();
   }
 
   // ========== generateDailyTodos with override ==========

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -746,6 +746,26 @@ class RoutineServiceTest {
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
+  // ========== occursToday ==========
+
+  @Test
+  void occursToday_DAILY는_항상_참() {
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
+    assertThat(routineService.occursToday(daily)).isTrue();
+  }
+
+  @Test
+  void occursToday_WEEKLY는_오늘_요일_비트가_켜져야_참() {
+    Routine wk = org.mockito.Mockito.mock(Routine.class);
+    given(wk.getRoutineType()).willReturn(RoutineType.WEEKLY);
+    // TEST_DATE = 2024-01-15 = 월요일(getDayOfWeek().getValue()=1) → 비트 1<<0 = 1
+    given(wk.getRoutineDate()).willReturn(1);
+    assertThat(routineService.occursToday(wk)).isTrue();
+    given(wk.getRoutineDate()).willReturn(2); // 화요일 비트만 → 오늘(월) 아님
+    assertThat(routineService.occursToday(wk)).isFalse();
+  }
+
   // ========== generateDailyTodos with override ==========
 
   @Test


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #222


## 변경 사항
리플랜으로 투두를 "수정"할 때, 지금까지는 그 투두 행을 **제자리에서 고쳤습니다.** 그러면 투두의 마감일이 다른 달로 바뀌면서 원래 속해 있던 달의 통계(달성률 등)가 흔들렸습니다. (예: 지난달에 못 한 투두를 이번 달로 미루면, 지난달 통계에서 그 실패가 사라져 지난달 달성률이 부풀려짐.)

이제 백엔드는 리플랜에서 기존 투두를 **제자리에서 고치지 않습니다.**

- **"수정" = 기존 투두를 치우고 + 새 투두 생성**
  - 마감이 이미 지난 경우(실패 후) → 기존 투두를 **비활성화** (통계에는 실패로 그대로 남김)
  - 마감 전이거나 마감이 없는 경우(실패 전) → 기존 투두를 **삭제** (통계에서 제외 — 미리 고친 걸 실패로 처벌하지 않음)
- **"추가" = 새 투두(또는 새 루틴 + 오늘 회차) 생성**
- **루틴 회차를 리플랜하면**: 루틴 규칙만 제자리 수정(규칙 자체는 절대 치우지 않음) + 그 루틴의 **미래 회차 수정기록(RoutineOverride) 폐기** + 회차 투두는 위 규칙대로 치움 + (실패 전이고 오늘이 새 규칙의 회차면) 오늘 회차를 **루틴과 연결해** 재생성
- **루틴 회차는 일반 투두 수정(`MODIFY_TODO`)으로 처리하지 않고 거부**합니다. 루틴 회차 변경은 루틴 전용 경로(`MODIFY_ROUTINE`)만 담당해야 루틴 연결·중복 생성·날짜 충돌 문제가 안 생깁니다.
- 새로 만든 투두에는 리플랜 표시를 붙여 리플랜 효과 통계에 잡히게 함

> 통계 동작: 비활성화된 투두는 월간 집계에 그대로 잡혀(실패로 남음), 삭제된 투두는 모든 조회·통계에서 제외됩니다. 그래서 "실패 후 = 비활성화 / 실패 전 = 삭제"가 의도한 통계 결과와 정확히 맞습니다.


## 테스트 결과
**단위 테스트**: `ReplanServiceTest` / `RoutineServiceTest` 전부 통과, 전체 `./gradlew build`(Spotless 포맷 검사 + 컴파일 + 전체 테스트) 성공.

**로컬 API 전수 테스트** (서버 기동 후 실제 요청 + DB 직접 확인):

| 시나리오 | 결과 |
|---|---|
| 실패 전 투두 `MODIFY_TODO` | 원본 soft delete, 새 투두 생성(리플랜 링크) ✅ |
| 실패 후 투두 `MODIFY_TODO` | 원본 비활성화(통계 잔존), 새 투두 생성 ✅ |
| 활성 투두 목록 | 비활성화·삭제된 원본 모두 숨김 ✅ |
| 루틴 `MODIFY_ROUTINE` | 루틴 규칙 수정 + 미래 override 폐기 + 회차 비활성화 ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 반복 일정의 다음 발생 여부를 더 정확히 반영해, 종료일 기준에 따라 이후 회차 생성이 처리됩니다.
  * 변경된 투두가 새 항목으로 대체되는 흐름을 지원해, 하위 항목 연결이 더 자연스럽게 유지됩니다.

* **버그 수정**
  * 마감이 지난 앵커 투두가 상황에 따라 과도하게 처리되던 동작을 조정했습니다.
  * 반복 일정 수정 시, 하위 회차나 종료된 항목에 대한 잘못된 변경을 방지했습니다.

* **테스트**
  * 앵커 대체, 반복 일정 종료일, 수정 제한 관련 시나리오 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->