### PR TITLE
v0.18.2

### DIFF
--- a/src/main/java/plana/replan/domain/replan/entity/Replan.java
+++ b/src/main/java/plana/replan/domain/replan/entity/Replan.java
@@ -41,4 +41,13 @@ public class Replan extends BaseTimeEntity {
     this.failureReason2 = failureReason2;
     this.failureReason3 = failureReason3;
   }
+
+  /**
+   * 리플랜이 가리키는 투두를 바꾼다. 리플랜이 "수정"한 원본 투두를 소프트 삭제(통계 제외)할 때, 삭제된 투두는
+   * {@code @SQLRestriction(deleted_at IS NULL)}으로 모든 조회에서 빠지므로 이 리플랜 자체가 월간 통계 집계에서 사라진다. 그래서 살아있는
+   * 새 투두로 옮겨 달아 리플랜이 정상 집계되게 한다.
+   */
+  public void relinkTodo(Todo todo) {
+    this.todo = Objects.requireNonNull(todo, "투두는 필수입니다.");
+  }
 }

--- a/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
+++ b/src/main/java/plana/replan/domain/replan/repository/ReplanRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import plana.replan.domain.replan.entity.Replan;
+import plana.replan.domain.todo.entity.Todo;
 import plana.replan.domain.user.entity.User;
 
 public interface ReplanRepository extends JpaRepository<Replan, Long> {
@@ -17,4 +18,10 @@ public interface ReplanRepository extends JpaRepository<Replan, Long> {
       @Param("user") User user,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  /**
+   * 특정 투두를 가리키는 리플랜(메모)을 모두 찾는다. 같은 투두를 한 달에 여러 번 리플랜하면 그 투두에 리플랜이 여러 개 달릴 수 있으므로, 그 투두를 소프트 삭제(통계
+   * 제외)하기 전에 달려 있던 리플랜을 빠짐없이 살아있는 새 투두로 옮기는 데 쓴다.
+   */
+  List<Replan> findByTodo(Todo todo);
 }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ import plana.replan.domain.replan.exception.ReplanErrorCode;
 import plana.replan.domain.replan.repository.ReplanRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
@@ -53,6 +55,7 @@ public class ReplanService {
   private final Clock clock;
   private final RoutineRepository routineRepository;
   private final RoutineService routineService;
+  private final RoutineOverrideRepository routineOverrideRepository;
 
   /**
    * 2단계 선택(+선택적 추가질문 답변)을 받아, 추가 질문이 필요하면 질문을, 충분하면 추천을 반환한다. 질문이 필요한지는 {@link
@@ -199,31 +202,37 @@ public class ReplanService {
       return;
     }
 
-    boolean anyAdd = false;
-    boolean anchorModifiedInPlace = false;
-
+    boolean anchorHandled = false;
+    boolean replacementCreated = false;
     for (ReplanOperation op : req.acceptedOperations()) {
       validateOperation(op);
       switch (op.action()) {
         case ADD -> {
           applyAdd(op, anchor, replan);
-          anyAdd = true;
+          replacementCreated = true;
         }
         case MODIFY_TODO -> {
           applyModifyTodo(op, anchor, replan);
           if (op.targetTodoId() != null && op.targetTodoId().equals(anchor.getId())) {
-            anchorModifiedInPlace = true;
+            anchorHandled = true;
           }
         }
-        case MODIFY_ROUTINE -> applyModifyRoutine(op, anchor, replan);
-        case CREATE_ROUTINE -> applyCreateRoutine(op, anchor, replan);
+        case MODIFY_ROUTINE -> {
+          applyModifyRoutine(op, anchor, replan);
+          anchorHandled = true;
+        }
+        case CREATE_ROUTINE -> {
+          // 회차 투두가 실제로 만들어졌을 때만 "앵커를 치울 대체가 생겼다"고 본다.
+          // (루틴 종료일이 이미 지나 회차가 안 생기면 앵커를 비활성화하면 안 된다 — 원본까지 사라짐)
+          replacementCreated |= applyCreateRoutine(op, anchor, replan);
+        }
       }
     }
 
-    // 마감 지난 일반 투두(앵커)를 ADD로 대체한 경우에만 한 번 숨긴다.
-    // MODIFY_TODO로 앵커 자체를 수정했다면 숨기지 않는다.
-    if (anchor.getRoutine() == null && isOverdue(anchor) && anyAdd && !anchorModifiedInPlace) {
-      anchor.deactivate();
+    // 마감 지난(실패 후) 앵커를 ADD/CREATE_ROUTINE으로 대체한 경우에만 앵커를 치운다(비활성화).
+    // 미래(실패 전) 앵커의 ADD는 보조 투두 추가일 수 있으므로 앵커를 건드리지 않는다.
+    if (!anchorHandled && isOverdue(anchor) && replacementCreated) {
+      retire(anchor);
     }
   }
 
@@ -304,21 +313,81 @@ public class ReplanService {
         todoRepository
             .findById(op.targetTodoId())
             .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND));
-    // 우선순위 등으로 앵커 외 다른 투두를 수정할 수 있으나, 반드시 같은 사용자 소유여야 한다
     if (!target.getUser().getId().equals(anchor.getUser().getId())) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
-    if (op.title() != null) {
-      target.updateTitle(op.title());
+    // 루틴 회차는 MODIFY_TODO로 고치지 않는다(루틴 변경은 MODIFY_ROUTINE 담당).
+    // 같은 (routine_id, due_date) 슬롯에 새 행을 만들면 partial unique index와 충돌하고,
+    // 분리 후 슬롯이 비면 스케줄러가 회차를 중복 생성하므로 거부한다.
+    if (target.getRoutine() != null) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
-    // dueDate/dueTime 중 하나라도 지정된 경우에만 업데이트한다 — 제목만 바꾸는 op이면 기존 마감일을 보존
-    if (op.dueDate() != null || op.dueTime() != null) {
-      target.updateDueDate(resolveModifiedDueDate(target, op));
+    // 하위 투두를 미리 스냅샷해두고 새 부모로 옮긴 뒤 부모만 치운다.
+    // retire(target)을 그대로 쓰면 하위 투두까지 소프트 삭제돼 사용자의 서브태스크가 모두 사라진다.
+    List<Todo> children = new ArrayList<>(target.getChildren());
+    Todo newTodo = recreateFromModify(target, op, replan);
+    children.forEach(child -> child.updateParent(newTodo));
+    retireWithoutChildren(target);
+    // 앵커 자신을 소프트 삭제하는 경우(실패 전), 위에서 만든 Replan이 가리키던 앵커가
+    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 사라진다.
+    // 리플랜을 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 정상 집계되게 한다.
+    // (앵커가 아닌 다른 투두 수정이나 실패 후 비활성화는 앵커가 살아있어 옮길 필요가 없다.)
+    if (target == anchor && !isOverdue(target)) {
+      replan.relinkTodo(newTodo);
     }
-    if (op.tagId() != null) {
-      target.updateTag(resolveTag(op.tagId(), target.getUser().getId()));
+  }
+
+  /**
+   * 기존 투두를 (하위 투두까지 함께) 치운다: 마감 지났으면 비활성화(통계에 실패로 남김), 아니면 소프트 삭제(통계에서 제외). 부모만 치우고 자식을 두면 상태가
+   * 어긋나므로 두 경로 모두 자식을 함께 처리한다.
+   */
+  private void retire(Todo target) {
+    if (isOverdue(target)) {
+      target.getChildren().forEach(Todo::deactivate);
+      target.deactivate();
+    } else {
+      target.getChildren().forEach(Todo::softDelete);
+      target.softDelete();
     }
-    target.linkReplan(replan);
+  }
+
+  /**
+   * 투두 자신만 치운다(하위 투두는 건드리지 않음): 마감 지났으면 비활성화, 아니면 소프트 삭제. MODIFY_TODO에서 하위 투두를 새 부모로 옮긴 뒤 원래 부모를 치울
+   * 때 사용한다.
+   */
+  private void retireWithoutChildren(Todo target) {
+    if (isOverdue(target)) {
+      target.deactivate();
+    } else {
+      target.softDelete();
+    }
+  }
+
+  /**
+   * op가 지정한 필드만 바꾸고 나머지는 기존 투두에서 물려받아 새 투두를 만든다. (루틴 회차는 applyModifyTodo에서 이미 거부되므로 여기서는 일반 투두만
+   * 다룬다.)
+   */
+  private Todo recreateFromModify(Todo target, ReplanOperation op, Replan replan) {
+    String title = op.title() != null ? op.title() : target.getTitle();
+    LocalDateTime dueDate =
+        (op.dueDate() != null || op.dueTime() != null)
+            ? resolveModifiedDueDate(target, op)
+            : target.getDueDate();
+    Tag tag =
+        op.tagId() != null ? resolveTag(op.tagId(), target.getUser().getId()) : target.getTag();
+    Todo created =
+        Todo.builder()
+            .title(title)
+            .dueDate(dueDate)
+            .sortOrder(target.getSortOrder())
+            .isPinned(target.isPinned())
+            .user(target.getUser())
+            .tag(tag)
+            .goal(target.getGoal())
+            .parent(target.getParent())
+            .build();
+    created.linkReplan(replan);
+    return todoRepository.save(created);
   }
 
   /** 앵커의 마감이 지났는지 확인한다. */
@@ -375,6 +444,12 @@ public class ReplanService {
     if (routine == null) {
       throw new CustomException(ReplanErrorCode.REPLAN_TODO_NOT_FOUND);
     }
+    // 하위 루틴 회차는 규칙(반복 유형/요일/시각/태그)을 따로 가지지 않고 엄마 루틴을 그대로 따른다.
+    // 따라서 루틴 규칙 변경(MODIFY_ROUTINE)은 엄마 루틴 회차에만 의미가 있으므로 하위 루틴 회차는 거부한다.
+    // (엄마 루틴 수정 API·루틴 오버라이드도 동일하게 하위 루틴을 거부한다.)
+    if (routine.isChild()) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+    }
     Tag tag =
         op.tagId() != null ? resolveTag(op.tagId(), anchor.getUser().getId()) : routine.getTag();
     RoutineType effectiveType =
@@ -399,22 +474,47 @@ public class ReplanService {
         tag);
     routine.linkReplan(replan);
 
-    // 이번 회차 투두(앵커)가 미완료면 새 규칙에 맞춰 동기화, 완료면 그대로 둔다
-    if (!anchor.isCompleted()) {
-      if (op.title() != null) {
-        anchor.updateTitle(op.title());
-      }
-      if (op.dueDate() != null || op.dueTime() != null) {
-        anchor.updateDueDate(resolveModifiedDueDate(anchor, op));
-      }
-      if (op.tagId() != null) {
-        anchor.updateTag(tag);
-      }
-      anchor.linkReplan(replan);
+    // 미래 회차 수정기록 폐기(옛 규칙 기준이라 의미 없어짐)
+    routineOverrideRepository.deleteByRoutineAndOverrideDateGreaterThanEqual(
+        routine, LocalDate.now(clock));
+
+    // 이번 회차(앵커) 치우기.
+    // 주의: 위에서 만든 Replan은 anchor를 가리킨다. 실패 전이라고 anchor를 소프트 삭제하면
+    // @SQLRestriction(deleted_at IS NULL) 때문에 월간 리포트의 리플랜 조회에서 이 리플랜이 통째로
+    // 빠진다(리플랜 횟수 누락). 그래서 대체할 살아있는 새 회차가 있을 때만 소프트 삭제하고
+    // 리플랜을 그 새 회차로 옮겨 달며, 새 회차가 없으면 비활성화로 남겨 리플랜이 사라지지 않게 한다.
+    boolean failedBefore = !isOverdue(anchor);
+    if (failedBefore && routineService.willCreateUpcomingOccurrence(routine)) {
+      // 실패 전 + 새 규칙의 다음 회차가 만들어짐 → 옛 회차는 소프트 삭제(통계 제외)하고,
+      // 새 규칙의 다음 회차(오늘 또는 가까운 미래)를 곧바로 만들어 리플랜을 그 회차로 옮긴다.
+      retire(anchor);
+      routineService.createTodoTreeFromMother(routine);
+      // willCreateUpcomingOccurrence가 true면 위 호출이 반드시 회차를 만든다.
+      // 만에 하나 못 찾으면 옛 회차를 소프트 삭제한 채 리플랜이 갈 곳을 잃으므로, 예외로 트랜잭션을 되돌려 데이터 유실을 막는다.
+      Todo instance =
+          todoRepository
+              .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
+              .orElseThrow(() -> new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION));
+      // 같은 슬롯에 회차가 이미 있어 createTodoTreeFromMother가 새로 만들지 않은 경우(no-op)에도
+      // 그 회차가 옛 규칙 내용으로 남지 않도록 제목·태그를 새 루틴 값으로 동기화한다(updateMotherRoutine과 동일).
+      instance.updateTitle(routine.getTitle());
+      instance.updateTag(routine.getTag());
+      instance.getChildren().forEach(child -> child.updateTag(routine.getTag()));
+      instance.linkReplan(replan);
+      replan.relinkTodo(instance);
+    } else if (failedBefore) {
+      // 실패 전이지만 반복 종료일이 지나 다음 회차가 더는 만들어지지 않는다(루틴이 사실상 끝남).
+      // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.
+      anchor.getChildren().forEach(Todo::deactivate);
+      anchor.deactivate();
+    } else {
+      // 실패 후 → 비활성화(통계에 실패로 남김). 앵커가 살아있어 리플랜도 정상 집계된다.
+      retire(anchor);
     }
   }
 
-  private void applyCreateRoutine(ReplanOperation op, Todo anchor, Replan replan) {
+  /** 새 루틴을 만들고 가까운 회차 투두를 리플랜에 연결한다. 회차 투두가 실제로 만들어졌으면 true. */
+  private boolean applyCreateRoutine(ReplanOperation op, Todo anchor, Replan replan) {
     if (op.routineType() == null) {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
@@ -437,9 +537,11 @@ public class ReplanService {
     routine.linkReplan(replan);
     routineRepository.save(routine);
     routineService.createTodoTreeFromMother(routine);
-    todoRepository
-        .findFirstUpcomingMotherTodoByRoutine(routine, LocalDate.now(clock).atStartOfDay())
-        .ifPresent(instanceTodo -> instanceTodo.linkReplan(replan));
+    Optional<Todo> instance =
+        todoRepository.findFirstUpcomingMotherTodoByRoutine(
+            routine, LocalDate.now(clock).atStartOfDay());
+    instance.ifPresent(instanceTodo -> instanceTodo.linkReplan(replan));
+    return instance.isPresent();
   }
 
   private void validateRecurrence(RoutineType type, Integer routineDate) {

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -328,13 +328,28 @@ public class ReplanService {
     Todo newTodo = recreateFromModify(target, op, replan);
     children.forEach(child -> child.updateParent(newTodo));
     retireWithoutChildren(target);
-    // 앵커 자신을 소프트 삭제하는 경우(실패 전), 위에서 만든 Replan이 가리키던 앵커가
-    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 사라진다.
-    // 리플랜을 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 정상 집계되게 한다.
-    // (앵커가 아닌 다른 투두 수정이나 실패 후 비활성화는 앵커가 살아있어 옮길 필요가 없다.)
-    if (target == anchor && !isOverdue(target)) {
-      replan.relinkTodo(newTodo);
+    // 수정 대상을 소프트 삭제하는 경우(실패 전), 그 투두를 가리키던 리플랜들이
+    // @SQLRestriction(deleted_at IS NULL) 때문에 리플랜 조회에서 통째로 사라진다.
+    // 이번에 만든 리플랜뿐 아니라, 같은 투두를 이전에 리플랜해 달려 있던 리플랜까지 모두
+    // 살아있는 새 투두로 옮겨 달아 월간 통계(리플랜 횟수 등)에 빠짐없이 집계되게 한다.
+    // (실패 후 비활성화는 투두가 살아 있어 옮길 필요가 없다.)
+    if (!isOverdue(target)) {
+      // 이번 리플랜은 앵커를 가리키므로, 앵커 자신을 수정한 경우에만 새 투두로 옮긴다.
+      // (앵커가 아닌 다른 투두 수정이면 이번 리플랜은 여전히 살아있는 앵커를 가리켜야 한다.)
+      if (target == anchor) {
+        replan.relinkTodo(newTodo);
+      }
+      // 그 투두에 이전부터 달려 있던 다른 리플랜들도 빠짐없이 새 투두로 옮긴다.
+      relinkReplansTo(target, newTodo);
     }
+  }
+
+  /**
+   * {@code from} 투두를 가리키던 리플랜(메모)을 모두 {@code to} 투두로 옮겨 단다. 같은 투두를 한 달에 여러 번 리플랜하면 리플랜이 여러 개 달릴 수
+   * 있는데, 그 투두를 소프트 삭제하면 달려 있던 리플랜이 전부 통계에서 사라진다. 그래서 소프트 삭제 직전에 호출해 모든 리플랜을 살아있는 새 투두로 옮긴다.
+   */
+  private void relinkReplansTo(Todo from, Todo to) {
+    replanRepository.findByTodo(from).forEach(r -> r.relinkTodo(to));
   }
 
   /**
@@ -501,7 +516,11 @@ public class ReplanService {
       instance.updateTag(routine.getTag());
       instance.getChildren().forEach(child -> child.updateTag(routine.getTag()));
       instance.linkReplan(replan);
+      // 이번 리플랜은 메모리에서 바로 새 회차로 옮기고,
+      // 같은 회차(앵커)에 이전부터 달려 있던 다른 리플랜들도 빠짐없이 새 회차로 옮긴다.
+      // (앵커를 위에서 소프트 삭제했으므로 옮기지 않으면 그 리플랜들이 통계에서 사라진다.)
       replan.relinkTodo(instance);
+      relinkReplansTo(anchor, instance);
     } else if (failedBefore) {
       // 실패 전이지만 반복 종료일이 지나 다음 회차가 더는 만들어지지 않는다(루틴이 사실상 끝남).
       // 소프트 삭제하면 리플랜이 통계에서 사라지므로, 회차와 하위 회차를 비활성화로 남긴다.

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -290,6 +290,19 @@ public class RoutineService {
         });
   }
 
+  /**
+   * {@link #createTodoTreeFromMother(Routine)}가 이 루틴의 다음 회차 투두를 실제로 만들지 판단한다. 다음 회차(오늘 또는 가까운 미래)가
+   * 반복 종료일을 넘지 않으면 만든다 — createTodoTreeFromMother와 같은 규칙이다. 리플랜에서 "옛 회차를 치우고 새 회차로 옮길 수 있는지"를 결정하는
+   * 데 쓴다(만들 수 없으면 옛 회차를 삭제하면 안 된다).
+   */
+  public boolean willCreateUpcomingOccurrence(Routine routine) {
+    if (routine.getDueDate() == null) {
+      return true; // 무기한 반복 → 다음 회차를 항상 만든다
+    }
+    LocalDate next = nextOccurrence(routine, LocalDate.now(clock));
+    return !next.isAfter(routine.getDueDate().toLocalDate());
+  }
+
   private boolean isOccurrenceDay(Routine routine, LocalDate today) {
     return switch (routine.getRoutineType()) {
       case DAILY -> true;

--- a/src/main/java/plana/replan/domain/todo/entity/Todo.java
+++ b/src/main/java/plana/replan/domain/todo/entity/Todo.java
@@ -100,6 +100,10 @@ public class Todo extends BaseTimeEntity {
     this.routine = routine;
   }
 
+  public void updateParent(Todo parent) {
+    this.parent = parent;
+  }
+
   public void updatePinned(boolean isPinned) {
     this.isPinned = isPinned;
   }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -33,6 +33,7 @@ import plana.replan.domain.replan.exception.ReplanErrorCode;
 import plana.replan.domain.replan.repository.ReplanRepository;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.tag.entity.Tag;
@@ -51,6 +52,7 @@ class ReplanServiceTest {
   @Mock private TagRepository tagRepository;
   @Mock private RoutineRepository routineRepository;
   @Mock private RoutineService routineService;
+  @Mock private RoutineOverrideRepository routineOverrideRepository;
 
   private final Clock clock = Clock.fixed(Instant.parse("2026-06-18T00:00:00Z"), ZoneId.of("UTC"));
 
@@ -66,7 +68,8 @@ class ReplanServiceTest {
             tagRepository,
             clock,
             routineRepository,
-            routineService);
+            routineService,
+            routineOverrideRepository);
   }
 
   private Todo ownedTodo(Long todoId, Long userId) {
@@ -216,17 +219,22 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_TODO는_기존_투두를_제자리_수정한다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
+  void MODIFY_TODO는_기존투두를_치우고_새투두를_만든다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    // 마감 전(2026-06-25) → 실패 전 → softDelete
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0));
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation modify =
         new ReplanOperation(
             ReplanAction.MODIFY_TODO,
             42L,
             "데이터 분석 1~2강",
-            "2026-06-20",
+            "2026-07-02",
             "23:59",
             null,
             null,
@@ -237,39 +245,49 @@ class ReplanServiceTest {
 
     replanService.save(1L, req);
 
-    then(todo).should().updateTitle("데이터 분석 1~2강");
-    then(todo).should().linkReplan(any(Replan.class));
-    then(todoRepository).should(never()).save(any(Todo.class));
+    then(anchor).should().softDelete(); // 실패 전이므로 삭제
+    then(anchor).should(never()).deactivate();
+    // 원본 앵커가 아니라 "새로 만든" 투두를 저장해야 한다(같은 인스턴스를 다시 저장하면 안 됨)
+    org.mockito.ArgumentCaptor<Todo> savedTodo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(savedTodo.capture());
+    assertThat(savedTodo.getValue()).isNotSameAs(anchor);
   }
 
   @Test
-  void MODIFY_TODO_제목만_바꾸면_마감일은_유지된다() {
+  void MODIFY_TODO_실패전_앵커를_치우면_리플랜은_새_투두를_가리킨다() {
+    // 앵커를 소프트 삭제하면 리플랜이 통계 조회에서 사라지므로, 리플랜은 새 투두를 가리켜야 한다.
     Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Replan> replanCaptor =
+        org.mockito.ArgumentCaptor.forClass(Replan.class);
+    org.mockito.ArgumentCaptor<Todo> todoCaptor = org.mockito.ArgumentCaptor.forClass(Todo.class);
 
     ReplanOperation modify =
         new ReplanOperation(
             ReplanAction.MODIFY_TODO,
             42L,
-            "새 제목",
-            null, // dueDate null
-            null, // dueTime null
+            "데이터 분석 1~2강",
+            "2026-07-02",
+            null,
             null,
             null,
             null,
             List.of());
-    ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
-    replanService.save(1L, req);
-
-    then(anchor).should().updateTitle("새 제목");
-    then(anchor).should(never()).updateDueDate(any());
+    then(replanRepository).should().save(replanCaptor.capture());
+    then(todoRepository).should().save(todoCaptor.capture());
+    assertThat(replanCaptor.getValue().getTodo()).isSameAs(todoCaptor.getValue());
   }
 
   @Test
-  void 우선순위_다른_투두도_같은_사용자면_수정된다() {
+  void 우선순위_다른_투두도_같은사용자면_치우고_새로만든다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
 
@@ -277,6 +295,8 @@ class ReplanServiceTest {
     given(sameUser.getId()).willReturn(1L);
     Todo target = org.mockito.Mockito.mock(Todo.class);
     given(target.getUser()).willReturn(sameUser);
+    given(target.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(target.getChildren()).willReturn(List.of());
     given(todoRepository.findById(99L)).willReturn(Optional.of(target));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -285,8 +305,8 @@ class ReplanServiceTest {
             ReplanAction.MODIFY_TODO,
             99L,
             "[1] 데이터 분석 1~2강",
-            "2026-06-20",
-            "23:59",
+            null,
+            null,
             null,
             null,
             null,
@@ -296,8 +316,33 @@ class ReplanServiceTest {
 
     replanService.save(1L, req);
 
-    then(target).should().updateTitle("[1] 데이터 분석 1~2강");
-    then(target).should().linkReplan(any(Replan.class));
+    then(target).should().softDelete();
+    // 원본 대상이 아니라 새로 만든 투두를 저장해야 한다
+    org.mockito.ArgumentCaptor<Todo> savedTodo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(savedTodo.capture());
+    assertThat(savedTodo.getValue()).isNotSameAs(target);
+  }
+
+  @Test
+  void MODIFY_TODO_마감_지난_대상은_비활성화된다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거(실패 후)
+    given(anchor.getTitle()).willReturn("데이터 분석");
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, null, "2026-07-02", null, null, null, null, List.of());
+    ReplanSaveRequest req =
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+
+    replanService.save(1L, req);
+
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
+    then(todoRepository).should().save(any(Todo.class));
   }
 
   @Test
@@ -329,74 +374,155 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_ROUTINE은_루틴_규칙을_수정한다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todo.getId()).willReturn(42L);
+  void MODIFY_ROUTINE은_규칙수정_미래override폐기_회차치우기를_한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
     Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(todo.getRoutine()).willReturn(routine);
-    given(todo.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
+    given(anchor.getRoutine()).willReturn(routine);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(routine))
+        .willReturn(false); // 종료일 경과 → 다음 회차 안 만들어짐
 
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE,
             42L,
-            "영단어 50개 암기",
+            "영단어 50개",
             null,
             "11:15",
             null,
             "WEEKLY",
             62,
             List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("INTERRUPT_LATE_END"), List.of(op));
-
-    replanService.save(1L, req);
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("INTERRUPT_LATE_END"), List.of(op)));
 
     then(routine)
         .should()
         .update(
-            eq("영단어 50개 암기"),
-            any(),
-            eq(RoutineType.WEEKLY),
-            eq(62),
-            eq(LocalTime.of(11, 15)),
-            any());
+            eq("영단어 50개"), any(), eq(RoutineType.WEEKLY), eq(62), eq(LocalTime.of(11, 15)), any());
     then(routine).should().linkReplan(any(Replan.class));
-    then(todo).should().linkReplan(any(Replan.class));
+    // 오늘 이후 override만 지워야 한다(과거/오늘 것을 같이 지우면 안 됨). 컷오프 = 오늘(clock=2026-06-18).
+    org.mockito.ArgumentCaptor<java.time.LocalDate> cutoff =
+        org.mockito.ArgumentCaptor.forClass(java.time.LocalDate.class);
+    then(routineOverrideRepository)
+        .should()
+        .deleteByRoutineAndOverrideDateGreaterThanEqual(eq(routine), cutoff.capture());
+    assertThat(cutoff.getValue()).isEqualTo(java.time.LocalDate.of(2026, 6, 18));
+    // 새 규칙에 오늘 회차가 없어 대체 투두가 없다 → 소프트 삭제하면 리플랜이 통계에서 사라지므로 비활성화로 남긴다
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
+    then(routineService).should(never()).createTodoTreeFromMother(any()); // 오늘 회차 아님
   }
 
   @Test
-  void 루틴_수정_시_미지정_필드는_기존값_유지된다() {
-    Todo todo = ownedTodo(42L, 1L);
-    given(todo.getId()).willReturn(42L);
+  void MODIFY_ROUTINE_실패전이고_오늘이_회차면_오늘회차를_재생성한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
     Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(todo.getRoutine()).willReturn(routine);
-    given(todo.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
-    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    // op에서 title만 지정, 나머지는 null → 기존 루틴 값으로 fallback
+    given(anchor.getRoutine()).willReturn(routine);
     given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
     given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
     given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(org.mockito.Mockito.mock(Todo.class)));
 
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
-    replanService.save(1L, req);
+    then(anchor).should().softDelete();
+    then(routineService).should().createTodoTreeFromMother(routine);
+  }
 
-    // DAILY는 반복 날짜를 null로 정규화하므로 routineDate는 null로 들어간다
-    then(routine)
-        .should()
-        .update(
-            eq("새 제목"),
-            any(),
-            eq(RoutineType.DAILY),
-            org.mockito.ArgumentMatchers.isNull(),
-            eq(LocalTime.of(7, 30)),
-            any());
+  @Test
+  void MODIFY_ROUTINE_재생성된_오늘회차에_리플랜링크를_단다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
+    Todo newInstance = org.mockito.Mockito.mock(Todo.class);
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(newInstance));
+    org.mockito.ArgumentCaptor<Replan> replanCaptor =
+        org.mockito.ArgumentCaptor.forClass(Replan.class);
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    then(newInstance).should().linkReplan(any(Replan.class));
+    // 리플랜은 소프트 삭제된 앵커가 아니라 재생성된 새 회차를 가리켜야 한다
+    then(replanRepository).should().save(replanCaptor.capture());
+    assertThat(replanCaptor.getValue().getTodo()).isSameAs(newInstance);
+  }
+
+  @Test
+  void MODIFY_ROUTINE_하위루틴_회차_대상이면_거부된다() {
+    // 하위 루틴 회차는 규칙을 따로 갖지 않고 엄마 루틴을 따른다 — 루틴 규칙 변경(MODIFY_ROUTINE)은 거부한다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    Routine child = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(child);
+    given(child.isChild()).willReturn(true);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+
+    assertThatThrownBy(
+            () ->
+                replanService.save(
+                    1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op))))
+        .isInstanceOfSatisfying(
+            CustomException.class,
+            e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
+    then(routineService).should(never()).createTodoTreeFromMother(any());
+  }
+
+  @Test
+  void MODIFY_ROUTINE_실패후면_회차와_하위회차를_함께_비활성화하고_재생성안한다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 11, 0)); // 과거(실패 후)
+    Todo subOccurrence = org.mockito.Mockito.mock(Todo.class); // 루틴 회차의 하위 회차
+    given(anchor.getChildren()).willReturn(List.of(subOccurrence));
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(null);
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    then(anchor).should().deactivate();
+    then(anchor).should(never()).softDelete();
+    then(subOccurrence).should().deactivate(); // 하위 회차도 함께 비활성화돼 부모와 상태가 맞아야 한다
+    then(routineService).should(never()).createTodoTreeFromMother(any());
   }
 
   @Test
