### PR TITLE
Feat: 일반 투두 삭제 취소 API 추가 및 특정 날짜의 루틴 오버라이드 상태를 조회 

### DIFF
--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +26,16 @@ import plana.replan.global.common.ApiResult;
 public class RoutineOverrideController implements RoutineOverrideControllerDocs {
 
   private final RoutineOverrideService routineOverrideService;
+
+  @Override
+  @GetMapping("/{routineId}/overrides/{date}")
+  public ResponseEntity<ApiResult<RoutineOverrideResponseDto>> getOverride(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long routineId,
+      @PathVariable LocalDate date) {
+    return ResponseEntity.ok(
+        ApiResult.ok(routineOverrideService.getOverride(userId, routineId, date)));
+  }
 
   @Override
   @PatchMapping("/{routineId}/overrides/{date}")

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
@@ -400,4 +400,139 @@ public interface RoutineOverrideControllerDocs {
       @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
       @Parameter(description = "건너뜀을 취소할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
           LocalDate date);
+
+  @Operation(
+      summary = "루틴 인스턴스 디테일 조회",
+      description =
+          """
+          특정 날짜의 루틴 인스턴스 정보를 조회한다.
+
+          - Todo가 이미 생성된 날짜라면 `todoId`가 포함된다.
+          - 미래 날짜(아직 Todo가 없는 경우)라면 `todoId`는 null이다.
+          - override가 없는 경우에도 루틴 기본값으로 응답한다.
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          **Path Variables**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | routineId | ✅ 필수 | integer | 루틴 ID | `1` |
+          | date | ✅ 필수 | string | 조회할 날짜 (yyyy-MM-dd 형식) | `2026-07-01` |
+
+          **Response Elements**
+
+          | 필드명 | 타입 | 설명 |
+          |--------|------|------|
+          | routineId | integer | 루틴 ID |
+          | overrideDate | string | 조회 날짜 (yyyy-MM-dd 형식) |
+          | effectiveTitle | string | 실제 적용될 제목 (override 우선) |
+          | effectiveTagId | integer | 실제 적용될 태그 ID. 없으면 null |
+          | effectiveTagTitle | string | 실제 적용될 태그 제목. 없으면 null |
+          | effectiveTagColor | string | 실제 적용될 태그 색상. 없으면 null |
+          | effectiveSortOrder | number | 실제 적용될 정렬 순서 |
+          | isSkipped | boolean | 건너뜀 여부 |
+          | isPinned | boolean | 핀 여부 |
+          | isCompleted | boolean | 완료 여부 |
+          | hasOverride | boolean | override 존재 여부 |
+          | todoId | integer | 생성된 Todo ID. 없으면 null |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "루틴 인스턴스 디테일 조회 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "routineId": 1,
+                                "overrideDate": "2026-07-01",
+                                "effectiveTitle": "아침 스트레칭",
+                                "effectiveTagId": 3,
+                                "effectiveTagTitle": "운동",
+                                "effectiveTagColor": "GREEN",
+                                "effectiveSortOrder": 10000.0,
+                                "isSkipped": false,
+                                "isPinned": false,
+                                "isCompleted": false,
+                                "hasOverride": false,
+                                "todoId": 42
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "루틴을 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_NOT_FOUND",
+                                "message": "루틴을 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<RoutineOverrideResponseDto>> getOverride(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
+      @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable
+          LocalDate date);
 }

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineOverrideResponseDto.java
@@ -25,12 +25,29 @@ public record RoutineOverrideResponseDto(
         boolean hasOverride,
     @Schema(description = "이미 배치로 생성된 Todo ID. 없으면 null", example = "42") Long todoId) {
 
+  public static RoutineOverrideResponseDto ofNoOverride(
+      Routine routine, LocalDate date, Long todoId) {
+    Tag tag = resolveTag(routine, null);
+    return new RoutineOverrideResponseDto(
+        routine.getId(),
+        date,
+        routine.getTitle(),
+        tag != null ? tag.getId() : null,
+        tag != null ? tag.getTitle() : null,
+        tag != null ? tag.getColor() : null,
+        routine.getDefaultSortOrder(),
+        false,
+        false,
+        false,
+        false,
+        todoId);
+  }
+
   public static RoutineOverrideResponseDto of(
       Routine routine, RoutineOverride override, Long todoId) {
-    Tag effectiveTag = override.getTag() != null ? override.getTag() : routine.getTag();
-    String effectiveTitle = override.getTitle() != null ? override.getTitle() : routine.getTitle();
-    double effectiveSortOrder =
-        override.getSortOrder() != null ? override.getSortOrder() : routine.getDefaultSortOrder();
+    Tag effectiveTag = resolveTag(routine, override);
+    String effectiveTitle = resolveTitle(routine, override);
+    double effectiveSortOrder = resolveSortOrder(routine, override);
 
     return new RoutineOverrideResponseDto(
         routine.getId(),
@@ -45,5 +62,21 @@ public record RoutineOverrideResponseDto(
         Boolean.TRUE.equals(override.getIsCompleted()),
         true,
         todoId);
+  }
+
+  private static Tag resolveTag(Routine routine, RoutineOverride override) {
+    return (override != null && override.getTag() != null) ? override.getTag() : routine.getTag();
+  }
+
+  private static String resolveTitle(Routine routine, RoutineOverride override) {
+    return (override != null && override.getTitle() != null)
+        ? override.getTitle()
+        : routine.getTitle();
+  }
+
+  private static double resolveSortOrder(Routine routine, RoutineOverride override) {
+    return (override != null && override.getSortOrder() != null)
+        ? override.getSortOrder()
+        : routine.getDefaultSortOrder();
   }
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -3,7 +3,6 @@ package plana.replan.domain.routine.service;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -123,6 +122,17 @@ public class RoutineOverrideService {
         routine, override, existingTodo.map(Todo::getId).orElse(null));
   }
 
+  @Transactional(readOnly = true)
+  public RoutineOverrideResponseDto getOverride(Long userId, Long routineId, LocalDate date) {
+    Routine routine = findOwnedMotherRoutine(userId, routineId);
+    Long todoId = findExistingTodo(routine, date).map(Todo::getId).orElse(null);
+
+    return routineOverrideRepository
+        .findByRoutineAndOverrideDate(routine, date)
+        .map(override -> RoutineOverrideResponseDto.of(routine, override, todoId))
+        .orElseGet(() -> RoutineOverrideResponseDto.ofNoOverride(routine, date, todoId));
+  }
+
   @Transactional
   public void skip(Long userId, Long routineId, LocalDate date) {
     Routine routine = findOwnedMotherRoutine(userId, routineId);
@@ -145,17 +155,26 @@ public class RoutineOverrideService {
   public void unskip(Long userId, Long routineId, LocalDate date) {
     Routine routine = findOwnedMotherRoutine(userId, routineId);
 
-    RoutineOverride override = upsert(routine, date);
-    override.unskip();
-
-    LocalDateTime start = date.atStartOfDay();
-    LocalDateTime end = date.plusDays(1).atStartOfDay();
-    todoRepository
-        .findDeletedMotherTodoByRoutineAndDate(routineId, start, end)
+    // skip된 override가 없으면 no-op (ghost override row 생성 방지)
+    routineOverrideRepository
+        .findByRoutineAndOverrideDate(routine, date)
+        .filter(RoutineOverride::isSkipped)
         .ifPresent(
-            todo -> {
-              todoRepository.findDeletedChildrenByParentId(todo.getId()).forEach(Todo::restore);
-              todo.restore();
+            override -> {
+              override.unskip();
+
+              LocalDateTime start = date.atStartOfDay();
+              LocalDateTime end = date.plusDays(1).atStartOfDay();
+              todoRepository
+                  .findDeletedMotherTodoByRoutineAndDate(routineId, start, end)
+                  .ifPresent(
+                      todo -> {
+                        todoRepository
+                            .findDeletedChildrenByParentId(
+                                todo.getId(), todo.getDeletedAt().minusSeconds(1))
+                            .forEach(Todo::restore);
+                        todo.restore();
+                      });
             });
   }
 
@@ -194,7 +213,7 @@ public class RoutineOverrideService {
 
   private Optional<Todo> findExistingTodo(Routine routine, LocalDate date) {
     LocalDateTime start = date.atStartOfDay();
-    LocalDateTime end = date.atTime(LocalTime.MAX);
+    LocalDateTime end = date.plusDays(1).atStartOfDay();
     return todoRepository.findMotherTodoByRoutineAndDate(routine, start, end);
   }
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -147,6 +147,16 @@ public class RoutineOverrideService {
 
     RoutineOverride override = upsert(routine, date);
     override.unskip();
+
+    LocalDateTime start = date.atStartOfDay();
+    LocalDateTime end = date.plusDays(1).atStartOfDay();
+    todoRepository
+        .findDeletedMotherTodoByRoutineAndDate(routineId, start, end)
+        .ifPresent(
+            todo -> {
+              todoRepository.findDeletedChildrenByParentId(todo.getId()).forEach(Todo::restore);
+              todo.restore();
+            });
   }
 
   private Routine findOwnedMotherRoutine(Long userId, Long routineId) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -143,8 +143,9 @@ public class RoutineOverrideService {
               if (todo.isCompleted()) {
                 throw new CustomException(RoutineErrorCode.ROUTINE_OVERRIDE_CANNOT_SKIP_COMPLETED);
               }
-              todo.getChildren().forEach(Todo::softDelete);
-              todo.softDelete();
+              LocalDateTime now = LocalDateTime.now(clock);
+              todo.getChildren().forEach(child -> child.softDelete(now));
+              todo.softDelete(now);
             });
 
     RoutineOverride override = upsert(routine, date);
@@ -170,8 +171,7 @@ public class RoutineOverrideService {
                   .ifPresent(
                       todo -> {
                         todoRepository
-                            .findDeletedChildrenByParentId(
-                                todo.getId(), todo.getDeletedAt().minusSeconds(1))
+                            .findDeletedChildrenByParentId(todo.getId(), todo.getDeletedAt())
                             .forEach(Todo::restore);
                         todo.restore();
                       });

--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -97,6 +97,14 @@ public class TodoController implements TodoControllerDocs {
   }
 
   @Override
+  @PatchMapping("/{todoId}/restore")
+  public ResponseEntity<ApiResult<Void>> restoreTodo(
+      @AuthenticationPrincipal Long userId, @PathVariable Long todoId) {
+    todoService.restoreTodo(userId, todoId);
+    return ResponseEntity.ok(ApiResult.ok(null));
+  }
+
+  @Override
   @PutMapping("/{todoId}")
   public ResponseEntity<ApiResult<TodoDetailResponseDto>> updateTodo(
       @AuthenticationPrincipal Long userId,

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -1657,4 +1657,113 @@ public interface TodoControllerDocs {
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "상위 투두 ID", example = "42") @PathVariable Long parentId,
       @Parameter(description = "삭제할 하위 투두 ID", example = "43") @PathVariable Long subTodoId);
+
+  @Operation(
+      summary = "일반 투두 삭제 취소",
+      description =
+          """
+          **호출 주체**: AccessToken을 보유한 인증 사용자
+
+          **요청 방법**: `Authorization: Bearer {accessToken}` 헤더 필수
+
+          삭제된 일반 투두를 복원합니다. 하위 투두도 함께 복원됩니다.
+
+          - 루틴 투두는 이 API로 복원할 수 없습니다. 루틴 투두는 `PATCH /api/routines/{routineId}/overrides/{date}/unskip` 을 사용하세요.
+
+          **Request Headers**
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          **Path Variable**
+
+          | 파라미터명 | 필수 여부 | 타입 | 설명 | 예시 |
+          |-----------|-----------|------|------|------|
+          | todoId | ✅ 필수 | integer | 복원할 투두 ID | `1` |
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "삭제 취소 성공"),
+    @ApiResponse(
+        responseCode = "400",
+        description = "루틴 투두에 호출한 경우",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 400,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "ROUTINE_TODO_USE_ROUTINE_API",
+                                "message": "반복 todo는 루틴 API를 통해 수정해주세요.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "404",
+        description = "삭제된 투두를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "TODO_NOT_FOUND",
+                                "message": "투두를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "AccessToken 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                }))
+  })
+  ResponseEntity<ApiResult<Void>> restoreTodo(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "복원할 투두 ID", example = "1") @PathVariable Long todoId);
 }

