### PR TITLE
Feat: AI 투두 추천이 유저 태그를 골라 태그ID·태그명을 함께 반환

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalController.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalController.java
@@ -74,7 +74,7 @@ public class GoalController implements GoalControllerDocs {
   @PostMapping("/ai/todo-recommendations")
   public ResponseEntity<ApiResult<TodoRecommendationResponse>> recommendTodos(
       @AuthenticationPrincipal Long userId, @Valid @RequestBody TodoRecommendationRequest request) {
-    return ResponseEntity.ok(ApiResult.ok(goalAiService.recommendTodos(request)));
+    return ResponseEntity.ok(ApiResult.ok(goalAiService.recommendTodos(userId, request)));
   }
 
   @Override

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -1029,6 +1029,8 @@ public interface GoalControllerDocs {
           | todos[].dueTime | string | 마감 시간 (HH:mm 형식). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
           | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자. DAILY·ONE_TIME: null |
+          | todos[].tagId | integer | AI가 이 투두에 배정한 태그 ID. 요청한 유저의 실제 태그 중에서 선택됨. 마땅한 태그가 없으면 null |
+          | todos[].tagName | string | 배정된 태그 이름. tagId가 null이면 함께 null |
 
           ---
 
@@ -1060,7 +1062,9 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-08-25",
                                     "dueTime": null,
                                     "routineType": "DAILY",
-                                    "routineDate": null
+                                    "routineDate": null,
+                                    "tagId": 1,
+                                    "tagName": "Study"
                                   },
                                   {
                                     "type": "ONE_TIME",
@@ -1068,7 +1072,9 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-06-10",
                                     "dueTime": "08:00",
                                     "routineType": null,
-                                    "routineDate": null
+                                    "routineDate": null,
+                                    "tagId": 1,
+                                    "tagName": "Study"
                                   },
                                   {
                                     "type": "ONE_TIME",
@@ -1076,7 +1082,9 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-08-24",
                                     "dueTime": null,
                                     "routineType": null,
-                                    "routineDate": null
+                                    "routineDate": null,
+                                    "tagId": null,
+                                    "tagName": null
                                   }
                                 ]
                               },

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -28,4 +28,11 @@ public record RecommendedTodo(
                 "반복 날짜 (RECURRING만 사용). WEEKLY: 요일 bitmask (월=1,화=2,수=4,목=8,금=16,토=32,일=64). MONTHLY: 일자(1~31). DAILY: null.",
             example = "62",
             nullable = true)
