### PR TITLE
Feat: 매월 반복 루틴에서 여러 날짜 선택 지원

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -243,7 +243,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
           | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
           | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
-          | todos[].routineDate | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자(1~31), DAILY: null | `null` |
+          | todos[].routineDate | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자 bitmask (여러 날 합산), DAILY: null | `null` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
           | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |
@@ -1028,7 +1028,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | string | 마감 날짜 (yyyy-MM-dd 형식). 없으면 null |
           | todos[].dueTime | string | 마감 시간 (HH:mm 형식). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
-          | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자. DAILY·ONE_TIME: null |
+          | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자 bitmask. DAILY·ONE_TIME: null |
           | todos[].tagId | integer | AI가 이 투두에 배정한 태그 ID. 요청한 유저의 실제 태그 중에서 선택됨. 마땅한 태그가 없으면 null |
           | todos[].tagName | string | 배정된 태그 이름. tagId가 null이면 함께 null |
 

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -22,7 +22,7 @@ public record TodoItemRequest(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. RECURRING만 사용. ONE_TIME이면 null. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자(1~31). DAILY: null.",
+                "반복 날짜. RECURRING만 사용. ONE_TIME이면 null. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: null.",
             example = "null")
         Integer routineDate,
     @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -25,7 +25,7 @@ public record RecommendedTodo(
         String routineType,
     @Schema(
             description =
-                "반복 날짜 (RECURRING만 사용). WEEKLY: 요일 bitmask (월=1,화=2,수=4,목=8,금=16,토=32,일=64). MONTHLY: 일자(1~31). DAILY: null.",
+                "반복 날짜 (RECURRING만 사용). WEEKLY: 요일 bitmask (월=1,화=2,수=4,목=8,금=16,토=32,일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: null.",
             example = "62",
             nullable = true)
         Integer routineDate,

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -268,7 +268,7 @@ public class GoalAiService {
         8. 이론 나열 금지. '수기 복습', '문제 풀이', '오답 노트' 등 아웃풋 태스크 반드시 중간에 배치
         9. 마감 D-1~2는 진도 금지. '최종 점검', '백지 복습' 등 마무리 태스크만 배치
         10. WEEKLY routineDate는 bitmask: 월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64
-        11. MONTHLY routineDate는 일자(1~31)
+        11. MONTHLY routineDate는 일자 비트마스크(1일=1, 2일=2, 3일=4 … d일=2^(d-1)). 여러 날짜면 각 비트를 더한다(예: 3일·20일 = 4 + 524288 = 524292)
         12. DAILY는 routineDate 불필요 (null)
         13. dueDate는 yyyy-MM-dd 형식 또는 null, dueTime은 HH:mm 형식 또는 null
         14. type은 "ONE_TIME" 또는 "RECURRING"만 허용

--- a/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
+++ b/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
@@ -20,7 +20,7 @@ public record ReplanOperation(
             example = "WEEKLY")
         String routineType,
     @Schema(
-            description = "반복 날짜(WEEKLY=요일 bitmask, MONTHLY=일자). 없으면 null",
+            description = "반복 날짜(WEEKLY=요일 bitmask, MONTHLY=일자 bitmask). 없으면 null",
             nullable = true,
             example = "62")
         Integer routineDate,

--- a/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
@@ -103,7 +103,7 @@ public class ReplanAiService {
            - MODIFY_TODO의 targetTodoId에는 위 '대상 투두 ID'를, 다른 기존 투두 수정(우선순위 등)은 아래 '선택 투두' 목록의 실제 ID만 사용. ID를 임의로 만들지 않는다.
         5. changedFields: 수정(MODIFY_TODO/MODIFY_ROUTINE)에서 바뀐 필드만 {field, before, after}로 채운다. field는 title/dueTime/tag/routineType.
            새로 만드는 ADD·CREATE_ROUTINE은 changedFields를 빈 배열([])로 둔다.
-        6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null, routineDate는 정수 또는 null.
+        6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDate는 비트마스크 정수 또는 null (DAILY는 null / WEEKLY는 요일 비트마스크: 월1·화2·수4·목8·금16·토32·일64를 합 / MONTHLY는 일자 비트마스크: d일=2^(d-1)을 합, 예 15일=16384, 3일과 20일=4+524288=524292). 절대 달력 날짜(예: 15)를 그대로 쓰지 말 것.
            - CREATE_ROUTINE의 dueDate는 '반복을 끝낼 종료일'을 뜻한다(이 날짜 이후로는 회차를 만들지 않음). 무기한 반복이면 null로 둔다. 새 루틴의 반복 시각은 dueTime으로 지정한다.
 
         반드시 아래 JSON만 출력 (다른 설명 없이):

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -472,7 +472,7 @@ public class ReplanService {
         op.tagId() != null ? resolveTag(op.tagId(), anchor.getUser().getId()) : routine.getTag();
     RoutineType effectiveType =
         op.routineType() != null ? parseRoutineType(op.routineType()) : routine.getRoutineType();
-    // 반복 유형이 바뀌면 기존 routineDate는 의미가 달라(WEEKLY=요일 비트마스크 ↔ MONTHLY=일자)
+    // 반복 유형이 바뀌면 기존 routineDate는 의미가 달라(WEEKLY=요일 비트마스크 ↔ MONTHLY=일자 비트마스크)
     // 재사용하지 않고, 새 유형에 맞는 routineDate를 op가 명시하도록 강제한다(없으면 아래 검증에서 400).
     // 유형이 그대로면 생략된 routineDate를 기존 값으로 보완한다.
     boolean typeChanged = op.routineType() != null && effectiveType != routine.getRoutineType();
@@ -571,8 +571,8 @@ public class ReplanService {
         && (routineDate == null || routineDate < 1 || routineDate > 127)) {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
-    if (type == RoutineType.MONTHLY
-        && (routineDate == null || routineDate < 1 || routineDate > 31)) {
+    // MONTHLY도 일자 비트마스크(일자 d → 비트 d-1). 양의 정수면 유효(1~31일이 비트 0~30에 대응).
+    if (type == RoutineType.MONTHLY && (routineDate == null || routineDate < 1)) {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
   }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -74,7 +74,7 @@ public interface RoutineControllerDocs {
           | dueDate | string | 반복 종료 마감일 (ISO 8601 형식). 없으면 null |
           | routineTime | string | 마감 시각 (HH:mm:ss 형식). 없으면 null |
           | routineType | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) |
-          | routineDate | integer | 반복 날짜 설정값. DAILY는 null, WEEKLY는 요일 비트마스크, MONTHLY는 일자 |
+          | routineDate | integer | 반복 날짜 설정값. DAILY는 null, WEEKLY는 요일 비트마스크, MONTHLY는 일자 비트마스크 |
           | tagId | integer | 태그 ID. 없으면 null |
           | tagTitle | string | 태그 제목. 없으면 null |
           | tagColor | string | 태그 색상. 없으면 null |
@@ -254,7 +254,7 @@ public interface RoutineControllerDocs {
           | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
           | dueDate | ❌ 선택 | string | 반복 종료 마감일 (ISO 8601 형식). 이 날짜 이후로는 반복 생성 안 됨 | `"2025-12-31T00:00:00"` |
           | routineTime | ❌ 선택 | string | 반복되는 날의 마감 시각 (HH:mm:ss 형식). 생략 시 23:59:59 | `"09:00:00"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요 | `21` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요 | `21` |
           | tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | goalId | ❌ 선택 | integer | 목표 ID | `2` |
 
@@ -268,7 +268,7 @@ public interface RoutineControllerDocs {
           |-------------|-----------------|-----------|
           | `DAILY` | 사용 안 함 (무시) | — |
           | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
-          | `MONTHLY` | 반복할 일자 | 1 ~ 31 |
+          | `MONTHLY` | 반복할 일자 비트마스크 (여러 날 합산) | 1일=1, 2일=2, 3일=4 … |
 
           **WEEKLY 예시**: 월+수+금 → 1+4+16 = **21**
 
@@ -658,7 +658,7 @@ public interface RoutineControllerDocs {
           | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
           | dueDate | ❌ 선택 | string | 반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거 | `"2025-12-31T00:00:00"` |
           | routineTime | ❌ 선택 | string | 반복되는 날의 마감 시각 (HH:mm:ss 형식). null이면 23:59:59로 처리 | `"09:00:00"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1~일=64). MONTHLY: 일자 (1~31). DAILY: 불필요 | `21` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1~일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요 | `21` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `1` |
 
           > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
@@ -671,7 +671,7 @@ public interface RoutineControllerDocs {
           |-------------|-----------------|-----------|
           | `DAILY` | 사용 안 함 (무시) | — |
           | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
-          | `MONTHLY` | 반복할 일자 | 1 ~ 31 |
+          | `MONTHLY` | 반복할 일자 비트마스크 (여러 날 합산) | 1일=1, 2일=2, 3일=4 … |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -35,7 +35,7 @@ public interface RoutineControllerDocs {
 
           - `DAILY` 루틴: 기간 내 모든 날짜에 포함
           - `WEEKLY` 루틴: 해당 날짜의 요일이 `routineDate` 비트마스크에 포함된 날짜에만 포함
-          - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDate`와 일치하는 날짜에만 포함
+          - `MONTHLY` 루틴: 해당 날짜의 일(day) 비트가 `routineDate` 비트마스크에 포함된 날짜에만 포함
 
           각 루틴에 해당 날짜의 Todo가 이미 생성되어 있으면 `todoId`가 포함되고, 아직 없으면 `null`입니다.
 
@@ -453,14 +453,14 @@ public interface RoutineControllerDocs {
                                 }
                                 """),
                         @ExampleObject(
-                            name = "MONTHLY — 매월 15일",
+                            name = "MONTHLY — 매월 15일 (15일=1<<14=16384)",
                             value =
                                 """
                                 {
                                   "title": "월간 회고",
                                   "dueDate": "2025-12-31T00:00:00",
                                   "routineType": "MONTHLY",
-                                  "routineDate": 15
+                                  "routineDate": 16384
                                 }
                                 """)
                       }))

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
@@ -31,7 +31,7 @@ public record RoutineCreateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요.",
+                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요.",
             example = "21")
         Integer routineDate,
     @Schema(description = "태그 ID", example = "1") Long tagId,

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -33,7 +33,7 @@ public class RoutineResponseDto {
   @Schema(description = "반복 유형", example = "DAILY")
   private RoutineType routineType;
 
-  @Schema(description = "반복 날짜 설정값. DAILY=null, WEEKLY=요일 비트마스크, MONTHLY=일자", example = "21")
+  @Schema(description = "반복 날짜 설정값. DAILY=null, WEEKLY=요일 비트마스크, MONTHLY=일자 비트마스크", example = "21")
   private Integer routineDate;
 
   @Schema(description = "태그 ID (override 적용값). 없으면 null", example = "3")

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
@@ -29,7 +29,7 @@ public record RoutineUpdateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 (1~31). DAILY: 불필요.",
+                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요.",
             example = "21")
         Integer routineDate,
     @Schema(description = "태그 ID. null이면 태그 제거", example = "1") Long tagId) {}

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -65,12 +65,12 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
             AND (
               r.routine_type = 'DAILY'
               OR (r.routine_type = 'WEEKLY'  AND (r.routine_date & :dayBit) != 0)
-              OR (r.routine_type = 'MONTHLY' AND  r.routine_date = :dayOfMonth)
+              OR (r.routine_type = 'MONTHLY' AND (r.routine_date & :monthDayBit) != 0)
             )
           """)
   List<RoutineDateProjection> findMotherRoutinesByDate(
       @Param("userId") Long userId,
       @Param("dayBit") int dayBit,
-      @Param("dayOfMonth") int dayOfMonth,
+      @Param("monthDayBit") int monthDayBit,
       @Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -211,8 +211,8 @@ public class RoutineService {
 
   private List<RoutineResponseDto> getRoutinesForDate(Long userId, LocalDate date) {
     int dayBit = 1 << (date.getDayOfWeek().getValue() - 1);
-    int dayOfMonth = date.getDayOfMonth();
-    return routineRepository.findMotherRoutinesByDate(userId, dayBit, dayOfMonth, date).stream()
+    int monthDayBit = 1 << (date.getDayOfMonth() - 1);
+    return routineRepository.findMotherRoutinesByDate(userId, dayBit, monthDayBit, date).stream()
         .map(RoutineResponseDto::from)
         .collect(Collectors.toList());
   }
@@ -307,7 +307,7 @@ public class RoutineService {
     return switch (routine.getRoutineType()) {
       case DAILY -> true;
       case WEEKLY -> (routine.getRoutineDate() & (1 << (today.getDayOfWeek().getValue() - 1))) != 0;
-      case MONTHLY -> routine.getRoutineDate().equals(today.getDayOfMonth());
+      case MONTHLY -> (routine.getRoutineDate() & (1 << (today.getDayOfMonth() - 1))) != 0;
     };
   }
 
@@ -423,14 +423,13 @@ public class RoutineService {
         yield today;
       }
       case MONTHLY -> {
-        int day = routine.getRoutineDate();
-        for (int k = 0; k < 12; k++) {
-          LocalDate firstOfMonth = today.withDayOfMonth(1).plusMonths(k);
-          if (firstOfMonth.lengthOfMonth() >= day) {
-            LocalDate candidate = firstOfMonth.withDayOfMonth(day);
-            if (!candidate.isBefore(today)) {
-              yield candidate;
-            }
+        // routineDate는 일자 비트마스크(일자 d → 비트 d-1). 오늘부터 하루씩 훑어
+        // 그 날짜의 일자 비트가 켜진 첫 날을 다음 회차로 잡는다. 짧은 달에 없는 일자(29~31)는 자연히 건너뛴다.
+        int mask = routine.getRoutineDate();
+        for (int i = 0; i < 366; i++) {
+          LocalDate d = today.plusDays(i);
+          if ((mask & (1 << (d.getDayOfMonth() - 1))) != 0) {
+            yield d;
           }
         }
         yield today;
@@ -444,7 +443,9 @@ public class RoutineService {
         throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
       }
     } else if (routineType == RoutineType.MONTHLY) {
-      if (routineDate == null || routineDate < 1 || routineDate > 31) {
+      // 일자 비트마스크(일자 d → 비트 d-1). 1~31일이 비트 0~30에 대응하며 최대값은 int 범위(2^31-1)에 들어간다.
+      // 양의 정수면 비트 31(부호비트)은 켜질 수 없으므로 1 이상만 검증한다.
+      if (routineDate == null || routineDate < 1) {
         throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
       }
     }

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -729,7 +729,7 @@ public interface TodoControllerDocs {
           | dueDate | ❌ 선택 | string | 마감 일시 (ISO 8601 형식). null이면 마감일 제거 | `"2025-12-31T23:59:59"` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `3` |
           | routineType | ❌ 선택 | string | 반복 유형 (`DAILY`/`WEEKLY`/`MONTHLY`). **이미 반복에 연결된 투두에는 무시됨** | `"WEEKLY"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
+          | routineDate | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
           | routineTime | ❌ 선택 | string | 반복 마감 시각 (HH:mm:ss). **이미 반복에 연결된 투두에는 무시됨** | `"09:00:00"` |
 
           ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
@@ -934,7 +934,7 @@ public interface TodoControllerDocs {
 
           **반환 필드**
           - `routineType`: 루틴에 연결된 투두인 경우 `DAILY` / `WEEKLY` / `MONTHLY`, 일반 투두는 `null`
-          - `routineDate`: WEEKLY이면 요일 비트마스크(1-127), MONTHLY이면 일자(1-31), DAILY 또는 루틴 없으면 `null`
+          - `routineDate`: WEEKLY이면 요일 비트마스크(1-127), MONTHLY이면 일자 비트마스크, DAILY 또는 루틴 없으면 `null`
           - `tagId`, `tagTitle`, `tagColor`: 태그가 없으면 모두 `null`
           - `subTodos`: 하위 투두 목록 (없으면 빈 배열)
           """,

--- a/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
@@ -41,7 +41,7 @@ public class TodoDetailResponseDto {
   private String routineType;
 
   @Schema(
-      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31 일자, DAILY 또는 반복 없으면 null)",
+      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크, DAILY 또는 반복 없으면 null)",
       example = "5")
   private Integer routineDate;
 

--- a/src/main/java/plana/replan/domain/todo/dto/TodoUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoUpdateRequestDto.java
@@ -24,7 +24,9 @@ public class TodoUpdateRequestDto {
   @Schema(description = "반복 유형 (DAILY/WEEKLY/MONTHLY). null이면 반복 없음")
   private RoutineType routineType;
 
-  @Schema(description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 1-31). DAILY는 null", example = "5")
+  @Schema(
+      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크). DAILY는 null",
+      example = "5")
   private Integer routineDate;
 
   @Schema(description = "반복 시각 (HH:mm:ss). 반복되는 날의 마감 시각. 생략 시 23:59:59로 처리", example = "09:00:00")

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -313,7 +313,7 @@ public class TodoService {
         throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
       }
     } else if (routineType == RoutineType.MONTHLY) {
-      if (routineDate == null || routineDate < 1 || routineDate > 31) {
+      if (routineDate == null || routineDate < 1) {
         throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
       }
     }

--- a/src/main/resources/db/migration/V19__convert_monthly_routine_date_to_bitmask.sql
+++ b/src/main/resources/db/migration/V19__convert_monthly_routine_date_to_bitmask.sql
@@ -1,0 +1,9 @@
+-- 매월(MONTHLY) 반복 루틴을 '일자 하나(1~31)'에서 '일자 비트마스크'로 바꾼다.
+-- 이제 여러 날짜를 한 루틴에 담을 수 있고, 규칙은 WEEKLY(요일 비트마스크)와 동일하다.
+-- 기존에 저장된 값은 '일자 d'였으므로 비트 (d-1)만 켠 값 (1 << (d-1)) 으로 1회 변환한다.
+-- 예) 15일 -> 1 << 14 = 16384,  3일 -> 1 << 2 = 4.
+-- 기존 값은 항상 1~31 범위였으므로 최대 1 << 30 = 1073741824 로 int 범위 안에 들어간다.
+UPDATE routine
+SET routine_date = (1 << (routine_date - 1))
+WHERE routine_type = 'MONTHLY'
+  AND routine_date BETWEEN 1 AND 31;

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -1111,7 +1111,7 @@ class ReplanServiceTest {
   }
 
   @Test
-  void CREATE_ROUTINE_먼슬리인데_날짜범위밖이면_400() {
+  void CREATE_ROUTINE_먼슬리인데_routineDate가_1미만이면_400() {
     Todo todo = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
@@ -1125,7 +1125,7 @@ class ReplanServiceTest {
             null,
             null,
             "MONTHLY",
-            40, // 31 초과 — 유효하지 않음
+            0, // 비트마스크는 1 이상만 유효 (0은 아무 날도 안 켜진 값)
             List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -303,20 +303,23 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
+    // routineDate는 일자 비트마스크. 15일 = 1 << 14 = 16384 (숫자 15가 아님)
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
-            new RoutineCreateRequestDto("월간 회고", null, null, RoutineType.MONTHLY, 15, null, null));
+            new RoutineCreateRequestDto(
+                "월간 회고", null, null, RoutineType.MONTHLY, 1 << 14, null, null));
 
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.MONTHLY);
-    assertThat(result.getRoutineDate()).isEqualTo(15);
+    assertThat(result.getRoutineDate()).isEqualTo(16384);
   }
 
   @Test
-  void 루틴_생성_MONTHLY_routineDate_경계값_1_성공() {
+  void 루틴_생성_MONTHLY_비트마스크_최솟값_1일_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
+    // 1일 = 1 << 0 = 1 (비트마스크 최솟값)
     RoutineResponseDto result =
         routineService.createRoutine(
             1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1, null, null));
@@ -325,15 +328,18 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_MONTHLY_routineDate_경계값_31_성공() {
+  void 루틴_생성_MONTHLY_비트마스크_31일_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
+    // 31일 = 1 << 30 = 1073741824 (숫자 31이 아님)
     RoutineResponseDto result =
         routineService.createRoutine(
-            1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 31, null, null));
+            1L,
+            new RoutineCreateRequestDto(
+                "루틴", null, null, RoutineType.MONTHLY, 1 << 30, null, null));
 
-    assertThat(result.getRoutineDate()).isEqualTo(31);
+    assertThat(result.getRoutineDate()).isEqualTo(1073741824);
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -371,7 +371,22 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_MONTHLY_routineDate_32이면_400() {
+  void 루틴_생성_MONTHLY_여러_날짜_비트마스크_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // 3일·20일 = 비트(2) + 비트(19) = 4 + 524288 = 524292
+    int mask = (1 << 2) | (1 << 19);
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L,
+            new RoutineCreateRequestDto("월 2회", null, null, RoutineType.MONTHLY, mask, null, null));
+
+    assertThat(result.getRoutineDate()).isEqualTo(524292);
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_routineDate_음수면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -379,7 +394,7 @@ class RoutineServiceTest {
                 routineService.createRoutine(
                     1L,
                     new RoutineCreateRequestDto(
-                        "루틴", null, null, RoutineType.MONTHLY, 32, null, null)))
+                        "루틴", null, null, RoutineType.MONTHLY, -1, null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -484,12 +499,13 @@ class RoutineServiceTest {
 
   @Test
   void 루틴_생성_MONTHLY_오늘_날짜_불일치여도_Todo_즉시_생성되고_다음_반복일이_dueDate() {
-    // TEST_DATE = 2024-01-15. routineDate=16 → 다음 발생 = 2024-01-16
+    // TEST_DATE = 2024-01-15. routineDate=16일 비트(1<<15=32768) → 다음 발생 = 2024-01-16
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
-        1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 16, null, null));
+        1L,
+        new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1 << 15, null, null));
 
     ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
     verify(todoRepository).saveAndFlush(captor.capture());
@@ -573,8 +589,22 @@ class RoutineServiceTest {
 
   @Test
   void generateDailyTodos_MONTHLY_오늘이_해당일_투두_생성됨() {
-    // 오늘=15일, MONTHLY(15일) → isOccurrenceDay = true → 오늘 투두 생성
-    Routine routine = buildRoutine(RoutineType.MONTHLY, 15);
+    // 오늘=15일, MONTHLY(15일 비트=1<<14) → isOccurrenceDay = true → 오늘 투두 생성
+    Routine routine = buildRoutine(RoutineType.MONTHLY, 1 << 14);
+    given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
+
+    routineService.generateDailyTodos();
+
+    ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
+    verify(todoRepository).saveAndFlush(captor.capture());
+    assertThat(captor.getValue().getDueDate())
+        .isEqualTo(LocalDate.of(2024, 1, 15).atTime(23, 59, 59));
+  }
+
+  @Test
+  void generateDailyTodos_MONTHLY_여러_날짜_중_오늘이_포함되면_생성됨() {
+    // 오늘=15일. MONTHLY(15일·20일 비트마스크) → isOccurrenceDay = true → 오늘 투두 생성
+    Routine routine = buildRoutine(RoutineType.MONTHLY, (1 << 14) | (1 << 19));
     given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
 
     routineService.generateDailyTodos();
@@ -587,8 +617,8 @@ class RoutineServiceTest {
 
   @Test
   void generateDailyTodos_MONTHLY_오늘이_해당일_아님_생성_안됨() {
-    // 오늘=15일, MONTHLY(16일) → isOccurrenceDay = false
-    Routine routine = buildRoutine(RoutineType.MONTHLY, 16);
+    // 오늘=15일, MONTHLY(16일 비트=1<<15) → isOccurrenceDay = false
+    Routine routine = buildRoutine(RoutineType.MONTHLY, 1 << 15);
     given(routineRepository.findAllActiveMotherRoutines()).willReturn(List.of(routine));
 
     routineService.generateDailyTodos();

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -487,12 +487,13 @@ class RoutineServiceTest {
 
   @Test
   void 루틴_생성_MONTHLY_오늘_날짜_일치_Todo_생성됨() {
-    // TEST_DATE = 15일. routineDate=15 → 일치
+    // TEST_DATE = 15일. routineDate=15일 비트(1<<14=16384) → 일치
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
-        1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 15, null, null));
+        1L,
+        new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1 << 14, null, null));
 
     verify(todoRepository).saveAndFlush(any(Todo.class));
   }

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1580,6 +1580,22 @@ class TodoServiceTest {
   }
 
   @Test
+  @DisplayName("updateTodo - MONTHLY + 여러 날짜 비트마스크(524292): 루틴 생성 성공")
+  void updateTodo_monthlyBitmask_success() {
+    User user = testUser();
+    given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo(1L, user)));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // 3일·20일 = (1<<2)|(1<<19) = 524292 → 31 초과지만 유효한 비트마스크
+    todoService.updateTodo(
+        1L, 1L, updateTodoRequest("제목", null, null, RoutineType.MONTHLY, 524292));
+
+    ArgumentCaptor<Routine> captor = ArgumentCaptor.forClass(Routine.class);
+    verify(routineRepository).save(captor.capture());
+    assertThat(captor.getValue().getRoutineDate()).isEqualTo(524292);
+  }
+
+  @Test
   @DisplayName("updateTodo - WEEKLY + routineDate null: ROUTINE_INVALID_DATE 예외")
   void updateTodo_weeklyNullDate_throws() {
     User user = testUser();


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가

## Related Issues
close #242

## 변경 사항
매월(MONTHLY) 반복 루틴은 지금까지 한 달에 **하루만** 지정할 수 있었습니다(`routineDate`가 단일 일자). 프론트에서 '매월 3일·20일'처럼 **여러 날짜**를 지정하고 싶어 해서, 매주(WEEKLY)가 요일을 비트마스크로 담던 방식과 **똑같이 MONTHLY도 일자 비트마스크로** 확장했습니다.

- 일자 d → 비트 (d-1). 기존 `routine_date` 컬럼 그대로 재사용(DB 구조 변경 없음).
- 발생일 판정 / 다음 발생일 / 날짜별 조회 쿼리 / 검증(루틴·리플랜·투두 3경로) / AI 프롬프트(추천·리플랜) / Swagger 문서를 비트마스크로 변경.
- 기존 MONTHLY 데이터를 비트마스크로 1회 변환하는 마이그레이션(`V19`) 추가.

## 주의 (호환성)
프론트도 이제 MONTHLY를 **비트마스크로 주고받아야** 하며 기존(단일 일자) 방식과 **호환이 깨집니다**. 예: 매월 15일 = `16384`, 3일·20일 = `524292`.

## 테스트 결과
- 유닛테스트 추가·수정, `./gradlew build`(JDK17, Spotless) 통과.
- 로컬 API: '매월 3일·20일'(`524292`) 루틴 → 2026-07 월간 조회에서 **정확히 07-03·07-20에만** 표시 확인. 마이그레이션 V19 로컬 적용 성공.

## 코드리뷰(Codex, PR 전) 반영
- 투두→루틴 전환(`TodoService`) MONTHLY 검증 상한 제거(놓쳤던 3번째 검증).
- 문서 '매월 15일' 예시를 비트마스크 값(16384)으로 수정.
- 리플랜 AI 프롬프트에 MONTHLY 비트마스크 규칙 명시(AI가 달력 날짜 15를 그대로 내던 문제 방지).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 월간 반복 일정이 여러 날짜를 비트마스크 방식으로 지정할 수 있게 바뀌었습니다.
  * 루틴 생성·수정·조회 및 투두 관련 화면/응답 안내 문구가 새 형식에 맞게 업데이트되었습니다.

* **Bug Fixes**
  * 월간 반복 일정의 다음 발생일 계산이 짧은 달까지 올바르게 처리되도록 개선되었습니다.
  * 월간 반복 값 검증 범위가 실제 사용 방식에 맞게 완화되었습니다.

* **Chores**
  * 기존 월간 반복 데이터가 새 형식으로 일괄 변환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->