--- a/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/plana/replan/domain/todo/exception/TodoErrorCode.java
@@ -10,7 +10,8 @@ public enum TodoErrorCode implements ErrorCode {
   TODO_NOT_FOUND(404, "투두를 찾을 수 없습니다."),
   INVALID_FILTER(400, "유효하지 않은 필터 값입니다. (all, day, week, month 중 하나)"),
   INVALID_SORT(400, "유효하지 않은 정렬 값입니다. (priority, dueDate 중 하나)"),
-  ROUTINE_TODO_USE_ROUTINE_API(400, "반복 todo는 루틴 API를 통해 수정해주세요.");
+  ROUTINE_TODO_USE_ROUTINE_API(400, "반복 todo는 루틴 API를 통해 수정해주세요."),
+  TODO_NOT_DELETED(400, "삭제된 투두가 아닙니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -104,14 +104,19 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
           + " AND t.deletedAt IS NULL")
   Optional<Double> findMaxSortOrderByUser(@Param("user") User user);
 
+  // native query: @SQLRestriction("deleted_at IS NULL") 우회 — 삭제된 행 조회용
   @Query(value = "SELECT * FROM todo WHERE id = :id AND deleted_at IS NOT NULL", nativeQuery = true)
   Optional<Todo> findDeletedById(@Param("id") Long id);
 
+  // native query: @SQLRestriction("deleted_at IS NULL") 우회 — 삭제된 행 조회용
+  // :since = 부모의 deletedAt - 1초. 부모 삭제 시점에 함께 삭제된 자식만 반환해 독립 삭제 자식 부활을 방지한다.
   @Query(
-      value = "SELECT * FROM todo WHERE parent_id = :parentId AND deleted_at IS NOT NULL",
+      value = "SELECT * FROM todo WHERE parent_id = :parentId AND deleted_at >= :since",
       nativeQuery = true)
-  List<Todo> findDeletedChildrenByParentId(@Param("parentId") Long parentId);
+  List<Todo> findDeletedChildrenByParentId(
+      @Param("parentId") Long parentId, @Param("since") LocalDateTime since);
 
+  // native query: @SQLRestriction("deleted_at IS NULL") 우회 — 삭제된 행 조회용
   @Query(
       value =
           "SELECT * FROM todo WHERE routine_id = :routineId AND parent_id IS NULL"

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -109,12 +109,12 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   Optional<Todo> findDeletedById(@Param("id") Long id);
 
   // native query: @SQLRestriction("deleted_at IS NULL") 우회 — 삭제된 행 조회용
-  // :since = 부모의 deletedAt - 1초. 부모 삭제 시점에 함께 삭제된 자식만 반환해 독립 삭제 자식 부활을 방지한다.
+  // :deletedAt = 부모와 동일한 softDelete 시각. skip/deleteTodo에서 공통 시각으로 삭제된 자식만 반환한다.
   @Query(
-      value = "SELECT * FROM todo WHERE parent_id = :parentId AND deleted_at >= :since",
+      value = "SELECT * FROM todo WHERE parent_id = :parentId AND deleted_at = :deletedAt",
       nativeQuery = true)
   List<Todo> findDeletedChildrenByParentId(
-      @Param("parentId") Long parentId, @Param("since") LocalDateTime since);
+      @Param("parentId") Long parentId, @Param("deletedAt") LocalDateTime deletedAt);
 
   // native query: @SQLRestriction("deleted_at IS NULL") 우회 — 삭제된 행 조회용
   @Query(

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -104,6 +104,24 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
           + " AND t.deletedAt IS NULL")
   Optional<Double> findMaxSortOrderByUser(@Param("user") User user);
 
+  @Query(value = "SELECT * FROM todo WHERE id = :id AND deleted_at IS NOT NULL", nativeQuery = true)
+  Optional<Todo> findDeletedById(@Param("id") Long id);
+
+  @Query(
+      value = "SELECT * FROM todo WHERE parent_id = :parentId AND deleted_at IS NOT NULL",
+      nativeQuery = true)
+  List<Todo> findDeletedChildrenByParentId(@Param("parentId") Long parentId);
+
+  @Query(
+      value =
+          "SELECT * FROM todo WHERE routine_id = :routineId AND parent_id IS NULL"
+              + " AND due_date >= :start AND due_date < :end AND deleted_at IS NOT NULL",
+      nativeQuery = true)
+  Optional<Todo> findDeletedMotherTodoByRoutineAndDate(
+      @Param("routineId") Long routineId,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.replan IS NOT NULL"
           + " AND ((t.dueDate >= :start AND t.dueDate < :end)"

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -462,8 +462,9 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
     }
 
-    todo.getChildren().forEach(child -> child.softDelete());
-    todo.softDelete();
+    LocalDateTime now = LocalDateTime.now(clock);
+    todo.getChildren().forEach(child -> child.softDelete(now));
+    todo.softDelete(now);
   }
 
   @Transactional