@@ -427,6 +553,35 @@ class ReplanServiceTest {
     then(routineRepository).should(times(1)).save(any(Routine.class));
     then(routineService).should().createTodoTreeFromMother(any());
     then(instanceTodo).should().linkReplan(any(Replan.class));
+  }
+
+  @Test
+  void CREATE_ROUTINE이_회차를_못만들면_마감지난_앵커를_치우지_않는다() {
+    // 루틴 종료일이 이미 지나 회차 투두가 안 생기는 경우, 앵커를 비활성화하면
+    // 원본도 대체도 없이 사라지므로 앵커를 건드리면 안 된다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거(실패 후)
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    // 회차 투두가 만들어지지 않음
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.empty());
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.CREATE_ROUTINE,
+            null,
+            "스트레칭",
+            "2020-01-01",
+            "20:00",
+            null,
+            "DAILY",
+            null,
+            List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("CONDITION_PAIN"), List.of(op)));
+
+    then(anchor).should(never()).deactivate();
+    then(anchor).should(never()).softDelete();
   }
 
   @Test
@@ -477,7 +632,6 @@ class ReplanServiceTest {
   @Test
   void 마감_지난_일반투두를_ADD로_대체하면_원본을_숨긴다() {
     Todo todo = ownedTodo(42L, 1L);
-    given(todo.getRoutine()).willReturn(null);
     given(todo.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
@@ -501,34 +655,154 @@ class ReplanServiceTest {
   }
 
   @Test
-  void 마감_지난_앵커를_MODIFY하고_ADD도_있으면_원본은_안숨긴다() {
+  void 앵커를_MODIFY로_치우면_post_loop에서_또_치우지_않는다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(anchor.getId()).willReturn(42L);
-    given(anchor.getRoutine()).willReturn(null);
     given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0)); // 과거
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation modifyOp =
         new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, "수정", "2026-06-25", null, null, null, null, List.of());
+    ReplanOperation addOp =
+        new ReplanOperation(
+            ReplanAction.ADD, null, "추가", "2026-06-26", null, null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp, addOp)));
+
+    then(anchor).should(times(1)).deactivate(); // MODIFY에서 1번만
+  }
+
+  @Test
+  void 미래_앵커에_보조_ADD만이면_앵커는_그대로_둔다() {
+    // 실패 전(미래) 앵커에 ADD는 보조 투두 추가일 수 있으므로 앵커를 치우면 안 된다
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 7, 1, 10, 0)); // 미래(실패 전)
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation addOp =
+        new ReplanOperation(
+            ReplanAction.ADD, null, "조용한 장소 세팅", "2026-07-02", null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(addOp)));
+
+    then(anchor).should(never()).softDelete();
+    then(anchor).should(never()).deactivate();
+    then(todoRepository).should().save(any(Todo.class)); // 보조 투두는 생성됨
+  }
+
+  @Test
+  void 우선순위_리플랜에서_앵커_아닌_투두만_수정하면_앵커는_건드리지_않는다() {
+    // Bug 1 회귀: ADD/CREATE_ROUTINE 없이 MODIFY_TODO만 있을 때 앵커를 오삭제하던 문제
+    Todo anchor = ownedTodo(42L, 1L);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+
+    User sameUser = org.mockito.Mockito.mock(User.class);
+    given(sameUser.getId()).willReturn(1L);
+    Todo target = org.mockito.Mockito.mock(Todo.class);
+    given(target.getUser()).willReturn(sameUser);
+    given(target.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(target.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(99L)).willReturn(Optional.of(target));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modifyOp =
+        new ReplanOperation(
             ReplanAction.MODIFY_TODO,
-            42L,
-            "수정된 제목",
-            "2026-06-25",
+            99L, // 앵커(42)가 아닌 다른 투두를 대상으로 한다
+            "[1] 데이터 분석 1~2강",
+            null,
             null,
             null,
             null,
             null,
             List.of());
-    ReplanOperation addOp =
-        new ReplanOperation(
-            ReplanAction.ADD, null, "추가 투두", "2026-06-26", null, null, null, null, List.of());
     ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp, addOp));
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp));
 
     replanService.save(1L, req);
 
