### PR TITLE
Fix: Capacitor 앱 webview origin CORS 허용 추가

### DIFF
--- a/src/main/java/plana/replan/global/config/SecurityConfig.java
+++ b/src/main/java/plana/replan/global/config/SecurityConfig.java
@@ -93,6 +93,11 @@ public class SecurityConfig {
     config.addAllowedOrigin("http://localhost:3000");
     config.addAllowedOrigin("http://localhost:5173");
     config.addAllowedOrigin("https://re-plan-fe.vercel.app");
+    // Capacitor 네이티브 앱(iOS/Android) webview origin 허용
+    config.addAllowedOrigin("capacitor://localhost");
+    config.addAllowedOrigin("ionic://localhost");
+    config.addAllowedOrigin("http://localhost");
+    config.addAllowedOrigin("https://localhost");
     config.addAllowedMethod("*");
     config.addAllowedHeader("*");
     config.setAllowCredentials(true);


### PR DESCRIPTION
## 문제
Capacitor 앱(iOS/Android)에서 로그인 API 호출 시 CORS preflight가 403으로 막힘. 앱 webview origin이 허용 목록에 없어서 발생.

## 수정
SecurityConfig CORS 허용에 capacitor://localhost, ionic://localhost, http(s)://localhost 추가.

close #233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 앱 접속이 허용되는 출처 범위가 확장되어, 로컬 환경과 모바일/하이브리드 환경에서의 접속 안정성이 개선되었습니다.
  * 기존 허용 출처 외에 `capacitor://localhost`, `ionic://localhost`, `http://localhost`, `https://localhost`가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->