### PR TITLE
v0.22.0

### DIFF
--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -243,7 +243,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
           | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
           | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
-          | todos[].routineDays | ❌ 선택 | array | 반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0 … 일=6), MONTHLY: 일자(1~31), DAILY: null 또는 빈 배열([]) | `[0, 2, 4]` |
+          | todos[].routineDays | ❌ 선택 | array | 반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0 … 일=6), MONTHLY: 일자(1~31), DAILY: null 또는 빈 배열([]) — 값이 있으면 400 | `[0, 2, 4]` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
           | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -243,7 +243,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
           | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
           | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
-          | todos[].routineDate | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자 bitmask (여러 날 합산), DAILY: null | `null` |
+          | todos[].routineDays | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자 bitmask (여러 날 합산), DAILY: null | `null` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
           | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |
@@ -388,7 +388,7 @@ public interface GoalControllerDocs {
                                       "dueDate": "2025-06-01",
                                       "dueTime": "09:00",
                                       "routineType": null,
-                                      "routineDate": null,
+                                      "routineDays": null,
                                       "tagId": 1,
                                       "subTodos": ["챕터 1", "챕터 2"]
                                     },
@@ -398,7 +398,7 @@ public interface GoalControllerDocs {
                                       "dueDate": null,
                                       "dueTime": null,
                                       "routineType": "DAILY",
-                                      "routineDate": null,
+                                      "routineDays": null,
                                       "tagId": null,
                                       "subTodos": [],
                                       "subRoutines": ["받아쓰기", "쉐도잉"]
@@ -1028,7 +1028,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | string | 마감 날짜 (yyyy-MM-dd 형식). 없으면 null |
           | todos[].dueTime | string | 마감 시간 (HH:mm 형식). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
-          | todos[].routineDate | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자 bitmask. DAILY·ONE_TIME: null |
+          | todos[].routineDays | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자 bitmask. DAILY·ONE_TIME: null |
           | todos[].tagId | integer | AI가 이 투두에 배정한 태그 ID. 요청한 유저의 실제 태그 중에서 선택됨. 마땅한 태그가 없으면 null |
           | todos[].tagName | string | 배정된 태그 이름. tagId가 null이면 함께 null |
 
@@ -1062,7 +1062,7 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-08-25",
                                     "dueTime": null,
                                     "routineType": "DAILY",
-                                    "routineDate": null,
+                                    "routineDays": null,
                                     "tagId": 1,
                                     "tagName": "Study"
                                   },
@@ -1072,7 +1072,7 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-06-10",
                                     "dueTime": "08:00",
                                     "routineType": null,
-                                    "routineDate": null,
+                                    "routineDays": null,
                                     "tagId": 1,
                                     "tagName": "Study"
                                   },
@@ -1082,7 +1082,7 @@ public interface GoalControllerDocs {
                                     "dueDate": "2025-08-24",
                                     "dueTime": null,
                                     "routineType": null,
-                                    "routineDate": null,
+                                    "routineDays": null,
                                     "tagId": null,
                                     "tagName": null
                                   }

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -243,7 +243,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
           | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
           | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
-          | todos[].routineDays | ❌ 선택 | array | 반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0 … 일=6), MONTHLY: 일자(1~31), DAILY: null | `[0, 2, 4]` |
+          | todos[].routineDays | ❌ 선택 | array | 반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0 … 일=6), MONTHLY: 일자(1~31), DAILY: null 또는 빈 배열([]) | `[0, 2, 4]` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
           | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |

--- a/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
+++ b/src/main/java/plana/replan/domain/goal/controller/GoalControllerDocs.java
@@ -243,7 +243,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | ❌ 선택 | string | 마감 날짜 (yyyy-MM-dd 형식). ONE_TIME만 사용. | `"2025-06-01"` |
           | todos[].dueTime | ❌ 선택 | string | 마감 시간 (HH:mm 형식). ONE_TIME만 사용. | `"09:00"` |
           | todos[].routineType | ❌ 선택 | string | 반복 유형. RECURRING만 사용. `DAILY` / `WEEKLY` / `MONTHLY` | `"DAILY"` |
-          | todos[].routineDays | ❌ 선택 | integer | 반복 날짜. RECURRING만 사용. WEEKLY: 요일 bitmask, MONTHLY: 일자 bitmask (여러 날 합산), DAILY: null | `null` |
+          | todos[].routineDays | ❌ 선택 | array | 반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0 … 일=6), MONTHLY: 일자(1~31), DAILY: null | `[0, 2, 4]` |
           | todos[].tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | todos[].subTodos | ❌ 선택 | array | 하위 투두 제목 목록. ONE_TIME만 사용 가능. | `["챕터 1"]` |
           | todos[].subRoutines | ❌ 선택 | array | 하위 루틴 제목 목록. RECURRING만 사용 가능. | `["스트레칭", "유산소"]` |
@@ -1028,7 +1028,7 @@ public interface GoalControllerDocs {
           | todos[].dueDate | string | 마감 날짜 (yyyy-MM-dd 형식). 없으면 null |
           | todos[].dueTime | string | 마감 시간 (HH:mm 형식). 없으면 null |
           | todos[].routineType | string | RECURRING만: `DAILY` / `WEEKLY` / `MONTHLY`. ONE_TIME이면 null |
-          | todos[].routineDays | integer | RECURRING WEEKLY: 요일 bitmask. MONTHLY: 일자 bitmask. DAILY·ONE_TIME: null |
+          | todos[].routineDays | array | RECURRING WEEKLY: 요일 인덱스(월=0 … 일=6). MONTHLY: 일자(1~31). DAILY·ONE_TIME: null |
           | todos[].tagId | integer | AI가 이 투두에 배정한 태그 ID. 요청한 유저의 실제 태그 중에서 선택됨. 마땅한 태그가 없으면 null |
           | todos[].tagName | string | 배정된 태그 이름. tagId가 null이면 함께 null |
 

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -22,7 +22,7 @@ public record TodoItemRequest(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0, 화=1 … 일=6). MONTHLY: 일자(1~31). ONE_TIME: null. DAILY: null 또는 빈 배열([]). 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+                "반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0, 화=1 … 일=6). MONTHLY: 일자(1~31). ONE_TIME: null. DAILY: null 또는 빈 배열([]) — 값이 있으면 400. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
             example = "[0, 2, 4]")
         List<Integer> routineDays,
     @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -22,9 +22,9 @@ public record TodoItemRequest(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. RECURRING만 사용. ONE_TIME이면 null. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: null.",
-            example = "null")
-        Integer routineDate,
+                "반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0, 화=1 … 일=6). MONTHLY: 일자(1~31). ONE_TIME/DAILY: null. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+            example = "[0, 2, 4]")
+        List<Integer> routineDays,
     @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,
     @Schema(description = "하위 투두 제목 목록. ONE_TIME만 사용 가능.", example = "[\"챕터 1\", \"챕터 2\"]")
         List<String> subTodos,

--- a/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
+++ b/src/main/java/plana/replan/domain/goal/dto/create/TodoItemRequest.java
@@ -22,7 +22,7 @@ public record TodoItemRequest(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0, 화=1 … 일=6). MONTHLY: 일자(1~31). ONE_TIME/DAILY: null. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+                "반복 날짜 배열. RECURRING만 사용. WEEKLY: 요일 인덱스(월=0, 화=1 … 일=6). MONTHLY: 일자(1~31). ONE_TIME: null. DAILY: null 또는 빈 배열([]). 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
             example = "[0, 2, 4]")
         List<Integer> routineDays,
     @Schema(description = "태그 ID. 없으면 null.", example = "1") Long tagId,