+    // 대체 투두(ADD)가 없으므로 앵커(42)는 건드리지 않아야 한다
+    then(anchor).should(never()).softDelete();
     then(anchor).should(never()).deactivate();
+    // 대상(99)은 치우고 새 투두로 대체해야 한다
+    then(target).should().softDelete();
+    then(todoRepository).should().save(any(Todo.class));
+  }
+
+  @Test
+  void MODIFY_TODO_부모투두_수정시_하위투두는_새_부모로_옮기고_삭제하지_않는다() {
+    // Bug 2 회귀: 하위 투두가 있는 부모를 수정할 때 하위 투두까지 삭제되던 문제
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+
+    Todo child1 = org.mockito.Mockito.mock(Todo.class);
+    Todo child2 = org.mockito.Mockito.mock(Todo.class);
+    given(anchor.getChildren()).willReturn(List.of(child1, child2));
+
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "데이터 분석 1~2강",
+            "2026-07-02",
+            "23:59",
+            null,
+            null,
+            null,
+            List.of());
+    ReplanSaveRequest req =
+        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+
+    replanService.save(1L, req);
+
+    // 새로 만들어진 부모 투두를 캡처해서 각 하위 투두가 그걸 부모로 갱신했는지 확인한다
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(todoRepository).should().save(captor.capture());
+    Todo newParent = captor.getValue();
+
+    then(child1).should().updateParent(newParent);
+    then(child2).should().updateParent(newParent);
+    // 하위 투두는 삭제돼서는 안 된다
+    then(child1).should(never()).softDelete();
+    then(child2).should(never()).softDelete();
+  }
+
+  @Test
+  void MODIFY_TODO_하위투두_수정시_부모를_유지한다() {
+    Todo parent = org.mockito.Mockito.mock(Todo.class);
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전
+    given(anchor.getChildren()).willReturn(List.of());
+    given(anchor.getParent()).willReturn(parent);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "수정된 제목",
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(todoRepository).should().save(captor.capture());
+    assertThat(captor.getValue().getParent()).isSameAs(parent);
   }
 
   @Test
