### PR TITLE
Fix: 같은 투두를 여러 번 리플랜해도 이전 리플랜이 통계에서 누락되지 않게 수정

### DIFF
--- a/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
+++ b/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import plana.replan.domain.replan.entity.Replan;
+import plana.replan.domain.todo.entity.Todo;
 import plana.replan.domain.user.entity.User;
 
 public interface ReplanRepository extends JpaRepository<Replan, Long> {
@@ -17,4 +18,10 @@ public interface ReplanRepository extends JpaRepository<Replan, Long> {
       @Param("user") User user,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  /**
+   * 특정 투두를 가리키는 리플랜(메모)을 모두 찾는다. 같은 투두를 한 달에 여러 번 리플랜하면 그 투두에 리플랜이 여러 개 달릴 수 있으므로, 그 투두를 소프트 삭제(통계
+   * 제외)하기 전에 달려 있던 리플랜을 빠짐없이 살아있는 새 투두로 옮기는 데 쓴다.
+   */
+  List<Replan> findByTodo(Todo todo);
 }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -328,13 +328,28 @@ public class ReplanService {
     Todo newTodo = recreateFromModify(target, op, replan);
     children.forEach(child -> child.updateParent(newTodo));
     retireWithoutChildren(target);
-    // 앵커 자신을 소프트 삭제하는 경우(실패 전), 위에서 만든 Replan이 가리키던 앵커가
-    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 사라진다.
-    // 리플랜을 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 정상 집계되게 한다.
-    // (앵커가 아닌 다른 투두 수정이나 실패 후 비활성화는 앵커가 살아있어 옮길 필요가 없다.)
-    if (target == anchor && !isOverdue(target)) {
-      replan.relinkTodo(newTodo);
+    // 수정 대상을 소프트 삭제하는 경우(실패 전), 그 투두를 가리키던 리플랜들이
+    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 통째로 사라진다.
+    // 이번에 만든 리플랜뿐 아니라, 같은 투두를 이전에 리플랜해 달려 있던 리플랜까지 모두
+    // 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 빠짐없이 집계되게 한다.
+    // (실패 후 비활성화는 투두가 살아 있어 옮길 필요가 없다.)
+    if (!isOverdue(target)) {
+      // 이번 리플랜은 앵커를 가리키므로, 앵커 자신을 수정한 경우에만 새 투두로 옮긴다.
+      // (앵커가 아닌 다른 투두 수정이면 이번 리플랜은 여전히 살아있는 앵커를 가리켜야 한다.)
+      if (target == anchor) {
+        replan.relinkTodo(newTodo);
+      }
+      // 그 투두에 이전부터 달려 있던 다른 리플랜들도 빠짐없이 새 투두로 옮긴다.
+      relinkReplansTo(target, newTodo);
     }
+  }
+
+  /**
+   * {@code from} 투두를 가리키던 리플랜(메모)을 모두 {@code to} 투두로 옮겨 단다. 같은 투두를 한 달에 여러 번 리플랜하면 리플랜이 여러 개 달릴 수
+   * 있는데, 그 투두를 소프트 삭제하면 달려 있던 리플랜이 전부 통계에서 사라진다. 그래서 소프트 삭제 직전에 호출해 모든 리플랜을 살아있는 새 투두로 옮긴다.
+   */
+  private void relinkReplansTo(Todo from, Todo to) {
+    replanRepository.findByTodo(from).forEach(r -> r.relinkTodo(to));
   }
 
   /**
@@ -501,7 +516,11 @@ public class ReplanService {
       instance.updateTag(routine.getTag());
       instance.getChildren().forEach(child -> child.updateTag(routine.getTag()));
       instance.linkReplan(replan);
+      // 이번 리플랜은 메모리에서 바로 새 회차로 옮기고,
+      // 같은 회차(앵커)에 이전부터 달려 있던 다른 리플랜들도 빠짐없이 새 회차로 옮긴다.
+      // (앵커를 위에서 소프트 삭제했으므로 옮기지 않으면 그 리플랜들이 통계에서 사라진다.)
       replan.relinkTodo(instance);
+      relinkReplansTo(anchor, instance);
     } else if (failedBefore) {
       // 실패 전이지만 반복 종료일이 지나 다음 회차가 더는 만들어지지 않는다(루틴이 사실상 끝남).
       // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -505,6 +505,41 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_ROUTINE_같은_회차를_여러_번_리플랜하면_이전_리플랜도_새_회차로_옮긴다() {
+    // 루틴 회차도 같은 회차를 한 달에 두 번 리플랜하면 리플랜이 여러 개 달릴 수 있다.
+    // 두 번째 리플랜으로 옛 회차를 소프트 삭제할 때 첫 번째 리플랜까지 새 회차로 옮기지 않으면,
+    // 첫 번째 리플랜이 통계 조회에서 사라진다(MODIFY_TODO와 동일한 누락).
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전 → 소프트 삭제
+    given(anchor.getChildren()).willReturn(List.of());
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
+    Todo newInstance = org.mockito.Mockito.mock(Todo.class);
+    given(newInstance.getChildren()).willReturn(List.of());
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(newInstance));
+    // 같은 회차(앵커)에 이전부터 달려 있던 리플랜(첫 번째 리플랜)
+    Replan previousReplan = org.mockito.Mockito.mock(Replan.class);
+    given(replanRepository.findByTodo(anchor))
+        .willReturn(new java.util.ArrayList<>(List.of(previousReplan)));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    // 이전 리플랜도 소프트 삭제된 옛 회차가 아니라 재생성된 새 회차를 가리켜야 한다.
+    then(previousReplan).should().relinkTodo(newInstance);
+  }
+
+  @Test
   void MODIFY_ROUTINE_하위루틴_회차_대상이면_거부된다() {
     // 하위 루틴 회차는 규칙을 따로 갖지 않고 엄마 루틴을 따른다 — 루틴 규칙 변경(MODIFY_ROUTINE)은 거부한다.
     Todo anchor = ownedTodo(42L, 1L);

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -287,6 +287,36 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_TODO_같은_투두를_여러_번_리플랜하면_이전_리플랜도_새_투두로_옮긴다() {
+    // 같은 투두를 한 달에 두 번 리플랜하면 그 투두에 리플랜이 여러 개 달릴 수 있다.
+    // 두 번째 리플랜으로 그 투두를 소프트 삭제할 때 첫 번째 리플랜까지 새 투두로 옮기지 않으면,
+    // 첫 번째 리플랜이 통계 조회에서 사라져 한 달에 두 번 한 리플랜이 한 번으로 잡힌다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전 → 소프트 삭제
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    // 같은 투두에 이전부터 달려 있던 리플랜(첫 번째 리플랜)
+    Replan previousReplan = org.mockito.Mockito.mock(Replan.class);
+    given(replanRepository.findByTodo(anchor))
+        .willReturn(new java.util.ArrayList<>(List.of(previousReplan)));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, "데이터 분석 다시", null, null, null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(anchor).should().softDelete();
+    // 이전 리플랜도 새 투두(원본 앵커가 아닌)로 옮겨져야 한다.
+    org.mockito.ArgumentCaptor<Todo> movedTo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(previousReplan).should().relinkTodo(movedTo.capture());
+    assertThat(movedTo.getValue()).isNotSameAs(anchor);
+  }
+
+  @Test
   void 우선순위_다른_투두도_같은사용자면_치우고_새로만든다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));


### PR DESCRIPTION
## PR 타입
- [x] 버그 수정

## Related Issues
close #227

## 변경 사항

리플랜으로 투두를 수정하면, 원래 투두를 그대로 두지 않고 통계에서 빼거나(소프트 삭제) 실패로 남긴 뒤(비활성화) 새 투두를 만든다. 소프트 삭제하는 경우, 그 투두에 달려 있던 리플랜(메모)을 살아있는 새 투두로 옮겨 달아야 월간 통계에 정상 집계된다.

그런데 지금은 **이번에 만든 리플랜 하나만** 새 투두로 옮겼다. 같은 투두를 한 달에 두 번 리플랜하면 그 투두에 리플랜이 두 개 달리는데, 두 번째 리플랜으로 그 투두를 소프트 삭제할 때 첫 번째 리플랜은 옮겨지지 않은 채 숨겨진 투두에 남았다. 결과적으로 첫 번째 리플랜이 통계 조회에서 사라져 **한 달에 두 번 한 리플랜이 한 번으로 잡혔다.**

- 투두를 소프트 삭제할 때, 그 투두를 가리키던 리플랜을 **전부** 새 투두로 옮기도록 고쳤다.
- 일반 투두 수정(`MODIFY_TODO`)과 루틴 회차 리플랜(`MODIFY_ROUTINE`) 두 경로 모두 적용.
- 앵커(이번에 리플랜한 투두) 자신을 수정하는 경우뿐 아니라, 앵커가 아닌 다른 투두를 수정해 소프트 삭제하는 경우에도 그 투두에 달려 있던 이전 리플랜이 사라지지 않게 했다.
- 리포지토리에 "이 투두를 가리키는 리플랜 전부 찾기"(`findByTodo`)를 추가했다.

## 테스트 결과

- `ReplanServiceTest`에 "같은 투두를 두 번 리플랜하면 이전 리플랜도 새 투두로 옮겨진다" 테스트 추가.
- 기존 리플랜 단위 테스트 전부 통과.
- JDK 17로 `./gradlew build`(Spotless 포맷 검사 + 컴파일 + 테스트) 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 투두를 수정할 때, 기존 투두에 연결된 메모(리플랜)가 새 투두로 함께 옮겨지도록 개선했습니다.
  * 앵커 회차나 반복 항목을 변경할 때도, 이전에 연결된 관련 메모들이 새 대상에 올바르게 재연결됩니다.
  * 동일한 투두를 여러 번 다시 연결하는 경우에도 이전 메모가 누락되지 않도록 동작을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->