--- a/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
+++ b/src/main/java/plana/replan/domain/goal/dto/recommend/RecommendedTodo.java
@@ -1,6 +1,7 @@
 package plana.replan.domain.goal.dto.recommend;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "AI 추천 투두 항목")
 public record RecommendedTodo(
@@ -25,10 +26,10 @@ public record RecommendedTodo(
         String routineType,
     @Schema(
             description =
-                "반복 날짜 (RECURRING만 사용). WEEKLY: 요일 bitmask (월=1,화=2,수=4,목=8,금=16,토=32,일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: null.",
-            example = "62",
+                "반복 날짜 배열 (RECURRING만 사용). WEEKLY: 요일 인덱스(월=0 … 일=6). MONTHLY: 일자(1~31). DAILY: null.",
+            example = "[0, 2, 4]",
             nullable = true)
-        Integer routineDate,
+        List<Integer> routineDays,
     @Schema(
             description = "AI가 이 투두에 배정한 태그 ID. 유저의 실제 태그 중에서 선택되며, 마땅한 태그가 없으면 null",
             example = "1",

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -267,9 +267,9 @@ public class GoalAiService {
         7. 인강 수강처럼 매번 다른 내용을 학습하는 것은 ONE_TIME 투두 여러 개로 생성
         8. 이론 나열 금지. '수기 복습', '문제 풀이', '오답 노트' 등 아웃풋 태스크 반드시 중간에 배치
         9. 마감 D-1~2는 진도 금지. '최종 점검', '백지 복습' 등 마무리 태스크만 배치
-        10. WEEKLY routineDate는 bitmask: 월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64
-        11. MONTHLY routineDate는 일자 비트마스크(1일=1, 2일=2, 3일=4 … d일=2^(d-1)). 여러 날짜면 각 비트를 더한다(예: 3일·20일 = 4 + 524288 = 524292)
-        12. DAILY는 routineDate 불필요 (null)
+        10. WEEKLY routineDays는 요일 인덱스 배열: 월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6 (예: 월·수·금 → [0,2,4])
+        11. MONTHLY routineDays는 일자 배열(1~31): 그 달 며칠에 반복할지 (예: 3일·20일 → [3,20])
+        12. DAILY는 routineDays 불필요 (null)
         13. dueDate는 yyyy-MM-dd 형식 또는 null, dueTime은 HH:mm 형식 또는 null
         14. type은 "ONE_TIME" 또는 "RECURRING"만 허용
         15. routineType은 "DAILY", "WEEKLY", "MONTHLY" 중 하나 (ONE_TIME이면 null)
@@ -281,7 +281,7 @@ public class GoalAiService {
             - 링크는 Google Search로 확인된 실제 URL만 사용. 확인 불가 시 링크 생략
 
         반드시 아래 JSON만 출력하세요 (다른 설명 없이):
-        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"dueTime":null,"routineType":null,"routineDate":null,"tagId":null}]}
+        {"overallReason":"","todos":[{"type":"","title":"","dueDate":null,"dueTime":null,"routineType":null,"routineDays":null,"tagId":null}]}
         """
             .formatted(req.goal(), deadlineInfo, buildSolutionInfo(req.solutions()), tagInfo);
     return prompt + refreshStyleBlock(req.refreshCount() == null ? 0 : req.refreshCount());
@@ -295,7 +295,7 @@ public class GoalAiService {
           case 2 -> "2회차(벼락치기): 버퍼 없이 혹은 마이너스로 빡빡하게 잡는다. 가장 핵심 1개(1-Pick) 위주로 줄이고, 어려운 것부터 역순으로 배치한다.";
           case 3 -> "3회차(환경 변경): 분량·난이도는 적정 수준으로 두되, 기존 진행 시간대·요일을 실제로 다른 쪽으로 옮겨 배치한다."
               + " 예: 평일 저녁 → 주말 오전, 평일 → 주말. 각 투두의 dueTime을 기존과 다른 시간대로 바꾸거나"
-              + " routineType/routineDate를 주말(토·일) 쪽으로 옮긴다.";
+              + " routineType/routineDays를 주말(토·일) 쪽으로 옮긴다.";
           default -> null;
         };
     if (line == null) {
@@ -349,15 +349,21 @@ public class GoalAiService {
         String dueTime = node.path("dueTime").isNull() ? null : node.path("dueTime").asText(null);
         String routineType =
             node.path("routineType").isNull() ? null : node.path("routineType").asText(null);
-        Integer routineDate = null;
-        JsonNode routineDateNode = node.path("routineDate");
-        if (!routineDateNode.isNull() && !routineDateNode.isMissingNode()) {
-          if (routineDateNode.isInt()) {
-            routineDate = routineDateNode.intValue();
-          } else if (routineDateNode.isTextual()) {
-            routineDate = Integer.valueOf(routineDateNode.asText());
-          } else {
-            throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
+        // routineDays: 반복 날짜 배열 (WEEKLY=요일 인덱스 0~6, MONTHLY=일자 1~31). 없으면 null.
+        List<Integer> routineDays = null;
+        JsonNode routineDaysNode = node.path("routineDays");
+        if (routineDaysNode.isArray()) {
+          routineDays = new ArrayList<>();
+          for (JsonNode e : routineDaysNode) {
+            if (e.canConvertToInt()) {
+              routineDays.add(e.asInt());
+            } else if (e.isTextual()) {
+              try {
+                routineDays.add(Integer.valueOf(e.asText().trim()));
+              } catch (NumberFormatException ignored) {
+                // 숫자로 못 바꾸는 원소는 건너뛴다
+              }
+            }
           }
         }
         // AI가 준 tagId를 유저의 실제 태그 목록으로 검증한다.
@@ -385,7 +391,7 @@ public class GoalAiService {
 
         todos.add(
             new RecommendedTodo(
-                type, title, dueDate, dueTime, routineType, routineDate, tagId, tagName));
+                type, title, dueDate, dueTime, routineType, routineDays, tagId, tagName));
       }
       return new TodoRecommendationResponse(overallReason, todos);
     } catch (Exception e) {

--- a/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalAiService.java
@@ -358,13 +358,20 @@ public class GoalAiService {
             if (e.canConvertToInt()) {
               routineDays.add(e.asInt());
             } else if (e.isTextual()) {
-              try {
-                routineDays.add(Integer.valueOf(e.asText().trim()));
-              } catch (NumberFormatException ignored) {
-                // 숫자로 못 바꾸는 원소는 건너뛴다
-              }
+              // 숫자로 못 바꾸면 NumberFormatException → 아래 catch(Exception)에서 파싱 오류로 처리
+              routineDays.add(Integer.valueOf(e.asText().trim()));
+            } else {
+              // 숫자/숫자문자열이 아닌 원소는 잘못된 응답으로 본다.
+              throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
             }
           }
+        }
+        // ONE_TIME·DAILY는 반복 날짜가 없어야 하고, WEEKLY/MONTHLY는 범위 안의 값이 하나 이상 있어야 한다.
+        // 부분 파싱한 값을 그대로 흘려보내지 않고 여기서 전체를 검증한다.
+        if (!"RECURRING".equals(type) || routineType == null || "DAILY".equals(routineType)) {
+          routineDays = null;
+        } else if (!isValidRecommendedRoutineDays(routineType, routineDays)) {
+          throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
         }
         // AI가 준 tagId를 유저의 실제 태그 목록으로 검증한다.
         // 실제 태그면 그대로 두고 이름은 DB 기준으로 확정, 아니면(지어낸 값 등) 태그 없이(null) 처리.
@@ -398,6 +405,18 @@ public class GoalAiService {
       log.error("Gemini recommend 응답 파싱 실패: {}", raw, e);
       throw new CustomException(GoalErrorCode.GEMINI_PARSE_ERROR);
     }
+  }
+
+  /** WEEKLY(요일 0~6)/MONTHLY(일자 1~31) 반복 날짜 배열이 비어있지 않고 범위 안인지 검사한다. */
+  private boolean isValidRecommendedRoutineDays(String routineType, List<Integer> routineDays) {
+    if (routineDays == null || routineDays.isEmpty()) {
+      return false;
+    }
+    return switch (routineType) {
+      case "WEEKLY" -> routineDays.stream().allMatch(d -> d >= 0 && d <= 6);
+      case "MONTHLY" -> routineDays.stream().allMatch(d -> d >= 1 && d <= 31);
+      default -> false;
+    };
   }
 
   String callGemini(String prompt) {

--- a/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
+++ b/src/main/java/plana/replan/domain/goal/service/GoalWithTodosService.java
@@ -16,7 +16,6 @@ import plana.replan.domain.goal.dto.create.TodoItemRequest;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.routine.dto.RoutineCreateRequestDto;
 import plana.replan.domain.routine.dto.SubRoutineCreateRequestDto;
-import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.service.RoutineService;
 import plana.replan.domain.todo.dto.SubTodoCreateRequestDto;
 import plana.replan.domain.todo.dto.TodoCreateRequestDto;
@@ -116,13 +115,13 @@ public class GoalWithTodosService {
   }
 
   private RoutineCreateRequestDto buildRoutineCreateRequest(TodoItemRequest item, Long goalId) {
-    Integer routineDate = item.routineType() == RoutineType.DAILY ? null : item.routineDate();
+    // routineDays(배열)는 그대로 넘기고, 배열→비트마스크 변환·검증은 RoutineService.createRoutine에서 한다.
     return new RoutineCreateRequestDto(
         item.title(),
         parseDateTime(item.dueDate(), item.dueTime()),
         null,
         item.routineType(),
-        routineDate,
+        item.routineDays(),
         item.tagId(),
         goalId);
   }

--- a/src/main/java/plana/replan/domain/replan/controller/ReplanControllerDocs.java
+++ b/src/main/java/plana/replan/domain/replan/controller/ReplanControllerDocs.java
@@ -79,7 +79,7 @@ public interface ReplanControllerDocs {
                                   "dueTime": "23:59",
                                   "tagId": null,
                                   "routineType": null,
-                                  "routineDate": null,
+                                  "routineDays": null,
                                   "changedFields": [
                                     {"field": "dueDate", "before": "2026-06-25", "after": "2026-06-26"}
                                   ]

--- a/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
+++ b/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
@@ -20,8 +20,8 @@ public record ReplanOperation(
             example = "WEEKLY")
         String routineType,
     @Schema(
-            description = "반복 날짜(WEEKLY=요일 bitmask, MONTHLY=일자 bitmask). 없으면 null",
+            description = "반복 날짜 배열(WEEKLY=요일 인덱스 월0…일6, MONTHLY=일자 1~31). 없으면 null",
             nullable = true,
-            example = "62")
-        Integer routineDate,
+            example = "[0, 2, 4]")
+        List<Integer> routineDays,
     @Schema(description = "바뀐 필드 목록") List<ChangedField> changedFields) {}

--- a/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
@@ -103,11 +103,11 @@ public class ReplanAiService {
            - MODIFY_TODO의 targetTodoId에는 위 '대상 투두 ID'를, 다른 기존 투두 수정(우선순위 등)은 아래 '선택 투두' 목록의 실제 ID만 사용. ID를 임의로 만들지 않는다.
         5. changedFields: 수정(MODIFY_TODO/MODIFY_ROUTINE)에서 바뀐 필드만 {field, before, after}로 채운다. field는 title/dueTime/tag/routineType.
            새로 만드는 ADD·CREATE_ROUTINE은 changedFields를 빈 배열([])로 둔다.
-        6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDate는 비트마스크 정수 또는 null (DAILY는 null / WEEKLY는 요일 비트마스크: 월1·화2·수4·목8·금16·토32·일64를 합 / MONTHLY는 일자 비트마스크: d일=2^(d-1)을 합, 예 15일=16384, 3일과 20일=4+524288=524292). 절대 달력 날짜(예: 15)를 그대로 쓰지 말 것.
+        6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDays는 정수 배열 또는 null (DAILY는 null / WEEKLY는 요일 인덱스 배열: 월=0·화=1·수=2·목=3·금=4·토=5·일=6, 예 월·수·금=[0,2,4] / MONTHLY는 일자 배열 1~31, 예 3일·20일=[3,20]).
            - CREATE_ROUTINE의 dueDate는 '반복을 끝낼 종료일'을 뜻한다(이 날짜 이후로는 회차를 만들지 않음). 무기한 반복이면 null로 둔다. 새 루틴의 반복 시각은 dueTime으로 지정한다.
 
         반드시 아래 JSON만 출력 (다른 설명 없이):
-        {"operations":[{"action":"","targetTodoId":null,"title":"","dueDate":null,"dueTime":null,"tagId":null,"routineType":null,"routineDate":null,"changedFields":[{"field":"","before":null,"after":""}]}]}
+        {"operations":[{"action":"","targetTodoId":null,"title":"","dueDate":null,"dueTime":null,"tagId":null,"routineType":null,"routineDays":null,"changedFields":[{"field":"","before":null,"after":""}]}]}
         """
             .formatted(
                 input.today(),
@@ -206,7 +206,7 @@ public class ReplanAiService {
                 textOrNull(op.path("dueTime")),
                 longOrNull(op.path("tagId")),
                 textOrNull(op.path("routineType")),
-                intOrNull(op.path("routineDate")),
+                intListOrNull(op.path("routineDays")),
                 changed));
       }
       return operations;
@@ -235,17 +235,25 @@ public class ReplanAiService {
     throw new IllegalArgumentException("숫자 필드(targetTodoId/tagId)가 숫자가 아닙니다: " + node);
   }
 
-  private Integer intOrNull(JsonNode node) {
+  /** routineDays: 정수 배열. 없으면 null. 각 원소는 숫자/숫자문자열만 허용. */
+  private List<Integer> intListOrNull(JsonNode node) {
     if (node.isNull() || node.isMissingNode()) {
       return null;
     }
-    if (node.isIntegralNumber()) {
-      return node.intValue();
+    if (!node.isArray()) {
+      throw new IllegalArgumentException("routineDays가 배열이 아닙니다: " + node);
     }
-    if (node.isTextual()) {
-      return Integer.parseInt(node.asText().trim());
+    List<Integer> days = new ArrayList<>();
+    for (JsonNode e : node) {
+      if (e.isIntegralNumber()) {
+        days.add(e.intValue());
+      } else if (e.isTextual()) {
+        days.add(Integer.parseInt(e.asText().trim()));
+      } else {
+        throw new IllegalArgumentException("routineDays 원소가 숫자가 아닙니다: " + e);
+      }
     }
-    throw new IllegalArgumentException("숫자 필드(routineDate)가 숫자가 아닙니다: " + node);
+    return days;
   }
 
   private String extractJson(String text) {

--- a/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
@@ -101,7 +101,7 @@ public class ReplanAiService {
            - 마감이 이미 지난 일반 투두는 MODIFY_TODO 대신 ADD로 새 투두를 만든다.
            - 반복 투두 규칙 변경은 MODIFY_ROUTINE(targetTodoId=대상 투두 ID), 새 루틴은 CREATE_ROUTINE.
            - MODIFY_TODO의 targetTodoId에는 위 '대상 투두 ID'를, 다른 기존 투두 수정(우선순위 등)은 아래 '선택 투두' 목록의 실제 ID만 사용. ID를 임의로 만들지 않는다.
-        5. changedFields: 수정(MODIFY_TODO/MODIFY_ROUTINE)에서 바뀐 필드만 {field, before, after}로 채운다. field는 title/dueTime/tag/routineType.
+        5. changedFields: 수정(MODIFY_TODO/MODIFY_ROUTINE)에서 바뀐 필드만 {field, before, after}로 채운다. field는 title/dueDate/dueTime/tag/routineType/routineDays.
            새로 만드는 ADD·CREATE_ROUTINE은 changedFields를 빈 배열([])로 둔다.
         6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDays는 정수 배열 또는 null (DAILY는 null / WEEKLY는 요일 인덱스 배열: 월=0·화=1·수=2·목=3·금=4·토=5·일=6, 예 월·수·금=[0,2,4] / MONTHLY는 일자 배열 1~31, 예 3일·20일=[3,20]).
            - CREATE_ROUTINE의 dueDate는 '반복을 끝낼 종료일'을 뜻한다(이 날짜 이후로는 회차를 만들지 않음). 무기한 반복이면 null로 둔다. 새 루틴의 반복 시각은 dueTime으로 지정한다.

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -30,6 +30,7 @@ import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.routine.service.RoutineService;
+import plana.replan.domain.routine.util.RoutineDays;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -472,17 +473,25 @@ public class ReplanService {
         op.tagId() != null ? resolveTag(op.tagId(), anchor.getUser().getId()) : routine.getTag();
     RoutineType effectiveType =
         op.routineType() != null ? parseRoutineType(op.routineType()) : routine.getRoutineType();
-    // 반복 유형이 바뀌면 기존 routineDate는 의미가 달라(WEEKLY=요일 비트마스크 ↔ MONTHLY=일자 비트마스크)
-    // 재사용하지 않고, 새 유형에 맞는 routineDate를 op가 명시하도록 강제한다(없으면 아래 검증에서 400).
-    // 유형이 그대로면 생략된 routineDate를 기존 값으로 보완한다.
+    // 반복 유형이 바뀌면 기존 값은 의미가 달라 재사용하지 않고, 새 유형에 맞는 routineDays를 op가 명시하도록 강제한다.
+    // 유형이 그대로이고 op가 routineDays를 생략하면 기존 비트마스크를 그대로 유지한다.
     boolean typeChanged = op.routineType() != null && effectiveType != routine.getRoutineType();
-    Integer effectiveRoutineDate =
-        typeChanged
-            ? op.routineDate()
-            : (op.routineDate() != null ? op.routineDate() : routine.getRoutineDate());
-    validateRecurrence(effectiveType, effectiveRoutineDate);
-    // DAILY는 반복 날짜가 의미 없으므로 null로 정규화한다(다른 루틴 생성 경로와 규약을 맞춘다).
-    effectiveRoutineDate = normalizeRoutineDate(effectiveType, effectiveRoutineDate);
+    Integer effectiveRoutineDate;
+    if (op.routineDays() != null) {
+      if (!RoutineDays.isValid(effectiveType, op.routineDays())) {
+        throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+      }
+      effectiveRoutineDate = RoutineDays.toMask(effectiveType, op.routineDays());
+    } else {
+      effectiveRoutineDate = typeChanged ? null : routine.getRoutineDate();
+    }
+    // WEEKLY/MONTHLY인데 최종 반복 날짜가 없으면 400. (DAILY는 null이 정상)
+    if (effectiveType != RoutineType.DAILY && effectiveRoutineDate == null) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+    }
+    if (effectiveType == RoutineType.DAILY) {
+      effectiveRoutineDate = null;
+    }
     routine.update(
         op.title() != null ? op.title() : routine.getTitle(),
         routine.getDueDate(),
@@ -541,7 +550,9 @@ public class ReplanService {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
     RoutineType type = parseRoutineType(op.routineType());
-    validateRecurrence(type, op.routineDate());
+    if (!RoutineDays.isValid(type, op.routineDays())) {
+      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
+    }
     User user = anchor.getUser();
     Tag tag = resolveTag(op.tagId(), user.getId());
     Routine routine =
@@ -551,8 +562,8 @@ public class ReplanService {
             .dueDate(parseRoutineEndDate(op.dueDate()))
             .routineTime(parseTime(op.dueTime()))
             .routineType(type)
-            // DAILY는 반복 날짜가 의미 없으므로 null로 정규화한다(다른 루틴 생성 경로와 규약을 맞춘다).
-            .routineDate(normalizeRoutineDate(type, op.routineDate()))
+            // 배열 → 비트마스크. DAILY는 null.
+            .routineDate(RoutineDays.toMask(type, op.routineDays()))
             .user(user)
             .tag(tag)
             .build();
@@ -564,22 +575,6 @@ public class ReplanService {
             routine, LocalDate.now(clock).atStartOfDay());
     instance.ifPresent(instanceTodo -> instanceTodo.linkReplan(replan));
     return instance.isPresent();
-  }
-
-  private void validateRecurrence(RoutineType type, Integer routineDate) {
-    if (type == RoutineType.WEEKLY
-        && (routineDate == null || routineDate < 1 || routineDate > 127)) {
-      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
-    }
-    // MONTHLY도 일자 비트마스크(일자 d → 비트 d-1). 양의 정수면 유효(1~31일이 비트 0~30에 대응).
-    if (type == RoutineType.MONTHLY && (routineDate == null || routineDate < 1)) {
-      throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
-    }
-  }
-
-  /** DAILY 루틴은 반복 날짜가 의미 없으므로 항상 null로 둔다(WEEKLY/MONTHLY는 그대로). */
-  private Integer normalizeRoutineDate(RoutineType type, Integer routineDate) {
-    return type == RoutineType.DAILY ? null : routineDate;
   }
 
   private LocalTime parseTime(String time) {

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -34,8 +34,8 @@ public interface RoutineControllerDocs {
           `filter`와 `date`를 기준으로 해당 기간의 루틴 목록을 날짜별로 묶어 반환합니다.
 
           - `DAILY` 루틴: 기간 내 모든 날짜에 포함
-          - `WEEKLY` 루틴: 해당 날짜의 요일이 `routineDate` 비트마스크에 포함된 날짜에만 포함
-          - `MONTHLY` 루틴: 해당 날짜의 일(day) 비트가 `routineDate` 비트마스크에 포함된 날짜에만 포함
+          - `WEEKLY` 루틴: 해당 날짜의 요일 인덱스가 `routineDays` 배열에 포함된 날짜에만 포함
+          - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDays` 배열에 포함된 날짜에만 포함
 
           각 루틴에 해당 날짜의 Todo가 이미 생성되어 있으면 `todoId`가 포함되고, 아직 없으면 `null`입니다.
 
@@ -74,7 +74,7 @@ public interface RoutineControllerDocs {
           | dueDate | string | 반복 종료 마감일 (ISO 8601 형식). 없으면 null |
           | routineTime | string | 마감 시각 (HH:mm:ss 형식). 없으면 null |
           | routineType | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) |
-          | routineDate | integer | 반복 날짜 설정값. DAILY는 null, WEEKLY는 요일 비트마스크, MONTHLY는 일자 비트마스크 |
+          | routineDays | integer | 반복 날짜 배열. DAILY는 null, WEEKLY는 요일 인덱스(월0…일6), MONTHLY는 일자(1~31) |
           | tagId | integer | 태그 ID. 없으면 null |
           | tagTitle | string | 태그 제목. 없으면 null |
           | tagColor | string | 태그 색상. 없으면 null |
@@ -103,7 +103,7 @@ public interface RoutineControllerDocs {
                                     "dueDate": null,
                                     "routineTime": "08:00:00",
                                     "routineType": "DAILY",
-                                    "routineDate": null,
+                                    "routineDays": null,
                                     "tagId": null,
                                     "tagTitle": null,
                                     "tagColor": null,
@@ -118,7 +118,7 @@ public interface RoutineControllerDocs {
                                     "dueDate": null,
                                     "routineTime": "08:00:00",
                                     "routineType": "DAILY",
-                                    "routineDate": null,
+                                    "routineDays": null,
                                     "tagId": null,
                                     "tagTitle": null,
                                     "tagColor": null,
@@ -131,7 +131,7 @@ public interface RoutineControllerDocs {
                                     "dueDate": "2025-12-31T00:00:00",
                                     "routineTime": "09:00:00",
                                     "routineType": "WEEKLY",
-                                    "routineDate": 21,
+                                    "routineDays": [0, 2, 4],
                                     "tagId": 3,
                                     "tagTitle": "영어",
                                     "tagColor": "BLUE",
@@ -254,7 +254,7 @@ public interface RoutineControllerDocs {
           | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
           | dueDate | ❌ 선택 | string | 반복 종료 마감일 (ISO 8601 형식). 이 날짜 이후로는 반복 생성 안 됨 | `"2025-12-31T00:00:00"` |
           | routineTime | ❌ 선택 | string | 반복되는 날의 마감 시각 (HH:mm:ss 형식). 생략 시 23:59:59 | `"09:00:00"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요 | `21` |
+          | routineDays | ❌ 선택 | integer | 반복 날짜 배열. WEEKLY: 요일 인덱스 배열(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자 배열(1~31). DAILY: 불필요 | `[0, 2, 4]` |
           | tagId | ❌ 선택 | integer | 태그 ID | `1` |
           | goalId | ❌ 선택 | integer | 목표 ID | `2` |
 
@@ -262,20 +262,18 @@ public interface RoutineControllerDocs {
 
           ---
 
-          ### routineDate 규칙
+          ### routineDays 규칙
 
-          | routineType | routineDate 의미 | 유효 범위 |
+          | routineType | routineDays 의미 | 예시 |
           |-------------|-----------------|-----------|
-          | `DAILY` | 사용 안 함 (무시) | — |
-          | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
-          | `MONTHLY` | 반복할 일자 비트마스크 (여러 날 합산) | 1일=1, 2일=2, 3일=4 … |
-
-          **WEEKLY 예시**: 월+수+금 → 1+4+16 = **21**
+          | `DAILY` | 사용 안 함 (null) | — |
+          | `WEEKLY` | 요일 인덱스 배열 (월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6) | 월·수·금 → [0, 2, 4] |
+          | `MONTHLY` | 반복할 일자 배열 (1~31) | 3·20일 → [3, 20] |
 
           ---
 
           ### 주의사항
-          - `WEEKLY` 또는 `MONTHLY` 타입에서 `routineDate`가 유효 범위를 벗어나면 400 반환
+          - `WEEKLY` 또는 `MONTHLY` 타입에서 `routineDays`가 유효 범위를 벗어나면 400 반환
           - `tagId`가 제공된 경우 해당 태그가 존재하지 않으면 404 반환
           - `goalId`가 제공된 경우 해당 목표가 존재하지 않으면 404 반환
           """,
@@ -300,7 +298,7 @@ public interface RoutineControllerDocs {
                                 "dueDate": "2025-12-31T00:00:00",
                                 "routineTime": "09:00:00",
                                 "routineType": "WEEKLY",
-                                "routineDate": 21,
+                                "routineDays": [0, 2, 4],
                                 "tagId": 1,
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
@@ -311,7 +309,7 @@ public interface RoutineControllerDocs {
                             """))),
     @ApiResponse(
         responseCode = "400",
-        description = "입력값 오류 (title/routineType 누락, 또는 routineDate 범위 오류)",
+        description = "입력값 오류 (title/routineType 누락, 또는 routineDays 범위 오류)",
         content =
             @Content(
                 examples = {
@@ -331,7 +329,7 @@ public interface RoutineControllerDocs {
                           }
                           """),
                   @ExampleObject(
-                      name = "routineDate 범위 오류",
+                      name = "routineDays 범위 오류",
                       value =
                           """
                           {
@@ -437,14 +435,14 @@ public interface RoutineControllerDocs {
                                   "dueDate": "2025-12-31T00:00:00",
                                   "routineTime": "09:00:00",
                                   "routineType": "WEEKLY",
-                                  "routineDate": 21,
+                                  "routineDays": [0, 2, 4],
                                   "tagId": 1,
                                   "goalId": 2
                                 }
                                 """),
                         @ExampleObject(
                             name = "DAILY — 필수 필드만",
-                            summary = "DAILY는 routineDate 불필요",
+                            summary = "DAILY는 routineDays 불필요",
                             value =
                                 """
                                 {
@@ -453,14 +451,14 @@ public interface RoutineControllerDocs {
                                 }
                                 """),
                         @ExampleObject(
-                            name = "MONTHLY — 매월 15일 (15일=1<<14=16384)",
+                            name = "MONTHLY — 매월 15일 ([15])",
                             value =
                                 """
                                 {
                                   "title": "월간 회고",
                                   "dueDate": "2025-12-31T00:00:00",
                                   "routineType": "MONTHLY",
-                                  "routineDate": 16384
+                                  "routineDays": [15]
                                 }
                                 """)
                       }))
@@ -474,7 +472,7 @@ public interface RoutineControllerDocs {
           엄마 루틴 아래에 하위 루틴을 추가합니다.
 
           ### 정책
-          - 하위 루틴은 `title`만 자체 값입니다. 스케줄(`routineType`/`routineDate`), `dueDate`, `tag`, `goal`, `user`는 모두 엄마 루틴을 따릅니다.
+          - 하위 루틴은 `title`만 자체 값입니다. 스케줄(`routineType`/`routineDays`), `dueDate`, `tag`, `goal`, `user`는 모두 엄마 루틴을 따릅니다.
           - 1단계 깊이만 허용합니다. 하위 루틴 ID를 `parentId`로 넘기면 404로 거부됩니다.
           - 호출 시점에 엄마 루틴의 살아있는 다음 발생일 Todo가 있으면, 해당 엄마 Todo 아래에 하위 Todo가 즉시 매달립니다. 없으면 다음 스케줄러 사이클에서 함께 생성됩니다.
 
@@ -658,20 +656,20 @@ public interface RoutineControllerDocs {
           | routineType | ✅ 필수 | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) | `"WEEKLY"` |
           | dueDate | ❌ 선택 | string | 반복 종료 마감일 (ISO 8601 형식). null이면 종료일 제거 | `"2025-12-31T00:00:00"` |
           | routineTime | ❌ 선택 | string | 반복되는 날의 마감 시각 (HH:mm:ss 형식). null이면 23:59:59로 처리 | `"09:00:00"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜. WEEKLY: 요일 bitmask (월=1~일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요 | `21` |
+          | routineDays | ❌ 선택 | integer | 반복 날짜 배열. WEEKLY: 요일 인덱스 배열(월=0 … 일=6). MONTHLY: 일자 배열(1~31). DAILY: 불필요 | `[0, 2, 4]` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `1` |
 
           > ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
 
           ---
 
-          ### routineDate 규칙
+          ### routineDays 규칙
 
-          | routineType | routineDate 의미 | 유효 범위 |
+          | routineType | routineDays 의미 | 예시 |
           |-------------|-----------------|-----------|
-          | `DAILY` | 사용 안 함 (무시) | — |
-          | `WEEKLY` | 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64) | 1 ~ 127 |
-          | `MONTHLY` | 반복할 일자 비트마스크 (여러 날 합산) | 1일=1, 2일=2, 3일=4 … |
+          | `DAILY` | 사용 안 함 (null) | — |
+          | `WEEKLY` | 요일 인덱스 배열 (월=0 … 일=6) | 월·수·금 → [0, 2, 4] |
+          | `MONTHLY` | 반복할 일자 배열 (1~31) | 3·20일 → [3, 20] |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
@@ -693,7 +691,7 @@ public interface RoutineControllerDocs {
                                 "dueDate": "2025-12-31T00:00:00",
                                 "routineTime": "09:00:00",
                                 "routineType": "WEEKLY",
-                                "routineDate": 21,
+                                "routineDays": [0, 2, 4],
                                 "tagId": 1,
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
@@ -704,7 +702,7 @@ public interface RoutineControllerDocs {
                             """))),
     @ApiResponse(
         responseCode = "400",
-        description = "입력값 오류 (title/routineType 누락, 또는 routineDate 범위 오류, 또는 하위 루틴 ID 사용)",
+        description = "입력값 오류 (title/routineType 누락, 또는 routineDays 범위 오류, 또는 하위 루틴 ID 사용)",
         content =
             @Content(
                 examples = {
@@ -724,7 +722,7 @@ public interface RoutineControllerDocs {
                           }
                           """),
                   @ExampleObject(
-                      name = "routineDate 범위 오류",
+                      name = "routineDays 범위 오류",
                       value =
                           """
                           {
@@ -846,13 +844,13 @@ public interface RoutineControllerDocs {
                                   "dueDate": "2025-12-31T00:00:00",
                                   "routineTime": "09:00:00",
                                   "routineType": "WEEKLY",
-                                  "routineDate": 21,
+                                  "routineDays": [0, 2, 4],
                                   "tagId": 1
                                 }
                                 """),
                         @ExampleObject(
                             name = "DAILY — 필수 필드만",
-                            summary = "DAILY는 routineDate 불필요, optional 필드 생략",
+                            summary = "DAILY는 routineDays 불필요, optional 필드 생략",
                             value =
                                 """
                                 {

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
@@ -32,7 +32,7 @@ public record RoutineCreateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열([]) — 값이 있으면 400. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
             example = "[0, 2, 4]")
         List<Integer> routineDays,
     @Schema(description = "태그 ID", example = "1") Long tagId,

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import plana.replan.domain.routine.entity.RoutineType;
 
 @Schema(description = "루틴 생성 요청")
@@ -31,8 +32,8 @@ public record RoutineCreateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요.",
-            example = "21")
-        Integer routineDate,
+                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+            example = "[0, 2, 4]")
+        List<Integer> routineDays,
     @Schema(description = "태그 ID", example = "1") Long tagId,
     @Schema(description = "목표 ID", example = "2") Long goalId) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.util.RoutineDays;
 
 @Schema(description = "루틴 조회 응답")
 @Getter
@@ -33,8 +35,10 @@ public class RoutineResponseDto {
   @Schema(description = "반복 유형", example = "DAILY")
   private RoutineType routineType;
 
-  @Schema(description = "반복 날짜 설정값. DAILY=null, WEEKLY=요일 비트마스크, MONTHLY=일자 비트마스크", example = "21")
-  private Integer routineDate;
+  @Schema(
+      description = "반복 날짜 배열. DAILY=null, WEEKLY=요일 인덱스(월0…일6), MONTHLY=일자(1~31)",
+      example = "[0, 2, 4]")
+  private List<Integer> routineDays;
 
   @Schema(description = "태그 ID (override 적용값). 없으면 null", example = "3")
   private Long tagId;
@@ -73,7 +77,7 @@ public class RoutineResponseDto {
         routine.getDueDate(),
         routine.getRoutineTime(),
         routine.getRoutineType(),
-        routine.getRoutineDate(),
+        RoutineDays.toDays(routine.getRoutineType(), routine.getRoutineDate()),
         routine.getTag() != null ? routine.getTag().getId() : null,
         routine.getTag() != null ? routine.getTag().getTitle() : null,
         routine.getTag() != null ? routine.getTag().getColor() : null,
@@ -89,13 +93,14 @@ public class RoutineResponseDto {
   public static RoutineResponseDto from(RoutineDateProjection p) {
     double effectiveSortOrder =
         p.getOverrideSortOrder() != null ? p.getOverrideSortOrder() : p.getDefaultSortOrder();
+    RoutineType type = p.getRoutineType() != null ? RoutineType.valueOf(p.getRoutineType()) : null;
     return new RoutineResponseDto(
         p.getRoutineId(),
         p.getTitle(),
         p.getDueDate(),
         p.getRoutineTime(),
-        p.getRoutineType() != null ? RoutineType.valueOf(p.getRoutineType()) : null,
-        p.getRoutineDate(),
+        type,
+        RoutineDays.toDays(type, p.getRoutineDate()),
         p.getTagId(),
         p.getTagTitle(),
         p.getTagColor(),

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
@@ -30,7 +30,7 @@ public record RoutineUpdateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열([]) — 값이 있으면 400. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
             example = "[0, 2, 4]")
         List<Integer> routineDays,
     @Schema(description = "태그 ID. null이면 태그 제거", example = "1") Long tagId) {}

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineUpdateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import plana.replan.domain.routine.entity.RoutineType;
 
 @Schema(description = "엄마 루틴 수정 요청 (goalId 수정 불가)")
@@ -29,7 +30,7 @@ public record RoutineUpdateRequestDto(
         RoutineType routineType,
     @Schema(
             description =
-                "반복 날짜. WEEKLY: 요일 bitmask (월=1, 화=2, 수=4, 목=8, 금=16, 토=32, 일=64). MONTHLY: 일자 bitmask (1일=1, 2일=2, 3일=4 … 여러 날 합산). DAILY: 불필요.",
-            example = "21")
-        Integer routineDate,
+                "반복 날짜 배열. WEEKLY: 요일 인덱스(월=0, 화=1, 수=2, 목=3, 금=4, 토=5, 일=6). MONTHLY: 일자(1~31). DAILY: null 또는 빈 배열. 예) 월·수·금=[0,2,4], 매월 3·20일=[3,20].",
+            example = "[0, 2, 4]")
+        List<Integer> routineDays,
     @Schema(description = "태그 ID. null이면 태그 제거", example = "1") Long tagId) {}

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -28,6 +28,7 @@ import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
 import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.routine.util.RoutineDays;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -58,7 +59,7 @@ public class RoutineService {
             .findById(userId)
             .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-    validateRoutineDate(request.routineType(), request.routineDate());
+    validateRoutineDays(request.routineType(), request.routineDays());
 
     Tag tag = null;
     if (request.tagId() != null) {
@@ -76,7 +77,7 @@ public class RoutineService {
               .orElseThrow(() -> new CustomException(GoalErrorCode.GOAL_NOT_FOUND));
     }
 
-    Integer routineDate = request.routineType() == RoutineType.DAILY ? null : request.routineDate();
+    Integer routineDate = RoutineDays.toMask(request.routineType(), request.routineDays());
 
     Routine routine =
         routineRepository.save(
@@ -137,7 +138,7 @@ public class RoutineService {
     if (routine.isChild()) {
       throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_TARGET);
     }
-    validateRoutineDate(request.routineType(), request.routineDate());
+    validateRoutineDays(request.routineType(), request.routineDays());
 
     Tag tag = null;
     if (request.tagId() != null) {
@@ -147,7 +148,7 @@ public class RoutineService {
               .orElseThrow(() -> new CustomException(TagErrorCode.TAG_NOT_FOUND));
     }
 
-    Integer routineDate = request.routineType() == RoutineType.DAILY ? null : request.routineDate();
+    Integer routineDate = RoutineDays.toMask(request.routineType(), request.routineDays());
     routine.update(
         request.title(),
         request.dueDate(),
@@ -437,17 +438,10 @@ public class RoutineService {
     };
   }
 
-  private void validateRoutineDate(RoutineType routineType, Integer routineDate) {
-    if (routineType == RoutineType.WEEKLY) {
-      if (routineDate == null || routineDate < 1 || routineDate > 127) {
-        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
-      }
-    } else if (routineType == RoutineType.MONTHLY) {
-      // 일자 비트마스크(일자 d → 비트 d-1). 1~31일이 비트 0~30에 대응하며 최대값은 int 범위(2^31-1)에 들어간다.
-      // 양의 정수면 비트 31(부호비트)은 켜질 수 없으므로 1 이상만 검증한다.
-      if (routineDate == null || routineDate < 1) {
-        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
-      }
+  private void validateRoutineDays(RoutineType routineType, List<Integer> routineDays) {
+    // WEEKLY: 요일 인덱스(0~6), MONTHLY: 일자(1~31). 비어있거나 범위 밖이면 400. DAILY는 무시.
+    if (!RoutineDays.isValid(routineType, routineDays)) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
     }
   }
 }

--- a/src/main/java/plana/replan/domain/routine/util/RoutineDays.java
+++ b/src/main/java/plana/replan/domain/routine/util/RoutineDays.java
@@ -24,10 +24,14 @@ public final class RoutineDays {
   private static final int MONTHLY_MIN = 1;
   private static final int MONTHLY_MAX = 31;
 
-  /** WEEKLY/MONTHLY 배열 값이 유효 범위 안이고 비어있지 않은지 검사한다. DAILY는 항상 true(무시). */
+  /** WEEKLY/MONTHLY 배열 값이 유효 범위 안이고 비어있지 않은지 검사한다. DAILY는 null 또는 빈 배열만 허용한다. */
   public static boolean isValid(RoutineType type, List<Integer> days) {
+    if (type == null) {
+      return false;
+    }
     if (type == RoutineType.DAILY) {
-      return true;
+      // DAILY는 반복 날짜가 없어야 한다. 값이 채워져 오면 잘못된 요청이다.
+      return days == null || days.isEmpty();
     }
     if (days == null || days.isEmpty()) {
       return false;

--- a/src/main/java/plana/replan/domain/routine/util/RoutineDays.java
+++ b/src/main/java/plana/replan/domain/routine/util/RoutineDays.java
@@ -1,0 +1,69 @@
+package plana.replan.domain.routine.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import plana.replan.domain.routine.entity.RoutineType;
+
+/**
+ * 반복 날짜의 API 표현(숫자 배열)과 내부 저장 표현(비트마스크 정수)을 변환한다.
+ *
+ * <p>프론트는 배열로 주고받고, 서버 내부(엔티티·발생일 판정·조회 쿼리)는 그대로 비트마스크를 쓴다. 이 변환은 요청 수신·응답 생성 경계에서만 일어난다.
+ *
+ * <ul>
+ *   <li>WEEKLY: 요일 인덱스 배열 (월=0, 화=1 … 일=6) → 비트 index 그대로. 예) [0,2,4] → 1|4|16 = 21
+ *   <li>MONTHLY: 일자 배열 (1~31) → 비트 (일-1). 예) [3,20] → (1&lt;&lt;2)|(1&lt;&lt;19) = 524292
+ *   <li>DAILY: 반복 날짜 없음 → null
+ * </ul>
+ */
+public final class RoutineDays {
+
+  private RoutineDays() {}
+
+  private static final int WEEKLY_MIN = 0;
+  private static final int WEEKLY_MAX = 6;
+  private static final int MONTHLY_MIN = 1;
+  private static final int MONTHLY_MAX = 31;
+
+  /** WEEKLY/MONTHLY 배열 값이 유효 범위 안이고 비어있지 않은지 검사한다. DAILY는 항상 true(무시). */
+  public static boolean isValid(RoutineType type, List<Integer> days) {
+    if (type == RoutineType.DAILY) {
+      return true;
+    }
+    if (days == null || days.isEmpty()) {
+      return false;
+    }
+    int min = type == RoutineType.WEEKLY ? WEEKLY_MIN : MONTHLY_MIN;
+    int max = type == RoutineType.WEEKLY ? WEEKLY_MAX : MONTHLY_MAX;
+    return days.stream().allMatch(d -> d != null && d >= min && d <= max);
+  }
+
+  /** 배열 → 비트마스크. DAILY이거나 days가 null이면 null. (유효성 검사는 호출 전에 {@link #isValid} 로 한다.) */
+  public static Integer toMask(RoutineType type, List<Integer> days) {
+    if (type == null || type == RoutineType.DAILY || days == null) {
+      return null;
+    }
+    int mask = 0;
+    for (Integer d : days) {
+      int bit = type == RoutineType.WEEKLY ? d : d - 1;
+      mask |= (1 << bit);
+    }
+    return mask;
+  }
+
+  /** 비트마스크 → 배열. type/mask가 null이면 null. */
+  public static List<Integer> toDays(RoutineType type, Integer mask) {
+    if (type == null || type == RoutineType.DAILY || mask == null) {
+      return null;
+    }
+    int min = type == RoutineType.WEEKLY ? WEEKLY_MIN : MONTHLY_MIN;
+    int max = type == RoutineType.WEEKLY ? WEEKLY_MAX : MONTHLY_MAX;
+    List<Integer> days = new ArrayList<>();
+    for (int d = min; d <= max; d++) {
+      int bit = type == RoutineType.WEEKLY ? d : d - 1;
+      if ((mask & (1 << bit)) != 0) {
+        days.add(d);
+      }
+    }
+    return days;
+  }
+}

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -729,7 +729,7 @@ public interface TodoControllerDocs {
           | dueDate | ❌ 선택 | string | 마감 일시 (ISO 8601 형식). null이면 마감일 제거 | `"2025-12-31T23:59:59"` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `3` |
           | routineType | ❌ 선택 | string | 반복 유형 (`DAILY`/`WEEKLY`/`MONTHLY`). **이미 반복에 연결된 투두에는 무시됨** | `"WEEKLY"` |
-          | routineDays | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 요일 인덱스 배열(월0…일6), MONTHLY: 일자 배열(1~31)). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
+          | routineDays | ❌ 선택 | array | 반복 날짜 배열 (WEEKLY: 요일 인덱스(월0…일6), MONTHLY: 일자(1~31)). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `[0, 2]` |
           | routineTime | ❌ 선택 | string | 반복 마감 시각 (HH:mm:ss). **이미 반복에 연결된 투두에는 무시됨** | `"09:00:00"` |
 
           ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -729,14 +729,14 @@ public interface TodoControllerDocs {
           | dueDate | ❌ 선택 | string | 마감 일시 (ISO 8601 형식). null이면 마감일 제거 | `"2025-12-31T23:59:59"` |
           | tagId | ❌ 선택 | integer | 태그 ID. null이면 태그 제거 | `3` |
           | routineType | ❌ 선택 | string | 반복 유형 (`DAILY`/`WEEKLY`/`MONTHLY`). **이미 반복에 연결된 투두에는 무시됨** | `"WEEKLY"` |
-          | routineDate | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
+          | routineDays | ❌ 선택 | integer | 반복 날짜 (WEEKLY: 요일 인덱스 배열(월0…일6), MONTHLY: 일자 배열(1~31)). DAILY는 null. **이미 반복에 연결된 투두에는 무시됨** | `5` |
           | routineTime | ❌ 선택 | string | 반복 마감 시각 (HH:mm:ss). **이미 반복에 연결된 투두에는 무시됨** | `"09:00:00"` |
 
           ❌ 선택 필드는 생략하거나 null로 전달해도 동일하게 처리됩니다.
 
           **반복(routine) 처리 규칙**
 
-          `routineType`/`routineDate`/`routineTime`은 **해당 투두에 아직 연결된 Routine이 없을 때만** 새 Routine을 생성해 연결합니다.
+          `routineType`/`routineDays`/`routineTime`은 **해당 투두에 아직 연결된 Routine이 없을 때만** 새 Routine을 생성해 연결합니다.
           이미 Routine이 연결되어 있다면 이 필드들은 무시됩니다 — 반복 시리즈 전체를 수정하려면 `PUT /api/routines/{id}`를 사용하세요.
 
           | 기존 상태 | routineType 값 | 동작 |
@@ -768,7 +768,7 @@ public interface TodoControllerDocs {
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
                                 "routineType": "WEEKLY",
-                                "routineDate": 5,
+                                "routineDays": [0, 2],
                                 "subTodos": []
                               },
                               "error": null
@@ -898,7 +898,7 @@ public interface TodoControllerDocs {
                             name = "전체 필드 포함",
                             value =
                                 """
-                                {"title": "토익 단어 50개 외우기", "dueDate": "2025-12-31T23:59:59", "tagId": 3, "routineType": "WEEKLY", "routineDate": 5}
+                                {"title": "토익 단어 50개 외우기", "dueDate": "2025-12-31T23:59:59", "tagId": 3, "routineType": "WEEKLY", "routineDays": [0, 2]}
                                 """),
                         @ExampleObject(
                             name = "필수 필드만 (optional 생략)",
@@ -934,7 +934,7 @@ public interface TodoControllerDocs {
 
           **반환 필드**
           - `routineType`: 루틴에 연결된 투두인 경우 `DAILY` / `WEEKLY` / `MONTHLY`, 일반 투두는 `null`
-          - `routineDate`: WEEKLY이면 요일 비트마스크(1-127), MONTHLY이면 일자 비트마스크, DAILY 또는 루틴 없으면 `null`
+          - `routineDays`: WEEKLY이면 요일 인덱스 배열(월0…일6), MONTHLY이면 일자 배열(1~31), DAILY 또는 루틴 없으면 `null`
           - `tagId`, `tagTitle`, `tagColor`: 태그가 없으면 모두 `null`
           - `subTodos`: 하위 투두 목록 (없으면 빈 배열)
           """,
@@ -961,7 +961,7 @@ public interface TodoControllerDocs {
                                 "tagTitle": "영어",
                                 "tagColor": "BLUE",
                                 "routineType": "DAILY",
-                                "routineDate": null,
+                                "routineDays": null,
                                 "subTodos": [
                                   {
                                     "todoId": 10,

--- a/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.util.RoutineDays;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.todo.entity.Todo;
 
@@ -41,9 +42,9 @@ public class TodoDetailResponseDto {
   private String routineType;
 
   @Schema(
-      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크, DAILY 또는 반복 없으면 null)",
-      example = "5")
-  private Integer routineDate;
+      description = "반복 날짜 배열 (WEEKLY: 요일 인덱스 월0…일6, MONTHLY: 일자 1~31, DAILY 또는 반복 없으면 null)",
+      example = "[0, 2, 4]")
+  private List<Integer> routineDays;
 
   @Schema(description = "하위 투두 목록")
   private List<SubTodoDto> subTodos;
@@ -83,7 +84,9 @@ public class TodoDetailResponseDto {
         routine != null && routine.getRoutineType() != null
             ? routine.getRoutineType().name()
             : null,
-        routine != null ? routine.getRoutineDate() : null,
+        routine != null
+            ? RoutineDays.toDays(routine.getRoutineType(), routine.getRoutineDate())
+            : null,
         subTodos);
   }
 }

--- a/src/main/java/plana/replan/domain/todo/dto/TodoUpdateRequestDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoUpdateRequestDto.java
@@ -3,6 +3,7 @@ package plana.replan.domain.todo.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import plana.replan.domain.routine.entity.RoutineType;
@@ -25,9 +26,9 @@ public class TodoUpdateRequestDto {
   private RoutineType routineType;
 
   @Schema(
-      description = "반복 날짜 (WEEKLY: 1-127 비트마스크, MONTHLY: 일자 비트마스크). DAILY는 null",
-      example = "5")
-  private Integer routineDate;
+      description = "반복 날짜 배열 (WEEKLY: 요일 인덱스 월0…일6, MONTHLY: 일자 1~31). DAILY는 null",
+      example = "[0, 2, 4]")
+  private List<Integer> routineDays;
 
   @Schema(description = "반복 시각 (HH:mm:ss). 반복되는 날의 마감 시각. 생략 시 23:59:59로 처리", example = "09:00:00")
   private LocalTime routineTime;

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -15,9 +15,9 @@ import plana.replan.domain.goal.entity.Goal;
 import plana.replan.domain.goal.exception.GoalErrorCode;
 import plana.replan.domain.goal.repository.GoalRepository;
 import plana.replan.domain.routine.entity.Routine;
-import plana.replan.domain.routine.entity.RoutineType;
 import plana.replan.domain.routine.exception.RoutineErrorCode;
 import plana.replan.domain.routine.repository.RoutineRepository;
+import plana.replan.domain.routine.util.RoutineDays;
 import plana.replan.domain.tag.entity.Tag;
 import plana.replan.domain.tag.exception.TagErrorCode;
 import plana.replan.domain.tag.repository.TagRepository;
@@ -291,9 +291,10 @@ public class TodoService {
     if (todo.getRoutine() != null || request.getRoutineType() == null) {
       return;
     }
-    validateRoutineDate(request.getRoutineType(), request.getRoutineDate());
-    Integer routineDate =
-        request.getRoutineType() == RoutineType.DAILY ? null : request.getRoutineDate();
+    if (!RoutineDays.isValid(request.getRoutineType(), request.getRoutineDays())) {
+      throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
+    }
+    Integer routineDate = RoutineDays.toMask(request.getRoutineType(), request.getRoutineDays());
     Routine newRoutine =
         routineRepository.save(
             Routine.builder()
@@ -305,18 +306,6 @@ public class TodoService {
                 .tag(tag)
                 .build());
     todo.updateRoutine(newRoutine);
-  }
-
-  private void validateRoutineDate(RoutineType routineType, Integer routineDate) {
-    if (routineType == RoutineType.WEEKLY) {
-      if (routineDate == null || routineDate < 1 || routineDate > 127) {
-        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
-      }
-    } else if (routineType == RoutineType.MONTHLY) {
-      if (routineDate == null || routineDate < 1) {
-        throw new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE);
-      }
-    }
   }
 
   @Transactional(readOnly = true)

--- a/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
@@ -20,10 +20,10 @@ class ReplanAiServiceTest {
         "operations":[
           {"action":"MODIFY_TODO","targetTodoId":42,"title":"데이터 분석 1~2강",
            "dueDate":"2026-06-08","dueTime":"23:59","tagId":5,
-           "routineType":null,"routineDate":null,
+           "routineType":null,"routineDays":null,
            "changedFields":[{"field":"title","before":"데이터 분석 공부","after":"데이터 분석 1~2강"}]},
           {"action":"ADD","targetTodoId":null,"title":"3~4강","dueDate":"2026-06-09",
-           "dueTime":null,"tagId":null,"routineType":null,"routineDate":null,
+           "dueTime":null,"tagId":null,"routineType":null,"routineDays":null,
            "changedFields":[{"field":"title","before":null,"after":"3~4강"}]}
         ]} 뒤 텍스트
         """;

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -681,7 +681,7 @@ class ReplanServiceTest {
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // DAILY인데 routineDays가 들어와도 저장 시 null로 정규화돼야 한다
+    // DAILY는 반복 날짜가 없으므로(빈 배열) 저장 시 routineDate가 null이어야 한다
     ReplanOperation op =
         new ReplanOperation(
             ReplanAction.CREATE_ROUTINE,
@@ -691,7 +691,7 @@ class ReplanServiceTest {
             "20:00",
             null,
             "DAILY",
-            java.util.List.of(5),
+            java.util.List.of(),
             List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("CONDITION_PAIN"), List.of(op));
 

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -425,7 +425,7 @@ class ReplanServiceTest {
             "11:15",
             null,
             "WEEKLY",
-            62,
+            java.util.List.of(1, 2, 3, 4, 5),
             List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("INTERRUPT_LATE_END"), List.of(op)));
 
@@ -681,10 +681,18 @@ class ReplanServiceTest {
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // DAILY인데 routineDate가 들어와도 저장 시 null로 정규화돼야 한다
+    // DAILY인데 routineDays가 들어와도 저장 시 null로 정규화돼야 한다
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.CREATE_ROUTINE, null, "스트레칭", null, "20:00", null, "DAILY", 5, List.of());
+            ReplanAction.CREATE_ROUTINE,
+            null,
+            "스트레칭",
+            null,
+            "20:00",
+            null,
+            "DAILY",
+            java.util.List.of(5),
+            List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("CONDITION_PAIN"), List.of(op));
 
     replanService.save(1L, req);
@@ -1111,7 +1119,7 @@ class ReplanServiceTest {
   }
 
   @Test
-  void CREATE_ROUTINE_먼슬리인데_routineDate가_1미만이면_400() {
+  void CREATE_ROUTINE_먼슬리인데_routineDays가_비면_400() {
     Todo todo = ownedTodo(42L, 1L);
     given(todoRepository.findById(42L)).willReturn(Optional.of(todo));
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
@@ -1125,7 +1133,7 @@ class ReplanServiceTest {
             null,
             null,
             "MONTHLY",
-            0, // 비트마스크는 1 이상만 유효 (0은 아무 날도 안 켜진 값)
+            java.util.List.of(), // 빈 배열은 유효하지 않음
             List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -102,14 +102,14 @@ class RoutineControllerTest {
         .andExpect(jsonPath("$.data.routineId").value(1))
         .andExpect(jsonPath("$.data.title").value("아침 스트레칭"))
         .andExpect(jsonPath("$.data.routineType").value("DAILY"))
-        .andExpect(jsonPath("$.data.routineDate").value(nullValue()))
+        .andExpect(jsonPath("$.data.routineDays").value(nullValue()))
         .andExpect(jsonPath("$.data.tagId").value(nullValue()))
         .andExpect(jsonPath("$.data.goalId").value(nullValue()))
         .andExpect(jsonPath("$.error").value(nullValue()));
   }
 
   @Test
-  @DisplayName("WEEKLY 루틴 생성 성공 (전체 필드): routineDate=21, tagId/goalId 포함")
+  @DisplayName("WEEKLY 루틴 생성 성공 (전체 필드): routineDays=[0,2,4], tagId/goalId 포함")
   void createRoutine_weekly_success_fullFields() throws Exception {
     LocalDateTime dueDate = LocalDateTime.of(2025, 12, 31, 0, 0);
     given(routineService.createRoutine(any(), any()))
@@ -120,7 +120,7 @@ class RoutineControllerTest {
                 dueDate,
                 null,
                 RoutineType.WEEKLY,
-                21,
+                java.util.List.of(0, 2, 4),
                 5L,
                 null,
                 null,
@@ -143,7 +143,7 @@ class RoutineControllerTest {
                       "title": "영어 단어",
                       "dueDate": "2025-12-31T00:00:00",
                       "routineType": "WEEKLY",
-                      "routineDate": 21,
+                      "routineDays": [0, 2, 4],
                       "tagId": 5,
                       "goalId": 2
                     }
@@ -152,14 +152,14 @@ class RoutineControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.data.routineId").value(2))
         .andExpect(jsonPath("$.data.routineType").value("WEEKLY"))
-        .andExpect(jsonPath("$.data.routineDate").value(21))
+        .andExpect(jsonPath("$.data.routineDays[0]").value(0))
         .andExpect(jsonPath("$.data.tagId").value(5))
         .andExpect(jsonPath("$.data.goalId").value(2))
         .andExpect(jsonPath("$.error").value(nullValue()));
   }
 
   @Test
-  @DisplayName("MONTHLY 루틴 생성 성공: routineDate=15")
+  @DisplayName("MONTHLY 루틴 생성 성공: routineDays=[15]")
   void createRoutine_monthly_success() throws Exception {
     given(routineService.createRoutine(any(), any()))
         .willReturn(
@@ -169,7 +169,7 @@ class RoutineControllerTest {
                 null,
                 null,
                 RoutineType.MONTHLY,
-                15,
+                java.util.List.of(15),
                 null,
                 null,
                 null,
@@ -188,11 +188,11 @@ class RoutineControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
-                    { "title": "월간 회고", "routineType": "MONTHLY", "routineDate": 15 }
+                    { "title": "월간 회고", "routineType": "MONTHLY", "routineDays": [15] }
                     """))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.data.routineType").value("MONTHLY"))
-        .andExpect(jsonPath("$.data.routineDate").value(15));
+        .andExpect(jsonPath("$.data.routineDays[0]").value(15));
   }
 
   @Test
@@ -262,7 +262,7 @@ class RoutineControllerTest {
   }
 
   @Test
-  @DisplayName("routineDate 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
+  @DisplayName("routineDays 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
   void createRoutine_invalidRoutineDate() throws Exception {
     willThrow(new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE))
         .given(routineService)
@@ -275,7 +275,7 @@ class RoutineControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
-                    { "title": "루틴", "routineType": "WEEKLY", "routineDate": 128 }
+                    { "title": "루틴", "routineType": "WEEKLY", "routineDays": [7] }
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.status").value(400))
@@ -373,7 +373,7 @@ class RoutineControllerTest {
                 dueDate,
                 null,
                 RoutineType.WEEKLY,
-                21,
+                java.util.List.of(0, 2, 4),
                 5L,
                 "영어",
                 "BLUE",
@@ -396,7 +396,7 @@ class RoutineControllerTest {
                       "title": "수정된 루틴",
                       "dueDate": "2025-12-31T00:00:00",
                       "routineType": "WEEKLY",
-                      "routineDate": 21,
+                      "routineDays": [0, 2, 4],
                       "tagId": 5
                     }
                     """))
@@ -404,7 +404,7 @@ class RoutineControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.data.title").value("수정된 루틴"))
         .andExpect(jsonPath("$.data.routineType").value("WEEKLY"))
-        .andExpect(jsonPath("$.data.routineDate").value(21))
+        .andExpect(jsonPath("$.data.routineDays[0]").value(0))
         .andExpect(jsonPath("$.data.tagId").value(5))
         .andExpect(jsonPath("$.error").value(nullValue()));
   }
@@ -430,7 +430,7 @@ class RoutineControllerTest {
   }
 
   @Test
-  @DisplayName("routineDate 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
+  @DisplayName("routineDays 범위 오류: status=400, error.code=ROUTINE_INVALID_DATE")
   void updateMotherRoutine_invalidRoutineDate() throws Exception {
     willThrow(new CustomException(RoutineErrorCode.ROUTINE_INVALID_DATE))
         .given(routineService)
@@ -443,7 +443,7 @@ class RoutineControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
-                    { "title": "수정", "routineType": "WEEKLY", "routineDate": 128 }
+                    { "title": "수정", "routineType": "WEEKLY", "routineDays": [7] }
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("ROUTINE_INVALID_DATE"));

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -176,24 +176,26 @@ class RoutineServiceTest {
 
     assertThat(result.getTitle()).isEqualTo("아침 스트레칭");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
-    assertThat(result.getRoutineDate()).isNull();
+    assertThat(result.getRoutineDays()).isNull();
     assertThat(result.getTagId()).isNull();
     assertThat(result.getGoalId()).isNull();
     assertThat(result.getDueDate()).isNull();
   }
 
   @Test
-  void 루틴_생성_DAILY_routineDate_무시됨() {
+  void 루틴_생성_DAILY_routineDays_무시됨() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // DAILY에서 routineDate=999를 넘겨도 null로 정규화되어 저장됨
+    // DAILY에서 routineDays를 넘겨도 null로 정규화되어 저장됨
     RoutineResponseDto result =
         routineService.createRoutine(
-            1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.DAILY, 999, null, null));
+            1L,
+            new RoutineCreateRequestDto(
+                "루틴", null, null, RoutineType.DAILY, List.of(3), null, null));
 
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
-    assertThat(result.getRoutineDate()).isNull();
+    assertThat(result.getRoutineDays()).isNull();
   }
 
   // ========== WEEKLY ==========
@@ -209,42 +211,47 @@ class RoutineServiceTest {
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
-            new RoutineCreateRequestDto("영어 단어", dueDate, null, RoutineType.WEEKLY, 21, 5L, 2L));
+            new RoutineCreateRequestDto(
+                "영어 단어", dueDate, null, RoutineType.WEEKLY, List.of(0, 2, 4), 5L, 2L));
 
     assertThat(result.getTitle()).isEqualTo("영어 단어");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
-    assertThat(result.getRoutineDate()).isEqualTo(21);
+    assertThat(result.getRoutineDays()).containsExactly(0, 2, 4);
     assertThat(result.getDueDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
     assertThat(result.getGoalId()).isEqualTo(2L);
   }
 
   @Test
-  void 루틴_생성_WEEKLY_routineDate_경계값_1_성공() {
+  void 루틴_생성_WEEKLY_routineDays_월요일_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     RoutineResponseDto result =
         routineService.createRoutine(
-            1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, 1, null, null));
+            1L,
+            new RoutineCreateRequestDto(
+                "루틴", null, null, RoutineType.WEEKLY, List.of(0), null, null));
 
-    assertThat(result.getRoutineDate()).isEqualTo(1);
+    assertThat(result.getRoutineDays()).containsExactly(0);
   }
 
   @Test
-  void 루틴_생성_WEEKLY_routineDate_경계값_127_성공() {
+  void 루틴_생성_WEEKLY_routineDays_전체요일_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     RoutineResponseDto result =
         routineService.createRoutine(
-            1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, 127, null, null));
+            1L,
+            new RoutineCreateRequestDto(
+                "루틴", null, null, RoutineType.WEEKLY, List.of(0, 1, 2, 3, 4, 5, 6), null, null));
 
-    assertThat(result.getRoutineDate()).isEqualTo(127);
+    assertThat(result.getRoutineDays()).containsExactly(0, 1, 2, 3, 4, 5, 6);
   }
 
   @Test
-  void 루틴_생성_WEEKLY_routineDate_null이면_400() {
+  void 루틴_생성_WEEKLY_routineDays_null이면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -263,7 +270,7 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_WEEKLY_routineDate_0이면_400() {
+  void 루틴_생성_WEEKLY_routineDays_빈배열이면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -271,7 +278,7 @@ class RoutineServiceTest {
                 routineService.createRoutine(
                     1L,
                     new RoutineCreateRequestDto(
-                        "루틴", null, null, RoutineType.WEEKLY, 0, null, null)))
+                        "루틴", null, null, RoutineType.WEEKLY, List.of(), null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -280,7 +287,7 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_WEEKLY_routineDate_128이면_400() {
+  void 루틴_생성_WEEKLY_routineDays_범위밖이면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -288,7 +295,7 @@ class RoutineServiceTest {
                 routineService.createRoutine(
                     1L,
                     new RoutineCreateRequestDto(
-                        "루틴", null, null, RoutineType.WEEKLY, 128, null, null)))
+                        "루틴", null, null, RoutineType.WEEKLY, List.of(7), null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -303,43 +310,43 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // routineDate는 일자 비트마스크. 15일 = 1 << 14 = 16384 (숫자 15가 아님)
+    // routineDays는 일자 배열. 15일 = [15]
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
             new RoutineCreateRequestDto(
-                "월간 회고", null, null, RoutineType.MONTHLY, 1 << 14, null, null));
+                "월간 회고", null, null, RoutineType.MONTHLY, List.of(15), null, null));
 
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.MONTHLY);
-    assertThat(result.getRoutineDate()).isEqualTo(16384);
+    assertThat(result.getRoutineDays()).containsExactly(15);
   }
 
   @Test
-  void 루틴_생성_MONTHLY_비트마스크_최솟값_1일_성공() {
+  void 루틴_생성_MONTHLY_1일_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // 1일 = 1 << 0 = 1 (비트마스크 최솟값)
-    RoutineResponseDto result =
-        routineService.createRoutine(
-            1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1, null, null));
-
-    assertThat(result.getRoutineDate()).isEqualTo(1);
-  }
-
-  @Test
-  void 루틴_생성_MONTHLY_비트마스크_31일_성공() {
-    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
-    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
-
-    // 31일 = 1 << 30 = 1073741824 (숫자 31이 아님)
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
             new RoutineCreateRequestDto(
-                "루틴", null, null, RoutineType.MONTHLY, 1 << 30, null, null));
+                "루틴", null, null, RoutineType.MONTHLY, List.of(1), null, null));
 
-    assertThat(result.getRoutineDate()).isEqualTo(1073741824);
+    assertThat(result.getRoutineDays()).containsExactly(1);
+  }
+
+  @Test
+  void 루틴_생성_MONTHLY_31일_성공() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RoutineResponseDto result =
+        routineService.createRoutine(
+            1L,
+            new RoutineCreateRequestDto(
+                "루틴", null, null, RoutineType.MONTHLY, List.of(31), null, null));
+
+    assertThat(result.getRoutineDays()).containsExactly(31);
   }
 
   @Test
@@ -360,7 +367,7 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_MONTHLY_routineDate_0이면_400() {
+  void 루틴_생성_MONTHLY_빈배열이면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -368,7 +375,7 @@ class RoutineServiceTest {
                 routineService.createRoutine(
                     1L,
                     new RoutineCreateRequestDto(
-                        "루틴", null, null, RoutineType.MONTHLY, 0, null, null)))
+                        "루틴", null, null, RoutineType.MONTHLY, List.of(), null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -381,18 +388,17 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // 3일·20일 = 비트(2) + 비트(19) = 4 + 524288 = 524292
-    int mask = (1 << 2) | (1 << 19);
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
-            new RoutineCreateRequestDto("월 2회", null, null, RoutineType.MONTHLY, mask, null, null));
+            new RoutineCreateRequestDto(
+                "월 2회", null, null, RoutineType.MONTHLY, List.of(3, 20), null, null));
 
-    assertThat(result.getRoutineDate()).isEqualTo(524292);
+    assertThat(result.getRoutineDays()).containsExactly(3, 20);
   }
 
   @Test
-  void 루틴_생성_MONTHLY_routineDate_음수면_400() {
+  void 루틴_생성_MONTHLY_범위밖이면_400() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
 
     assertThatThrownBy(
@@ -400,7 +406,7 @@ class RoutineServiceTest {
                 routineService.createRoutine(
                     1L,
                     new RoutineCreateRequestDto(
-                        "루틴", null, null, RoutineType.MONTHLY, -1, null, null)))
+                        "루틴", null, null, RoutineType.MONTHLY, List.of(32), null, null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -466,24 +472,26 @@ class RoutineServiceTest {
 
   @Test
   void 루틴_생성_WEEKLY_오늘_요일_포함_Todo_생성됨() {
-    // TEST_DATE = Monday(bit=1). routineDate=1 → Monday만 포함 → 일치
+    // TEST_DATE = Monday. routineDays=[0] → 월요일만 포함 → 일치
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
-        1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, 1, null, null));
+        1L,
+        new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, List.of(0), null, null));
 
     verify(todoRepository).saveAndFlush(any(Todo.class));
   }
 
   @Test
   void 루틴_생성_WEEKLY_오늘_요일_미포함이어도_Todo_즉시_생성되고_다음_반복일이_dueDate() {
-    // TEST_DATE = 2024-01-15(Mon). routineDate=2 → Tuesday만 → 다음 발생 = 2024-01-16
+    // TEST_DATE = 2024-01-15(Mon). routineDays=[1] → 화요일만 → 다음 발생 = 2024-01-16
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
-        1L, new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, 2, null, null));
+        1L,
+        new RoutineCreateRequestDto("루틴", null, null, RoutineType.WEEKLY, List.of(1), null, null));
 
     ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
     verify(todoRepository).saveAndFlush(captor.capture());
@@ -493,26 +501,28 @@ class RoutineServiceTest {
 
   @Test
   void 루틴_생성_MONTHLY_오늘_날짜_일치_Todo_생성됨() {
-    // TEST_DATE = 15일. routineDate=15일 비트(1<<14=16384) → 일치
+    // TEST_DATE = 15일. routineDays=[15] → 일치
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L,
-        new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1 << 14, null, null));
+        new RoutineCreateRequestDto(
+            "루틴", null, null, RoutineType.MONTHLY, List.of(15), null, null));
 
     verify(todoRepository).saveAndFlush(any(Todo.class));
   }
 
   @Test
   void 루틴_생성_MONTHLY_오늘_날짜_불일치여도_Todo_즉시_생성되고_다음_반복일이_dueDate() {
-    // TEST_DATE = 2024-01-15. routineDate=16일 비트(1<<15=32768) → 다음 발생 = 2024-01-16
+    // TEST_DATE = 2024-01-15. routineDays=[16] → 다음 발생 = 2024-01-16
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
     routineService.createRoutine(
         1L,
-        new RoutineCreateRequestDto("루틴", null, null, RoutineType.MONTHLY, 1 << 15, null, null));
+        new RoutineCreateRequestDto(
+            "루틴", null, null, RoutineType.MONTHLY, List.of(16), null, null));
 
     ArgumentCaptor<Todo> captor = ArgumentCaptor.forClass(Todo.class);
     verify(todoRepository).saveAndFlush(captor.capture());
@@ -682,7 +692,7 @@ class RoutineServiceTest {
 
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
-    assertThat(result.getRoutineDate()).isNull();
+    assertThat(result.getRoutineDays()).isNull();
     assertThat(result.getDueDate()).isNull();
     assertThat(result.getTagId()).isNull();
   }
@@ -698,11 +708,12 @@ class RoutineServiceTest {
         routineService.updateMotherRoutine(
             1L,
             10L,
-            new RoutineUpdateRequestDto("수정된 루틴", dueDate, null, RoutineType.WEEKLY, 21, 5L));
+            new RoutineUpdateRequestDto(
+                "수정된 루틴", dueDate, null, RoutineType.WEEKLY, List.of(0, 2, 4), 5L));
 
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
-    assertThat(result.getRoutineDate()).isEqualTo(21);
+    assertThat(result.getRoutineDays()).containsExactly(0, 2, 4);
     assertThat(result.getDueDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
   }
@@ -730,7 +741,7 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 엄마루틴_수정_routineDate_범위오류_400() {
+  void 엄마루틴_수정_routineDays_범위오류_400() {
     Routine routine = motherRoutine();
     given(routineRepository.findById(10L)).willReturn(Optional.of(routine));
 
@@ -739,7 +750,8 @@ class RoutineServiceTest {
                 routineService.updateMotherRoutine(
                     1L,
                     10L,
-                    new RoutineUpdateRequestDto("수정", null, null, RoutineType.WEEKLY, 128, null)))
+                    new RoutineUpdateRequestDto(
+                        "수정", null, null, RoutineType.WEEKLY, List.of(7), null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -183,19 +183,37 @@ class RoutineServiceTest {
   }
 
   @Test
-  void 루틴_생성_DAILY_routineDays_무시됨() {
+  void 루틴_생성_DAILY_빈배열이면_성공() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     given(routineRepository.save(any(Routine.class))).willAnswer(inv -> inv.getArgument(0));
 
-    // DAILY에서 routineDays를 넘겨도 null로 정규화되어 저장됨
+    // DAILY는 빈 배열을 넘겨도(=반복 날짜 없음) null로 저장된다.
     RoutineResponseDto result =
         routineService.createRoutine(
             1L,
             new RoutineCreateRequestDto(
-                "루틴", null, null, RoutineType.DAILY, List.of(3), null, null));
+                "루틴", null, null, RoutineType.DAILY, List.of(), null, null));
 
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
     assertThat(result.getRoutineDays()).isNull();
+  }
+
+  @Test
+  void 루틴_생성_DAILY_routineDays_있으면_400() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    // DAILY는 반복 날짜가 없어야 한다. 값이 채워져 오면 잘못된 요청으로 400.
+    assertThatThrownBy(
+            () ->
+                routineService.createRoutine(
+                    1L,
+                    new RoutineCreateRequestDto(
+                        "루틴", null, null, RoutineType.DAILY, List.of(3), null, null)))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(RoutineErrorCode.ROUTINE_INVALID_DATE));
   }
 
   // ========== WEEKLY ==========

--- a/src/test/java/plana/replan/domain/routine/util/RoutineDaysTest.java
+++ b/src/test/java/plana/replan/domain/routine/util/RoutineDaysTest.java
@@ -1,0 +1,79 @@
+package plana.replan.domain.routine.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import plana.replan.domain.routine.entity.RoutineType;
+
+class RoutineDaysTest {
+
+  @Test
+  @DisplayName("WEEKLY 배열 → 비트마스크 (월0…일6 → 비트 index)")
+  void weeklyToMask() {
+    // 월·수·금 = [0,2,4] → 1 + 4 + 16 = 21
+    assertThat(RoutineDays.toMask(RoutineType.WEEKLY, List.of(0, 2, 4))).isEqualTo(21);
+    // 일요일 = [6] → 1<<6 = 64
+    assertThat(RoutineDays.toMask(RoutineType.WEEKLY, List.of(6))).isEqualTo(64);
+  }
+
+  @Test
+  @DisplayName("WEEKLY 비트마스크 → 배열")
+  void weeklyToDays() {
+    assertThat(RoutineDays.toDays(RoutineType.WEEKLY, 21)).containsExactly(0, 2, 4);
+    assertThat(RoutineDays.toDays(RoutineType.WEEKLY, 64)).containsExactly(6);
+  }
+
+  @Test
+  @DisplayName("MONTHLY 배열 → 비트마스크 (일자 d → 비트 d-1)")
+  void monthlyToMask() {
+    // 15일 = [15] → 1<<14 = 16384
+    assertThat(RoutineDays.toMask(RoutineType.MONTHLY, List.of(15))).isEqualTo(16384);
+    // 3·20일 = [3,20] → (1<<2)+(1<<19) = 4 + 524288 = 524292
+    assertThat(RoutineDays.toMask(RoutineType.MONTHLY, List.of(3, 20))).isEqualTo(524292);
+    // 31일 = [31] → 1<<30 = 1073741824
+    assertThat(RoutineDays.toMask(RoutineType.MONTHLY, List.of(31))).isEqualTo(1073741824);
+  }
+
+  @Test
+  @DisplayName("MONTHLY 비트마스크 → 배열")
+  void monthlyToDays() {
+    assertThat(RoutineDays.toDays(RoutineType.MONTHLY, 16384)).containsExactly(15);
+    assertThat(RoutineDays.toDays(RoutineType.MONTHLY, 524292)).containsExactly(3, 20);
+  }
+
+  @Test
+  @DisplayName("배열↔비트마스크 왕복 변환이 일치한다")
+  void roundTrip() {
+    List<Integer> weekly = List.of(0, 3, 6);
+    assertThat(
+            RoutineDays.toDays(RoutineType.WEEKLY, RoutineDays.toMask(RoutineType.WEEKLY, weekly)))
+        .isEqualTo(weekly);
+    List<Integer> monthly = List.of(1, 15, 31);
+    assertThat(
+            RoutineDays.toDays(
+                RoutineType.MONTHLY, RoutineDays.toMask(RoutineType.MONTHLY, monthly)))
+        .isEqualTo(monthly);
+  }
+
+  @Test
+  @DisplayName("DAILY는 항상 null (배열 무시)")
+  void dailyIsNull() {
+    assertThat(RoutineDays.toMask(RoutineType.DAILY, List.of(1, 2))).isNull();
+    assertThat(RoutineDays.toDays(RoutineType.DAILY, 21)).isNull();
+    assertThat(RoutineDays.isValid(RoutineType.DAILY, null)).isTrue();
+  }
+
+  @Test
+  @DisplayName("유효성: WEEKLY는 0~6, MONTHLY는 1~31, 비어있으면 무효")
+  void validity() {
+    assertThat(RoutineDays.isValid(RoutineType.WEEKLY, List.of(0, 6))).isTrue();
+    assertThat(RoutineDays.isValid(RoutineType.WEEKLY, List.of(7))).isFalse(); // 범위 밖
+    assertThat(RoutineDays.isValid(RoutineType.WEEKLY, List.of())).isFalse(); // 빈 배열
+    assertThat(RoutineDays.isValid(RoutineType.WEEKLY, null)).isFalse(); // null
+    assertThat(RoutineDays.isValid(RoutineType.MONTHLY, List.of(1, 31))).isTrue();
+    assertThat(RoutineDays.isValid(RoutineType.MONTHLY, List.of(0))).isFalse(); // 0은 무효
+    assertThat(RoutineDays.isValid(RoutineType.MONTHLY, List.of(32))).isFalse(); // 32 무효
+  }
+}

--- a/src/test/java/plana/replan/domain/routine/util/RoutineDaysTest.java
+++ b/src/test/java/plana/replan/domain/routine/util/RoutineDaysTest.java
@@ -58,11 +58,14 @@ class RoutineDaysTest {
   }
 
   @Test
-  @DisplayName("DAILY는 항상 null (배열 무시)")
+  @DisplayName("DAILY는 null 또는 빈 배열만 허용한다")
   void dailyIsNull() {
-    assertThat(RoutineDays.toMask(RoutineType.DAILY, List.of(1, 2))).isNull();
+    assertThat(RoutineDays.toMask(RoutineType.DAILY, null)).isNull();
+    assertThat(RoutineDays.toMask(RoutineType.DAILY, List.of())).isNull();
     assertThat(RoutineDays.toDays(RoutineType.DAILY, 21)).isNull();
     assertThat(RoutineDays.isValid(RoutineType.DAILY, null)).isTrue();
+    assertThat(RoutineDays.isValid(RoutineType.DAILY, List.of())).isTrue();
+    assertThat(RoutineDays.isValid(RoutineType.DAILY, List.of(1, 2))).isFalse();
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/plana/replan/domain/todo/controller/TodoControllerTest.java
@@ -980,7 +980,16 @@ class TodoControllerTest {
   void updateTodo_success() throws Exception {
     TodoDetailResponseDto response =
         new TodoDetailResponseDto(
-            1L, "수정된 제목", null, false, 3L, "영어", "BLUE", "WEEKLY", 5, List.of());
+            1L,
+            "수정된 제목",
+            null,
+            false,
+            3L,
+            "영어",
+            "BLUE",
+            "WEEKLY",
+            java.util.List.of(0, 2),
+            List.of());
 
     given(todoService.updateTodo(any(), any(), any())).willReturn(response);
 
@@ -991,7 +1000,7 @@ class TodoControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
-                    { "title": "수정된 제목", "tagId": 3, "routineType": "WEEKLY", "routineDate": 5 }
+                    { "title": "수정된 제목", "tagId": 3, "routineType": "WEEKLY", "routineDays": [0, 2] }
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value(200))
@@ -1099,7 +1108,7 @@ class TodoControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
-                    { "title": "수정된 제목", "routineType": "WEEKLY", "routineDate": 200 }
+                    { "title": "수정된 제목", "routineType": "WEEKLY", "routineDays": [7] }
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("ROUTINE_INVALID_DATE"))

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -1463,13 +1463,13 @@ class TodoServiceTest {
       LocalDateTime dueDate,
       Long tagId,
       RoutineType routineType,
-      Integer routineDate) {
+      java.util.List<Integer> routineDays) {
     TodoUpdateRequestDto dto = new TodoUpdateRequestDto();
     ReflectionTestUtils.setField(dto, "title", title);
     ReflectionTestUtils.setField(dto, "dueDate", dueDate);
     ReflectionTestUtils.setField(dto, "tagId", tagId);
     ReflectionTestUtils.setField(dto, "routineType", routineType);
-    ReflectionTestUtils.setField(dto, "routineDate", routineDate);
+    ReflectionTestUtils.setField(dto, "routineDays", routineDays);
     return dto;
   }
 
@@ -1546,7 +1546,7 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - WEEKLY + routineDate > 127: ROUTINE_INVALID_DATE 예외")
+  @DisplayName("updateTodo - WEEKLY + 범위밖 요일: ROUTINE_INVALID_DATE 예외")
   void updateTodo_weeklyInvalidDate_throws() {
     User user = testUser();
     given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo(1L, user)));
@@ -1554,7 +1554,9 @@ class TodoServiceTest {
     assertThatThrownBy(
             () ->
                 todoService.updateTodo(
-                    1L, 1L, updateTodoRequest("제목", null, null, RoutineType.WEEKLY, 128)))
+                    1L,
+                    1L,
+                    updateTodoRequest("제목", null, null, RoutineType.WEEKLY, java.util.List.of(7))))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -1563,7 +1565,7 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - MONTHLY + routineDate = 0: ROUTINE_INVALID_DATE 예외")
+  @DisplayName("updateTodo - MONTHLY + 빈 배열: ROUTINE_INVALID_DATE 예외")
   void updateTodo_monthlyInvalidDate_throws() {
     User user = testUser();
     given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo(1L, user)));
@@ -1571,7 +1573,9 @@ class TodoServiceTest {
     assertThatThrownBy(
             () ->
                 todoService.updateTodo(
-                    1L, 1L, updateTodoRequest("제목", null, null, RoutineType.MONTHLY, 0)))
+                    1L,
+                    1L,
+                    updateTodoRequest("제목", null, null, RoutineType.MONTHLY, java.util.List.of())))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -1580,7 +1584,7 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - MONTHLY + 여러 날짜 비트마스크(524292): 루틴 생성 성공")
+  @DisplayName("updateTodo - MONTHLY + 여러 날짜 [3,20]: 루틴 생성 성공")
   void updateTodo_monthlyBitmask_success() {
     User user = testUser();
     given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo(1L, user)));
@@ -1588,7 +1592,7 @@ class TodoServiceTest {
 
     // 3일·20일 = (1<<2)|(1<<19) = 524292 → 31 초과지만 유효한 비트마스크
     todoService.updateTodo(
-        1L, 1L, updateTodoRequest("제목", null, null, RoutineType.MONTHLY, 524292));
+        1L, 1L, updateTodoRequest("제목", null, null, RoutineType.MONTHLY, java.util.List.of(3, 20)));
 
     ArgumentCaptor<Routine> captor = ArgumentCaptor.forClass(Routine.class);
     verify(routineRepository).save(captor.capture());
@@ -1596,7 +1600,7 @@ class TodoServiceTest {
   }
 
   @Test
-  @DisplayName("updateTodo - WEEKLY + routineDate null: ROUTINE_INVALID_DATE 예외")
+  @DisplayName("updateTodo - WEEKLY + routineDays null: ROUTINE_INVALID_DATE 예외")
   void updateTodo_weeklyNullDate_throws() {
     User user = testUser();
     given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo(1L, user)));
@@ -1604,7 +1608,10 @@ class TodoServiceTest {
     assertThatThrownBy(
             () ->
                 todoService.updateTodo(
-                    1L, 1L, updateTodoRequest("제목", null, null, RoutineType.WEEKLY, null)))
+                    1L,
+                    1L,
+                    updateTodoRequest(
+                        "제목", null, null, RoutineType.WEEKLY, (java.util.List<Integer>) null)))
         .isInstanceOf(CustomException.class)
         .satisfies(
             e ->
@@ -1709,7 +1716,9 @@ class TodoServiceTest {
 
     TodoDetailResponseDto result =
         todoService.updateTodo(
-            1L, 1L, updateTodoRequest("제목", null, null, RoutineType.DAILY, null));
+            1L,
+            1L,
+            updateTodoRequest("제목", null, null, RoutineType.DAILY, (java.util.List<Integer>) null));
 
     ArgumentCaptor<Routine> captor = ArgumentCaptor.forClass(Routine.class);
     verify(routineRepository).save(captor.capture());


### PR DESCRIPTION
## 변경 사항
반복 루틴의 반복 날짜를 비트마스크 정수(`routineDate`) 대신 **숫자 배열(`routineDays`)** 로 주고받도록 바꿨습니다. (#245, #246)

- WEEKLY: 요일 인덱스 배열(월=0 … 일=6), MONTHLY: 일자 배열(1~31), DAILY: null 또는 빈 배열
- 서버 내부 저장은 그대로 비트마스크 — 요청 수신/응답 생성 경계에서만 변환
- DAILY에 값이 채워져 오면 400으로 막음 (조용히 버리지 않음)
- AI 추천/리플랜 파싱·프롬프트, Swagger 문서 전부 반영

## 테스트 결과
- CI 빌드(JDK17, Spotless) 통과, CodeRabbit 리뷰 반영 완료
- 로컬 API 전수 테스트 통과(WEEKLY/MONTHLY/DAILY, 잘못된 값 400)