@@ -589,31 +863,26 @@ class ReplanServiceTest {
             e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
   }
 
-  // Fix 2 — 시간만 바꾸면 기존 날짜 보존
   @Test
-  void MODIFY_TODO_시간만_바꾸면_기존_날짜는_유지된다() {
+  void MODIFY_TODO_시간만_바꾸면_새투두는_기존_날짜를_유지한다() {
     Todo anchor = ownedTodo(42L, 1L);
-    given(anchor.getDueDate()).willReturn(java.time.LocalDateTime.of(2026, 6, 20, 10, 0));
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 10, 0)); // 실패 전
+    given(anchor.getTitle()).willReturn("데이터 분석");
+    given(anchor.getChildren()).willReturn(List.of());
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    org.mockito.ArgumentCaptor<Todo> captor = org.mockito.ArgumentCaptor.forClass(Todo.class);
 
     ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO,
-            42L,
-            null, // 제목 변경 없음
-            null, // dueDate null — 기존 날짜 유지
-            "15:30", // dueTime만 변경
-            null,
-            null,
-            null,
-            List.of());
-    ReplanSaveRequest req =
-        new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
+            ReplanAction.MODIFY_TODO, 42L, null, null, "15:30", null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
-    replanService.save(1L, req);
-
-    then(anchor).should().updateDueDate(java.time.LocalDateTime.of(2026, 6, 20, 15, 30));
+    then(todoRepository).should().save(captor.capture());
+    assertThat(captor.getValue().getDueDate()).isEqualTo(LocalDateTime.of(2026, 6, 25, 15, 30));
   }
 
   // Fix 3 — 실패 이유 개수 검증