@@ -489,7 +490,7 @@ public class TodoService {
     }
 
     todoRepository
-        .findDeletedChildrenByParentId(todoId, todo.getDeletedAt().minusSeconds(1))
+        .findDeletedChildrenByParentId(todoId, todo.getDeletedAt())
         .forEach(Todo::restore);
     todo.restore();
   }

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -480,11 +480,17 @@ public class TodoService {
       throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
     }
 
+    if (todo.getParent() != null) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
     if (todo.getRoutine() != null) {
       throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
     }
 
-    todoRepository.findDeletedChildrenByParentId(todoId).forEach(Todo::restore);
+    todoRepository
+        .findDeletedChildrenByParentId(todoId, todo.getDeletedAt().minusSeconds(1))
+        .forEach(Todo::restore);
     todo.restore();
   }
 

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -467,6 +467,28 @@ public class TodoService {
   }
 
   @Transactional
+  public void restoreTodo(Long userId, Long todoId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    Todo todo =
+        todoRepository
+            .findDeletedById(todoId)
+            .orElseThrow(() -> new CustomException(TodoErrorCode.TODO_NOT_FOUND));
+
+    if (!todo.getUser().getId().equals(userId)) {
+      throw new CustomException(TodoErrorCode.TODO_NOT_FOUND);
+    }
+
+    if (todo.getRoutine() != null) {
+      throw new CustomException(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API);
+    }
+
+    todoRepository.findDeletedChildrenByParentId(todoId).forEach(Todo::restore);
+    todo.restore();
+  }
+
+  @Transactional
   public void deleteSubTodo(Long userId, Long parentId, Long subTodoId) {
     if (userId == null) {
       throw new CustomException(UserErrorCode.USER_NOT_FOUND);

--- a/src/main/java/plana/replan/global/entity/BaseTimeEntity.java
+++ b/src/main/java/plana/replan/global/entity/BaseTimeEntity.java
@@ -25,4 +25,8 @@ public abstract class BaseTimeEntity {
   public void softDelete() {
     this.deletedAt = LocalDateTime.now();
   }
+
+  public void restore() {
+    this.deletedAt = null;
+  }
 }

--- a/src/main/java/plana/replan/global/entity/BaseTimeEntity.java
+++ b/src/main/java/plana/replan/global/entity/BaseTimeEntity.java
@@ -26,6 +26,10 @@ public abstract class BaseTimeEntity {
     this.deletedAt = LocalDateTime.now();
   }
 
+  public void softDelete(LocalDateTime at) {
+    this.deletedAt = at;
+  }
+
   public void restore() {
     this.deletedAt = null;
   }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1793,4 +1793,109 @@ class TodoServiceTest {
                 assertThat(((CustomException) e).getErrorCode())
                     .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
   }
+
+  // ── restoreTodo ─────────────────────────────────────────────────────────────
+
+  private Todo deletedTodo(Long id, User user) {
+    Todo todo = testTodo(id, user);
+    todo.softDelete();
+    return todo;
+  }
+
+  @Test
+  @DisplayName("restoreTodo - userId null: USER_NOT_FOUND 예외")
+  void restoreTodo_nullUserId_throws() {
+    assertThatThrownBy(() -> todoService.restoreTodo(null, 1L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("restoreTodo - 삭제된 투두 없음: TODO_NOT_FOUND 예외")
+  void restoreTodo_notFound_throws() {
+    given(todoRepository.findDeletedById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> todoService.restoreTodo(1L, 99L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("restoreTodo - 다른 유저 소유: TODO_NOT_FOUND 예외")
+  void restoreTodo_otherUserTodo_throws() {
+    User other =
+        User.builder()
+            .email("other@test.com")
+            .nickname("타인")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    ReflectionTestUtils.setField(other, "id", 99L);
+    Todo todo = deletedTodo(1L, other);
+
+    given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(() -> todoService.restoreTodo(1L, 1L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
+  @DisplayName("restoreTodo - 루틴 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
+  void restoreTodo_routineTodo_throws() {
+    User user = testUser();
+    Todo todo = deletedTodo(1L, user);
+    Routine routine = testRoutine(user, RoutineType.DAILY);
+    ReflectionTestUtils.setField(todo, "routine", routine);
+
+    given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(todo));
+
+    assertThatThrownBy(() -> todoService.restoreTodo(1L, 1L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.ROUTINE_TODO_USE_ROUTINE_API));
+  }
+
+  @Test
+  @DisplayName("restoreTodo - 성공 (하위 투두 없음): deletedAt null로 복원")
+  void restoreTodo_success_noChildren() {
+    User user = testUser();
+    Todo todo = deletedTodo(1L, user);
+
+    given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(todo));
+    given(todoRepository.findDeletedChildrenByParentId(1L)).willReturn(List.of());
+
+    todoService.restoreTodo(1L, 1L);
+
+    assertThat(ReflectionTestUtils.getField(todo, "deletedAt")).isNull();
+  }
+
+  @Test
+  @DisplayName("restoreTodo - 성공 (하위 투두 있음): 부모·하위 투두 모두 deletedAt null로 복원")
+  void restoreTodo_success_withChildren() {
+    User user = testUser();
+    Todo parent = deletedTodo(1L, user);
+    Todo child1 = deletedTodo(10L, user);
+    Todo child2 = deletedTodo(11L, user);
+
+    given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(parent));
+    given(todoRepository.findDeletedChildrenByParentId(1L)).willReturn(List.of(child1, child2));
+
+    todoService.restoreTodo(1L, 1L);
+
+    assertThat(ReflectionTestUtils.getField(parent, "deletedAt")).isNull();
+    assertThat(ReflectionTestUtils.getField(child1, "deletedAt")).isNull();
+    assertThat(ReflectionTestUtils.getField(child2, "deletedAt")).isNull();
+  }
 }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -1850,6 +1851,24 @@ class TodoServiceTest {
   }
 
   @Test
+  @DisplayName("restoreTodo - 서브투두 ID로 호출: TODO_NOT_FOUND 예외")
+  void restoreTodo_subTodo_throws() {
+    User user = testUser();
+    Todo parent = testTodo(10L, user);
+    Todo subTodo = deletedTodo(1L, user);
+    ReflectionTestUtils.setField(subTodo, "parent", parent);
+
+    given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(subTodo));
+
+    assertThatThrownBy(() -> todoService.restoreTodo(1L, 1L))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(TodoErrorCode.TODO_NOT_FOUND));
+  }
+
+  @Test
   @DisplayName("restoreTodo - 루틴 투두: ROUTINE_TODO_USE_ROUTINE_API 예외")
   void restoreTodo_routineTodo_throws() {
     User user = testUser();
@@ -1874,7 +1893,8 @@ class TodoServiceTest {
     Todo todo = deletedTodo(1L, user);
 
     given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(todo));
-    given(todoRepository.findDeletedChildrenByParentId(1L)).willReturn(List.of());
+    given(todoRepository.findDeletedChildrenByParentId(eq(1L), any(LocalDateTime.class)))
+        .willReturn(List.of());
 
     todoService.restoreTodo(1L, 1L);
 
@@ -1890,7 +1910,8 @@ class TodoServiceTest {
     Todo child2 = deletedTodo(11L, user);
 
     given(todoRepository.findDeletedById(1L)).willReturn(Optional.of(parent));
-    given(todoRepository.findDeletedChildrenByParentId(1L)).willReturn(List.of(child1, child2));
+    given(todoRepository.findDeletedChildrenByParentId(eq(1L), any(LocalDateTime.class)))
+        .willReturn(List.of(child1, child2));
 
     todoService.restoreTodo(1L, 1L);
 


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #236 


## 변경 사항
  - PATCH /api/todos/{todoId}/restore — 일반 투두 삭제 취소 API 추가 (하위 투두 포함 복원)                                                                                  
  - GET /api/routines/{routineId}/overrides/{date} — 루틴 인스턴스 디테일 조회 API 추가 (Todo 존재 여부와 무관하게 단일 엔드포인트로 처리)                                  
  - unskip 강화 — skip으로 삭제된 Todo가 있을 경우 unskip 시 함께 복원


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 삭제된 일반 투두를 다시 복원할 수 있게 되었습니다.
  * 특정 날짜의 루틴 오버라이드 상태를 조회할 수 있게 되었습니다.

* **Bug Fixes**
  * 복원 시 하위 투두도 함께 정상 복구되도록 개선했습니다.
  * 복원 대상이 아닌 항목에 대한 잘못된 복원 동작을 방지했습니다.
  * 루틴 오버라이드가 없는 경우에도 기본 루틴 정보로 결과를 반환하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->