-        Integer routineDate) {}
+        Integer routineDate,
+    @Schema(
+            description = "AI가 이 투두에 배정한 태그 ID. 유저의 실제 태그 중에서 선택되며, 마땅한 태그가 없으면 null",
+            example = "1",
+            nullable = true)
+        Long tagId,
+    @Schema(description = "배정된 태그 이름. tagId가 null이면 함께 null", example = "Study", nullable = true)
+        String tagName) {}

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -365,9 +365,19 @@ public class GoalAiService {
         Long tagId = null;
         String tagName = null;
         JsonNode tagIdNode = node.path("tagId");
-        if (!tagIdNode.isNull() && !tagIdNode.isMissingNode() && tagIdNode.canConvertToLong()) {
-          Long candidate = tagIdNode.asLong();
-          if (validTags.containsKey(candidate)) {
+        if (!tagIdNode.isNull() && !tagIdNode.isMissingNode()) {
+          // 숫자(1)뿐 아니라 문자열("1")로 온 경우도 받아들인다. LLM이 숫자를 따옴표로 감싸 주는 일이 흔하다.
+          Long candidate = null;
+          if (tagIdNode.canConvertToLong()) {
+            candidate = tagIdNode.asLong();
+          } else if (tagIdNode.isTextual()) {
+            try {
+              candidate = Long.valueOf(tagIdNode.asText().trim());
+            } catch (NumberFormatException ignored) {
+              candidate = null;
+            }
+          }
+          if (candidate != null && validTags.containsKey(candidate)) {
             tagId = candidate;
             tagName = validTags.get(candidate);
           }

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,8 @@ import plana.replan.domain.goal.dto.refine.RefinedField;
 import plana.replan.domain.goal.dto.refine.RefinedNoteItem;
 import plana.replan.domain.goal.dto.refine.RefinedSolution;
 import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.tag.repository.TagRepository;
 import plana.replan.global.exception.CustomException;
 
 @Slf4j
@@ -40,6 +43,7 @@ public class GoalAiService {
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent";
 
   private final RestClient geminiRestClient;
+  private final TagRepository tagRepository;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Value("${gemini.api-key}")
@@ -195,11 +199,24 @@ public class GoalAiService {
     }
   }
 
-  public TodoRecommendationResponse recommendTodos(TodoRecommendationRequest request) {
+  public TodoRecommendationResponse recommendTodos(Long userId, TodoRecommendationRequest request) {
     validateRefreshCount(request.refreshCount());
-    String prompt = buildRecommendPrompt(request);
+    List<Tag> tags = tagRepository.findAllByUserId(userId);
+    String prompt = buildRecommendPrompt(request, buildTagInfo(tags));
     String raw = callGemini(prompt);
-    return parseRecommendResponse(raw);
+    return parseRecommendResponse(raw, tags);
+  }
+
+  /** 유저 태그 목록을 프롬프트용 문자열로 만든다. 태그가 없으면 "없음". */
+  String buildTagInfo(List<Tag> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return "없음";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Tag tag : tags) {
+      sb.append("- id=").append(tag.getId()).append(", name=").append(tag.getTitle()).append("\n");
+    }
+    return sb.toString();
   }
 
   /** 새로고침 횟수를 0~3 범위로 검증한다. null은 허용(첫 추천으로 취급). */
@@ -209,7 +226,7 @@ public class GoalAiService {
     }
   }
 
-  String buildRecommendPrompt(TodoRecommendationRequest req) {
+  String buildRecommendPrompt(TodoRecommendationRequest req, String tagInfo) {
     String deadlineInfo = buildDeadlineInfo(req.deadlineDate(), req.deadlineTime());
     String prompt =
         """
@@ -219,6 +236,12 @@ public class GoalAiService {
         마감기한: %s
         솔루션:
         %s
+
+        [사용 가능한 태그 목록]
+        %s
+        각 투두마다 위 목록에서 가장 적절한 태그 하나를 골라 그 태그의 id를 tagId에 넣으세요.
+        - tagId는 반드시 위 목록에 있는 id 중 하나여야 합니다. 목록에 없는 id를 지어내지 마세요.
+        - 마땅한 태그가 없거나 목록이 "없음"이면 tagId는 null로 두세요.
 
         [1단계 — 교재·강의 정보 수집, 투두 생성 전 반드시 먼저 수행]
         솔루션에 교재·강의명이 하나라도 있으면:
@@ -258,9 +281,9 @@ public class GoalAiService {
             - 링크는 Google Search로 확인된 실제 URL만 사용. 확인 불가 시 링크 생략
 
         반드시 아래 JSON만 출력하세요 (다른 설명 없이):
-        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"dueTime":null,"routineType":null,"routineDate":null}]}
+        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"dueTime":null,"routineType":null,"routineDate":null,"tagId":null}]}
         """
-            .formatted(req.goal(), deadlineInfo, buildSolutionInfo(req.solutions()));
+            .formatted(req.goal(), deadlineInfo, buildSolutionInfo(req.solutions()), tagInfo);
     return prompt + refreshStyleBlock(req.refreshCount() == null ? 0 : req.refreshCount());
   }
 
@@ -304,7 +327,14 @@ public class GoalAiService {
     return deadlineTime;
   }
 
-  private TodoRecommendationResponse parseRecommendResponse(String raw) {
+  TodoRecommendationResponse parseRecommendResponse(String raw, List<Tag> tags) {
+    // 유저의 실제 태그만 담은 (id -> 이름) 맵. AI가 준 tagId 검증·태그명 확정에 사용한다.
+    Map<Long, String> validTags = new LinkedHashMap<>();
+    if (tags != null) {
+      for (Tag tag : tags) {
+        validTags.put(tag.getId(), tag.getTitle());
+      }
+    }
     try {
       String json = extractJson(raw);
       JsonNode root = objectMapper.readTree(json);
@@ -330,7 +360,22 @@ public class GoalAiService {
             throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
           }
         }
-        todos.add(new RecommendedTodo(type, title, dueDate, dueTime, routineType, routineDate));
+        // AI가 준 tagId를 유저의 실제 태그 목록으로 검증한다.
+        // 실제 태그면 그대로 두고 이름은 DB 기준으로 확정, 아니면(지어낸 값 등) 태그 없이(null) 처리.
+        Long tagId = null;
+        String tagName = null;
+        JsonNode tagIdNode = node.path("tagId");
+        if (!tagIdNode.isNull() && !tagIdNode.isMissingNode() && tagIdNode.canConvertToLong()) {
+          Long candidate = tagIdNode.asLong();
+          if (validTags.containsKey(candidate)) {
+            tagId = candidate;
+            tagName = validTags.get(candidate);
+          }
+        }
+
+        todos.add(
+            new RecommendedTodo(
+                type, title, dueDate, dueTime, routineType, routineDate, tagId, tagName));
       }
       return new TodoRecommendationResponse(overallReason, todos);
     } catch (Exception e) {

--- a/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
+++ b/src/main/java/plana/replan/domain/tag/repository/TagRepository.java
@@ -13,6 +13,9 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
   List<Tag> findAllByUserOrderByCreatedAtDescIdDesc(User user);
 
+  @Query("SELECT t FROM Tag t WHERE t.user.id = :userId")
+  List<Tag> findAllByUserId(@Param("userId") Long userId);
+
   @Modifying
   @Query("UPDATE Tag t SET t.deletedAt = :now WHERE t.user.id = :userId AND t.deletedAt IS NULL")
   void softDeleteAllByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);

--- a/src/test/java/plana/replan/domain/goal/service/GoalAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalAiServiceTest.java
@@ -5,20 +5,39 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import plana.replan.domain.goal.dto.explore.GoalExploreRequest;
 import plana.replan.domain.goal.dto.explore.GoalExploreResponse;
 import plana.replan.domain.goal.dto.recommend.SolutionInput;
 import plana.replan.domain.goal.dto.recommend.TodoRecommendationRequest;
+import plana.replan.domain.goal.dto.recommend.TodoRecommendationResponse;
 import plana.replan.domain.goal.dto.refine.GoalRefinementRequest;
 import plana.replan.domain.goal.dto.refine.GoalRefinementResponse;
 import plana.replan.domain.goal.dto.refine.QuestionAnswer;
 import plana.replan.domain.goal.dto.refine.RefinedNoteItem;
 import plana.replan.domain.goal.exception.GoalErrorCode;
+import plana.replan.domain.tag.entity.Tag;
+import plana.replan.domain.user.entity.Provider;
+import plana.replan.domain.user.entity.Role;
+import plana.replan.domain.user.entity.User;
 import plana.replan.global.exception.CustomException;
 
 class GoalAiServiceTest {
 
-  private final GoalAiService service = new GoalAiService(null);
+  private final GoalAiService service = new GoalAiService(null, null);
+
+  private Tag tag(long id, String title) {
+    User user =
+        User.builder()
+            .email("a@a.com")
+            .nickname("n")
+            .role(Role.ROLE_USER)
+            .provider(Provider.LOCAL)
+            .build();
+    Tag t = Tag.builder().title(title).user(user).build();
+    ReflectionTestUtils.setField(t, "id", id);
+    return t;
+  }
 
   private TodoRecommendationRequest req(Integer refreshCount) {
     return new TodoRecommendationRequest(
@@ -70,7 +89,7 @@ class GoalAiServiceTest {
 
   @Test
   void 새로고침_횟수가_3을_넘으면_추천_실패() {
-    assertThatThrownBy(() -> service.recommendTodos(req(4)))
+    assertThatThrownBy(() -> service.recommendTodos(1L, req(4)))
         .isInstanceOfSatisfying(
             CustomException.class,
             e -> assertThat(e.getErrorCode()).isEqualTo(GoalErrorCode.INVALID_REFRESH_COUNT));
@@ -78,7 +97,7 @@ class GoalAiServiceTest {
 
   @Test
   void 새로고침_횟수가_음수면_추천_실패() {
-    assertThatThrownBy(() -> service.recommendTodos(req(-1)))
+    assertThatThrownBy(() -> service.recommendTodos(1L, req(-1)))
         .isInstanceOfSatisfying(
             CustomException.class,
             e -> assertThat(e.getErrorCode()).isEqualTo(GoalErrorCode.INVALID_REFRESH_COUNT));
@@ -86,19 +105,19 @@ class GoalAiServiceTest {
 
   @Test
   void 새로고침_0회차면_스타일_블록이_없다() {
-    String prompt = service.buildRecommendPrompt(req(0));
+    String prompt = service.buildRecommendPrompt(req(0), "없음");
     assertThat(prompt).doesNotContain("[이번 새로고침 스타일]");
   }
 
   @Test
   void 새로고침_생략_null이면_0회차처럼_스타일_블록이_없다() {
-    String prompt = service.buildRecommendPrompt(req(null));
+    String prompt = service.buildRecommendPrompt(req(null), "없음");
     assertThat(prompt).doesNotContain("[이번 새로고침 스타일]");
   }
 
   @Test
   void 새로고침_2회차면_벼락치기_스타일_블록이_붙는다() {
-    String prompt = service.buildRecommendPrompt(req(2));
+    String prompt = service.buildRecommendPrompt(req(2), "없음");
     assertThat(prompt).contains("[이번 새로고침 스타일]");
     assertThat(prompt).contains("벼락치기");
     assertThat(prompt).contains("todos"); // 기존 JSON 포맷 규칙 유지
@@ -106,9 +125,63 @@ class GoalAiServiceTest {
 
   @Test
   void 추천_프롬프트에_솔루션이_들어간다() {
-    String prompt = service.buildRecommendPrompt(req(0));
+    String prompt = service.buildRecommendPrompt(req(0), "없음");
     assertThat(prompt).contains("[현재 수준]");
     assertThat(prompt).contains("실력: 토익 600점");
+  }
+
+  @Test
+  void 추천_프롬프트에_태그_목록이_들어간다() {
+    String prompt =
+        service.buildRecommendPrompt(req(0), "- id=1, name=Study\n- id=2, name=Health\n");
+    assertThat(prompt).contains("[사용 가능한 태그 목록]");
+    assertThat(prompt).contains("id=1, name=Study");
+    assertThat(prompt).contains("id=2, name=Health");
+    assertThat(prompt).contains("tagId"); // 출력 JSON 스키마에 tagId 포함
+  }
+
+  @Test
+  void 태그정보_문자열_생성_태그가_없으면_없음() {
+    assertThat(service.buildTagInfo(List.of())).isEqualTo("없음");
+  }
+
+  @Test
+  void 태그정보_문자열_생성_id와_이름이_들어간다() {
+    String info = service.buildTagInfo(List.of(tag(1L, "Study"), tag(2L, "Health")));
+    assertThat(info).contains("id=1, name=Study");
+    assertThat(info).contains("id=2, name=Health");
+  }
+
+  @Test
+  void 추천파싱_AI가_준_tagId가_유저태그면_tagId와_이름을_채운다() {
+    String raw =
+        "{\"overallReason\":\"r\",\"todos\":[{\"type\":\"ONE_TIME\",\"title\":\"단어 암기\","
+            + "\"dueDate\":null,\"dueTime\":null,\"routineType\":null,\"routineDate\":null,\"tagId\":1}]}";
+    TodoRecommendationResponse res =
+        service.parseRecommendResponse(raw, List.of(tag(1L, "Study"), tag(2L, "Health")));
+    assertThat(res.todos()).hasSize(1);
+    assertThat(res.todos().get(0).tagId()).isEqualTo(1L);
+    assertThat(res.todos().get(0).tagName()).isEqualTo("Study");
+  }
+
+  @Test
+  void 추천파싱_AI가_지어낸_tagId면_태그없음으로_처리한다() {
+    String raw =
+        "{\"overallReason\":\"r\",\"todos\":[{\"type\":\"ONE_TIME\",\"title\":\"단어 암기\","
+            + "\"dueDate\":null,\"dueTime\":null,\"routineType\":null,\"routineDate\":null,\"tagId\":999}]}";
+    TodoRecommendationResponse res = service.parseRecommendResponse(raw, List.of(tag(1L, "Study")));
+    assertThat(res.todos().get(0).tagId()).isNull();
+    assertThat(res.todos().get(0).tagName()).isNull();
+  }
+
+  @Test
+  void 추천파싱_tagId가_null이면_태그없음() {
+    String raw =
+        "{\"overallReason\":\"r\",\"todos\":[{\"type\":\"ONE_TIME\",\"title\":\"단어 암기\","
+            + "\"dueDate\":null,\"dueTime\":null,\"routineType\":null,\"routineDate\":null,\"tagId\":null}]}";
+    TodoRecommendationResponse res = service.parseRecommendResponse(raw, List.of(tag(1L, "Study")));
+    assertThat(res.todos().get(0).tagId()).isNull();
+    assertThat(res.todos().get(0).tagName()).isNull();
   }
 
   private GoalRefinementRequest refineReq() {

--- a/src/test/java/plana/replan/domain/goal/service/GoalAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/goal/service/GoalAiServiceTest.java
@@ -165,6 +165,16 @@ class GoalAiServiceTest {
   }
 
   @Test
+  void 추천파싱_tagId가_문자열_숫자여도_유저태그면_채운다() {
+    String raw =
+        "{\"overallReason\":\"r\",\"todos\":[{\"type\":\"ONE_TIME\",\"title\":\"단어 암기\","
+            + "\"dueDate\":null,\"dueTime\":null,\"routineType\":null,\"routineDate\":null,\"tagId\":\"1\"}]}";
+    TodoRecommendationResponse res = service.parseRecommendResponse(raw, List.of(tag(1L, "Study")));
+    assertThat(res.todos().get(0).tagId()).isEqualTo(1L);
+    assertThat(res.todos().get(0).tagName()).isEqualTo("Study");
+  }
+
+  @Test
   void 추천파싱_AI가_지어낸_tagId면_태그없음으로_처리한다() {
     String raw =
         "{\"overallReason\":\"r\",\"todos\":[{\"type\":\"ONE_TIME\",\"title\":\"단어 암기\","


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가

## Related Issues
close #239

## 변경 사항
프론트에서 AI 투두 추천(`POST /api/goals/ai/todo-recommendations`) 결과에 각 투두의 태그(카테고리)를 함께 달아달라고 요청했습니다. 우리 시스템에서 '카테고리'는 사실상 **태그**로 구현돼 있어(가입 시 Study/Project/Health/Other 기본 태그 생성), 추천이 태그를 골라 주도록 바꿨습니다.

- 추천 요청이 오면 서버가 **그 유저의 태그 목록을 DB에서 조회**해 AI 프롬프트에 넣습니다.
- AI는 각 추천 투두마다 그 목록 중 **가장 적절한 태그 하나(tagId)** 를 고르고, 마땅치 않으면 고르지 않습니다(null).
- 서버는 AI가 준 tagId가 **실제로 그 유저의 태그인지 검증**합니다. 유효하면 tagId와 태그명(DB 기준으로 확정)을 채우고, 지어낸 값이면 **태그 없이(null)** 안전하게 처리합니다. 그래서 이 tagId를 그대로 저장(`/with-todos`)에 써도 `TAG_NOT_FOUND`가 나지 않습니다. (숫자를 문자열 `"1"`로 주는 경우도 인식합니다.)
- 추천 응답의 각 투두에 **`tagId`·`tagName`** 을 추가했습니다. (기존 필드는 그대로)
- Swagger 문서(`GoalControllerDocs` 응답 표·예시)와 DTO 스키마를 함께 갱신했습니다.

## 테스트 결과
- 유닛테스트 추가: 프롬프트에 태그 목록 주입 / 유효한 tagId → 이름까지 채움 / 문자열 숫자("1") → 채움 / 지어낸 tagId(999) → null / tagId=null → null. `./gradlew build`(JDK17, Spotless 포함) 통과.
- 로컬 API 전수 테스트(테스트 계정, 기본 태그 Study=5·Project=6·Health=7·Other=8):
  - 토익(공부) 목표 → 대부분 `tagId=5, "Study"`, 컨디션 조절 투두는 `tagId=7, "Health"`
  - 감량·러닝(운동) 목표 → 전부 `tagId=7, "Health"`
  - 반환된 tagId가 모두 유저의 실제 태그 범위(5~8) 안에서만 나오고 태그명도 DB와 일치함을 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI 추천 할 일에 사용자별 태그 정보가 반영되어, 추천 결과에 태그 ID와 태그 이름이 함께 표시됩니다.
  * 추천 요청 처리 시 로그인한 사용자 기준으로 개인 태그 목록을 활용합니다.

* **Documentation**
  * AI 할 일 추천 API 문서에 태그 관련 응답 필드와 예시가 추가되었습니다.

* **Tests**
  * 추천 응답의 태그 매칭, null 처리, 문자열/숫자 ID 처리에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->