@@ -852,41 +1121,31 @@ class ReplanServiceTest {
   }
 
   @Test
-  void MODIFY_ROUTINE_태그변경은_미완료_현재투두에도_반영된다() {
-    // ownedTodo가 내부적으로 User mock(getId()→1L)을 anchor.getUser()에 연결해 둔다
-    Todo anchor = ownedTodo(42L, 1L);
-    given(anchor.getId()).willReturn(42L);
-    Routine routine = org.mockito.Mockito.mock(Routine.class);
-    given(anchor.getRoutine()).willReturn(routine);
-    given(anchor.isCompleted()).willReturn(false);
-    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+  void MODIFY_TODO_루틴회차_대상이면_거부된다() {
+    // 루틴 회차 변경은 MODIFY_ROUTINE 담당 — MODIFY_TODO로 오면 거부
+    Todo target = ownedTodo(42L, 1L);
+    given(target.getRoutine()).willReturn(org.mockito.Mockito.mock(Routine.class));
+    given(todoRepository.findById(42L)).willReturn(Optional.of(target));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
-    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
-    given(routine.getRoutineDate()).willReturn(null);
-    given(routine.getRoutineTime()).willReturn(null);
 
-    // tag의 소유자 id가 anchor와 동일한 1L이어야 resolveTag 통과
-    Tag tag = org.mockito.Mockito.mock(Tag.class);
-    User tagOwner = org.mockito.Mockito.mock(User.class);
-    given(tagOwner.getId()).willReturn(1L);
-    given(tag.getUser()).willReturn(tagOwner);
-    given(tagRepository.findById(10L)).willReturn(Optional.of(tag));
-
-    ReplanOperation op =
+    ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE,
+            ReplanAction.MODIFY_TODO,
             42L,
+            "가벼운 스트레칭",
+            "2026-07-02",
             null,
             null,
-            null,
-            10L, // tagId 지정
             null,
             null,
             List.of());
-    ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
-    replanService.save(1L, req);
-
-    then(anchor).should().updateTag(tag);
+    assertThatThrownBy(
+            () ->
+                replanService.save(
+                    1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify))))
+        .isInstanceOfSatisfying(
+            CustomException.class,
+            e -> assertThat(e.getErrorCode()).isEqualTo(ReplanErrorCode.REPLAN_INVALID_OPERATION));
   }
 }

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -287,6 +287,36 @@ class ReplanServiceTest {
   }
 
   @Test
+  void MODIFY_TODO_같은_투두를_여러_번_리플랜하면_이전_리플랜도_새_투두로_옮긴다() {
+    // 같은 투두를 한 달에 두 번 리플랜하면 그 투두에 리플랜이 여러 개 달릴 수 있다.
+    // 두 번째 리플랜으로 그 투두를 소프트 삭제할 때 첫 번째 리플랜까지 새 투두로 옮기지 않으면,
+    // 첫 번째 리플랜이 통계 조회에서 사라져 한 달에 두 번 한 리플랜이 한 번으로 잡힌다.
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전 → 소프트 삭제
+    given(anchor.getChildren()).willReturn(List.of());
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(todoRepository.save(any(Todo.class))).willAnswer(inv -> inv.getArgument(0));
+    // 같은 투두에 이전부터 달려 있던 리플랜(첫 번째 리플랜)
+    Replan previousReplan = org.mockito.Mockito.mock(Replan.class);
+    given(replanRepository.findByTodo(anchor))
+        .willReturn(new java.util.ArrayList<>(List.of(previousReplan)));
+
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, "데이터 분석 다시", null, null, null, null, null, List.of());
+    replanService.save(
+        1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
+
+    then(anchor).should().softDelete();
+    // 이전 리플랜도 새 투두(원본 앵커가 아닌)로 옮겨져야 한다.
+    org.mockito.ArgumentCaptor<Todo> movedTo = org.mockito.ArgumentCaptor.forClass(Todo.class);
+    then(previousReplan).should().relinkTodo(movedTo.capture());
+    assertThat(movedTo.getValue()).isNotSameAs(anchor);
+  }
+
+  @Test
   void 우선순위_다른_투두도_같은사용자면_치우고_새로만든다() {
     Todo anchor = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
@@ -472,6 +502,41 @@ class ReplanServiceTest {
     // 리플랜은 소프트 삭제된 앵커가 아니라 재생성된 새 회차를 가리켜야 한다
     then(replanRepository).should().save(replanCaptor.capture());
     assertThat(replanCaptor.getValue().getTodo()).isSameAs(newInstance);
+  }
+
+  @Test
+  void MODIFY_ROUTINE_같은_회차를_여러_번_리플랜하면_이전_리플랜도_새_회차로_옮긴다() {
+    // 루틴 회차도 같은 회차를 한 달에 두 번 리플랜하면 리플랜이 여러 개 달릴 수 있다.
+    // 두 번째 리플랜으로 옛 회차를 소프트 삭제할 때 첫 번째 리플랜까지 새 회차로 옮기지 않으면,
+    // 첫 번째 리플랜이 통계 조회에서 사라진다(MODIFY_TODO와 동일한 누락).
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 25, 11, 0)); // 실패 전 → 소프트 삭제
+    given(anchor.getChildren()).willReturn(List.of());
+    Routine routine = org.mockito.Mockito.mock(Routine.class);
+    given(anchor.getRoutine()).willReturn(routine);
+    given(routine.getRoutineType()).willReturn(RoutineType.DAILY);
+    given(routine.getRoutineTime()).willReturn(LocalTime.of(7, 30));
+    given(routine.getTag()).willReturn(null);
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
+    given(routineService.willCreateUpcomingOccurrence(routine)).willReturn(true);
+    Todo newInstance = org.mockito.Mockito.mock(Todo.class);
+    given(newInstance.getChildren()).willReturn(List.of());
+    given(todoRepository.findFirstUpcomingMotherTodoByRoutine(any(), any()))
+        .willReturn(Optional.of(newInstance));
+    // 같은 회차(앵커)에 이전부터 달려 있던 리플랜(첫 번째 리플랜)
+    Replan previousReplan = org.mockito.Mockito.mock(Replan.class);
+    given(replanRepository.findByTodo(anchor))
+        .willReturn(new java.util.ArrayList<>(List.of(previousReplan)));
+
+    ReplanOperation op =
+        new ReplanOperation(
+            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+    replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
+
+    // 이전 리플랜도 소프트 삭제된 옛 회차가 아니라 재생성된 새 회차를 가리켜야 한다.
+    then(previousReplan).should().relinkTodo(newInstance);
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -746,6 +746,33 @@ class RoutineServiceTest {
                     .isEqualTo(RoutineErrorCode.ROUTINE_NOT_FOUND));
   }
 
+  // ========== willCreateUpcomingOccurrence ==========
+
+  @Test
+  void willCreateUpcomingOccurrence_종료일없으면_참() {
+    // 종료일이 없으면(무기한 반복) 다음 회차를 항상 만든다.
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isTrue();
+  }
+
+  @Test
+  void willCreateUpcomingOccurrence_다음회차가_종료일_이내면_참() {
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
+    // TEST_DATE = 2024-01-15. DAILY의 다음 회차는 오늘. 종료일이 오늘이면 만든다.
+    given(daily.getDueDate()).willReturn(LocalDateTime.of(2024, 1, 15, 0, 0));
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isTrue();
+  }
+
+  @Test
+  void willCreateUpcomingOccurrence_다음회차가_종료일_지나면_거짓() {
+    Routine daily = org.mockito.Mockito.mock(Routine.class);
+    given(daily.getRoutineType()).willReturn(RoutineType.DAILY);
+    // TEST_DATE = 2024-01-15. 종료일이 2024-01-10이면 다음 회차(오늘)가 종료일을 넘어 만들지 않는다.
+    given(daily.getDueDate()).willReturn(LocalDateTime.of(2024, 1, 10, 0, 0));
+    assertThat(routineService.willCreateUpcomingOccurrence(daily)).isFalse();
+  }
+
   // ========== generateDailyTodos with override ==========
 
   @Test


### PR DESCRIPTION
## 변경 사항

리플랜으로 투두를 저장하는 방식과 그에 따른 월간 통계 집계를 바로잡았습니다.

### 1) 리플랜으로 투두를 옮길 때 지난 달 통계가 왜곡되던 문제 수정
리플랜이 투두를 "수정"할 때, 기존 투두를 그 자리에서 덮어쓰지 않고 상황에 맞게 정리한 뒤 새 투두를 만들도록 바꿨습니다. 마감이 지난(실패한) 투두는 통계에 실패로 남기고, 마감 전 투두는 통계에서 빼는 식으로 구분해, 지난 달 달성률·통계가 뒤늦게 바뀌지 않게 했습니다. 루틴 회차를 리플랜하는 경우도 같은 원칙으로 정리합니다.

### 2) 같은 투두를 한 달에 여러 번 리플랜하면 이전 리플랜이 통계에서 누락되던 문제 수정
같은 투두를 한 달에 두 번 리플랜하면 첫 번째 리플랜 기록이 통계에서 사라져, 두 번 한 리플랜이 한 번으로 잡히던 문제를 고쳤습니다. 투두를 정리할 때 거기 달려 있던 리플랜 기록을 전부 새 투두로 옮기도록 했습니다. (일반 투두·루틴 회차 모두 적용)

## 테스트 결과

- 단위 테스트 전부 통과(리플랜 저장 각 경로 + 같은 투두 여러 번 리플랜 회귀 테스트 포함).
- 로컬 서버에서 실제 API로 전수 확인: 투두 생성 → 1차 리플랜 → 2차 리플랜 후 월간 리포트의 리플랜 횟수가 정확히 2로 집계됨.
- JDK 17 빌드(Spotless 포맷 검사 포함) + CI 통과.
- 배포 후 운영 서버에서 동일 케이스 전수 테스트 예정.
