### PR TITLE
Feat: GET /api/routines/pinned 추가 및 루틴-투두 API 분리

### DIFF
--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -35,6 +35,13 @@ public class RoutineController implements RoutineControllerDocs {
   private final RoutineService routineService;
 
   @Override
+  @GetMapping("/pinned")
+  public ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getPinnedRoutines(
+      @AuthenticationPrincipal Long userId) {
+    return ResponseEntity.ok(ApiResult.ok(routineService.getPinnedRoutines(userId)));
+  }
+
+  @Override
   @GetMapping
   public ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getRoutinesByFilter(
       @AuthenticationPrincipal Long userId,

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -28,6 +28,133 @@ import plana.replan.global.common.ApiResult;
 public interface RoutineControllerDocs {
 
   @Operation(
+      summary = "핀된 루틴 인스턴스 조회",
+      description =
+          """
+          핀(pin) 처리된 모든 루틴 인스턴스를 날짜별로 묶어 반환합니다.
+
+          - override의 `isPinned = true`인 인스턴스를 날짜 오름차순으로 반환합니다.
+          - 건너뜀(`isSkipped = true`) 처리된 인스턴스는 포함되지 않습니다.
+          - 과거·현재·미래 날짜 모두 포함됩니다.
+          - 응답 구조는 `GET /api/routines`와 동일하게 날짜(yyyy-MM-dd) → 루틴 배열 형태입니다.
+
+          ---
+
+          ### Request Headers
+
+          | 헤더명 | 필수 여부 | 타입 | 설명 |
+          |--------|-----------|------|------|
+          | Authorization | ✅ 필수 | string | `Bearer {accessToken}` 형식의 JWT 액세스 토큰 |
+
+          ---
+
+          ### Response Elements
+
+          응답 `data`는 날짜(yyyy-MM-dd)를 키로 하는 객체이며, 값은 해당 날짜의 핀된 루틴 배열입니다.
+          각 항목의 필드는 `GET /api/routines` 응답과 동일합니다.
+          """,
+      security = @SecurityRequirement(name = "Bearer Authentication"))
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 200,
+                              "success": true,
+                              "data": {
+                                "2025-06-20": [
+                                  {
+                                    "routineId": 1,
+                                    "title": "아침 스트레칭",
+                                    "dueDate": "2025-06-20T08:00:00",
+                                    "repeatEndDate": null,
+                                    "routineTime": "08:00:00",
+                                    "routineType": "DAILY",
+                                    "routineDays": null,
+                                    "tagId": null,
+                                    "tagTitle": null,
+                                    "tagColor": null,
+                                    "goalId": null,
+                                    "todoId": 42,
+                                    "sortOrder": 10000.0,
+                                    "isPinned": true,
+                                    "isCompleted": false,
+                                    "isOverdue": true,
+                                    "hasOverride": true
+                                  }
+                                ]
+                              },
+                              "error": null
+                            }
+                            """))),
+    @ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 — 토큰 없음 또는 만료",
+        content =
+            @Content(
+                examples = {
+                  @ExampleObject(
+                      name = "토큰 없음",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EMPTY_TOKEN",
+                              "message": "토큰이 없습니다.",
+                              "detail": null
+                            }
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "만료된 토큰",
+                      value =
+                          """
+                          {
+                            "status": 401,
+                            "success": false,
+                            "data": null,
+                            "error": {
+                              "code": "EXPIRED_TOKEN",
+                              "message": "만료된 토큰입니다.",
+                              "detail": null
+                            }
+                          }
+                          """)
+                })),
+    @ApiResponse(
+        responseCode = "404",
+        description = "유저를 찾을 수 없음",
+        content =
+            @Content(
+                examples =
+                    @ExampleObject(
+                        value =
+                            """
+                            {
+                              "status": 404,
+                              "success": false,
+                              "data": null,
+                              "error": {
+                                "code": "USER_NOT_FOUND",
+                                "message": "유저를 찾을 수 없습니다.",
+                                "detail": null
+                              }
+                            }
+                            """)))
+  })
+  ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getPinnedRoutines(
+      @AuthenticationPrincipal Long userId);
+
+  @Operation(
       summary = "루틴 조회 (날짜 / 주간 / 월간)",
       description =
           """
@@ -70,16 +197,22 @@ public interface RoutineControllerDocs {
           | 필드명 | 타입 | 설명 |
           |--------|------|------|
           | routineId | integer | 루틴 ID |
-          | title | string | 루틴 제목 |
-          | dueDate | string | 반복 종료 마감일 (ISO 8601 형식). 없으면 null |
+          | title | string | 루틴 제목 (override 적용값) |
+          | dueDate | string | 해당 날짜 인스턴스 마감 일시 (ISO 8601 형식). instanceDate + routineTime (없으면 23:59:59) |
+          | repeatEndDate | string | 반복 종료 마감일 (ISO 8601 형식). 없으면 null |
           | routineTime | string | 마감 시각 (HH:mm:ss 형식). 없으면 null |
           | routineType | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) |
-          | routineDays | integer | 반복 날짜 배열. DAILY는 null, WEEKLY는 요일 인덱스(월0…일6), MONTHLY는 일자(1~31) |
-          | tagId | integer | 태그 ID. 없으면 null |
+          | routineDays | array | 반복 날짜 배열. DAILY는 null, WEEKLY는 요일 인덱스(월0…일6), MONTHLY는 일자(1~31) |
+          | tagId | integer | 태그 ID (override 적용값). 없으면 null |
           | tagTitle | string | 태그 제목. 없으면 null |
           | tagColor | string | 태그 색상. 없으면 null |
           | goalId | integer | 목표 ID. 없으면 null |
           | todoId | integer | 해당 날짜에 생성된 Todo ID. 아직 생성 안 됐으면 null |
+          | sortOrder | number | 해당 날짜 인스턴스의 정렬 순서 |
+          | isPinned | boolean | 해당 날짜 핀 여부 |
+          | isCompleted | boolean | 해당 날짜 완료 여부 |
+          | isOverdue | boolean | 마감 시각이 지났고 미완료인 경우 true |
+          | hasOverride | boolean | override 존재 여부 |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
@@ -100,7 +233,8 @@ public interface RoutineControllerDocs {
                                   {
                                     "routineId": 1,
                                     "title": "아침 스트레칭",
-                                    "dueDate": null,
+                                    "dueDate": "2025-06-20T08:00:00",
+                                    "repeatEndDate": null,
                                     "routineTime": "08:00:00",
                                     "routineType": "DAILY",
                                     "routineDays": null,
@@ -108,14 +242,20 @@ public interface RoutineControllerDocs {
                                     "tagTitle": null,
                                     "tagColor": null,
                                     "goalId": null,
-                                    "todoId": 42
+                                    "todoId": 42,
+                                    "sortOrder": 10000.0,
+                                    "isPinned": false,
+                                    "isCompleted": false,
+                                    "isOverdue": false,
+                                    "hasOverride": false
                                   }
                                 ],
                                 "2025-06-21": [
                                   {
                                     "routineId": 1,
                                     "title": "아침 스트레칭",
-                                    "dueDate": null,
+                                    "dueDate": "2025-06-21T08:00:00",
+                                    "repeatEndDate": null,
                                     "routineTime": "08:00:00",
                                     "routineType": "DAILY",
                                     "routineDays": null,
@@ -123,12 +263,18 @@ public interface RoutineControllerDocs {
                                     "tagTitle": null,
                                     "tagColor": null,
                                     "goalId": null,
-                                    "todoId": null
+                                    "todoId": null,
+                                    "sortOrder": 10000.0,
+                                    "isPinned": false,
+                                    "isCompleted": false,
+                                    "isOverdue": false,
+                                    "hasOverride": false
                                   },
                                   {
                                     "routineId": 2,
                                     "title": "영어 단어 외우기",
-                                    "dueDate": "2025-12-31T00:00:00",
+                                    "dueDate": "2025-06-21T09:00:00",
+                                    "repeatEndDate": "2025-12-31T00:00:00",
                                     "routineTime": "09:00:00",
                                     "routineType": "WEEKLY",
                                     "routineDays": [0, 2, 4],
@@ -136,7 +282,12 @@ public interface RoutineControllerDocs {
                                     "tagTitle": "영어",
                                     "tagColor": "BLUE",
                                     "goalId": 2,
-                                    "todoId": 43
+                                    "todoId": 43,
+                                    "sortOrder": 20000.0,
+                                    "isPinned": false,
+                                    "isCompleted": false,
+                                    "isOverdue": false,
+                                    "hasOverride": false
                                   }
                                 ]
                               },

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideController.java
@@ -92,12 +92,12 @@ public class RoutineOverrideController implements RoutineOverrideControllerDocs 
   }
 
   @Override
-  @PatchMapping("/{routineId}/overrides/{date}/unskip")
-  public ResponseEntity<ApiResult<Void>> unskip(
+  @PatchMapping("/{routineId}/overrides/{date}/undo")
+  public ResponseEntity<ApiResult<Void>> undo(
       @AuthenticationPrincipal Long userId,
       @PathVariable Long routineId,
       @PathVariable LocalDate date) {
-    routineOverrideService.unskip(userId, routineId, date);
+    routineOverrideService.undo(userId, routineId, date);
     return ResponseEntity.ok(ApiResult.ok(null));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineOverrideControllerDocs.java
@@ -331,7 +331,7 @@ public interface RoutineOverrideControllerDocs {
 
           - 이미 배치로 Todo가 생성된 날짜라면 해당 Todo를 soft delete 한다.
           - 이미 완료된 Todo가 있는 날짜는 건너뜀 처리할 수 없다 (400).
-          - 건너뜀을 취소하려면 `PATCH /api/routines/{routineId}/overrides/{date}/unskip`을 호출한다.
+          - 건너뜀을 취소하려면 `PATCH /api/routines/{routineId}/overrides/{date}/undo`을 호출한다.
 
           ### Path Variables
 
@@ -373,13 +373,13 @@ public interface RoutineOverrideControllerDocs {
           LocalDate date);
 
   @Operation(
-      summary = "루틴 인스턴스 건너뜀 취소",
+      summary = "루틴 인스턴스 건너뜀 실행 취소 (undo)",
       description =
           """
           건너뜀 처리된 날짜를 다시 활성화한다.
 
           - override의 `isSkipped`를 `false`로 되돌린다.
-          - 이미 soft-delete된 Todo는 복구되지 않는다. 새 배치 실행 시 해당 날짜가 발생일이면 재생성된다.
+          - soft-delete된 Todo가 있으면 함께 복구한다.
           - 건너뜀 상태가 아닌 날짜에 호출해도 에러 없이 idempotent하게 처리된다.
 
           ### Path Variables
@@ -395,7 +395,7 @@ public interface RoutineOverrideControllerDocs {
     @ApiResponse(responseCode = "401", description = "인증 실패"),
     @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
   })
-  ResponseEntity<ApiResult<Void>> unskip(
+  ResponseEntity<ApiResult<Void>> undo(
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "루틴 ID", example = "1") @PathVariable Long routineId,
       @Parameter(description = "건너뜀을 취소할 날짜 (yyyy-MM-dd)", example = "2026-07-01") @PathVariable

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineDateProjection.java
@@ -1,5 +1,6 @@
 package plana.replan.domain.routine.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
@@ -9,6 +10,8 @@ public interface RoutineDateProjection {
   String getTitle();
 
   LocalDateTime getDueDate();
+
+  LocalDateTime getRepeatEndDate();
 
   LocalTime getRoutineTime();
 
@@ -26,15 +29,15 @@ public interface RoutineDateProjection {
 
   Long getTodoId();
 
-  Double getOverrideSortOrder();
-
-  Double getDefaultSortOrder();
-
-  Boolean getIsSkipped();
+  Double getSortOrder();
 
   Boolean getIsPinned();
 
   Boolean getIsCompleted();
 
+  Boolean getIsOverdue();
+
   Boolean getHasOverride();
+
+  LocalDate getOverrideDate();
 }

--- a/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
+++ b/src/main/java/plana/replan/domain/routine/dto/RoutineResponseDto.java
@@ -26,8 +26,14 @@ public class RoutineResponseDto {
   @Schema(description = "제목 (override 적용값)", example = "아침 스트레칭")
   private String title;
 
-  @Schema(description = "반복 종료 마감일 (ISO 8601 형식). 없으면 null", example = "2025-12-31T00:00:00")
+  @Schema(
+      description =
+          "해당 날짜 인스턴스 마감 일시 (ISO 8601 형식). instanceDate + routineTime, 없으면 23:59:59. 단건 조회 시 null",
+      example = "2025-06-20T08:00:00")
   private LocalDateTime dueDate;
+
+  @Schema(description = "반복 종료 마감일 (ISO 8601 형식). 없으면 null", example = "2025-12-31T00:00:00")
+  private LocalDateTime repeatEndDate;
 
   @Schema(description = "마감 시각 (HH:mm:ss 형식). 없으면 null", example = "08:00:00")
   private LocalTime routineTime;
@@ -56,16 +62,16 @@ public class RoutineResponseDto {
   private Long todoId;
 
   @Schema(description = "해당 날짜 인스턴스의 정렬 순서", example = "10000.0")
-  private double effectiveSortOrder;
-
-  @Schema(description = "해당 날짜 건너뜀 여부", example = "false")
-  private boolean isSkipped;
+  private double sortOrder;
 
   @Schema(description = "해당 날짜 핀 여부", example = "false")
   private boolean isPinned;
 
   @Schema(description = "해당 날짜 완료 여부", example = "false")
   private boolean isCompleted;
+
+  @Schema(description = "마감 시각이 지났고 미완료인 경우 true", example = "false")
+  private boolean isOverdue;
 
   @Schema(description = "해당 날짜에 override 존재 여부", example = "false")
   private boolean hasOverride;
@@ -74,6 +80,7 @@ public class RoutineResponseDto {
     return new RoutineResponseDto(
         routine.getId(),
         routine.getTitle(),
+        null,
         routine.getDueDate(),
         routine.getRoutineTime(),
         routine.getRoutineType(),
@@ -91,13 +98,12 @@ public class RoutineResponseDto {
   }
 
   public static RoutineResponseDto from(RoutineDateProjection p) {
-    double effectiveSortOrder =
-        p.getOverrideSortOrder() != null ? p.getOverrideSortOrder() : p.getDefaultSortOrder();
     RoutineType type = p.getRoutineType() != null ? RoutineType.valueOf(p.getRoutineType()) : null;
     return new RoutineResponseDto(
         p.getRoutineId(),
         p.getTitle(),
         p.getDueDate(),
+        p.getRepeatEndDate(),
         p.getRoutineTime(),
         type,
         RoutineDays.toDays(type, p.getRoutineDate()),
@@ -106,10 +112,10 @@ public class RoutineResponseDto {
         p.getTagColor(),
         p.getGoalId(),
         p.getTodoId(),
-        effectiveSortOrder,
-        Boolean.TRUE.equals(p.getIsSkipped()),
+        p.getSortOrder() != null ? p.getSortOrder() : 10000.0,
         Boolean.TRUE.equals(p.getIsPinned()),
         Boolean.TRUE.equals(p.getIsCompleted()),
+        Boolean.TRUE.equals(p.getIsOverdue()),
         Boolean.TRUE.equals(p.getHasOverride()));
   }
 }

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -62,7 +62,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
                  ro.override_date                                      AS overrideDate,
                  (COALESCE(td.due_date,
                     CAST(CAST(:targetDate AS date) + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
-                  ) < NOW()
+                  ) < NOW() AT TIME ZONE 'Asia/Seoul'
                   AND CASE WHEN td.id IS NOT NULL THEN td.is_completed
                            ELSE COALESCE(ro.is_completed, FALSE)
                       END = FALSE)                                     AS isOverdue
@@ -126,7 +126,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
                  ro.override_date                                      AS overrideDate,
                  (COALESCE(td.due_date,
                     CAST(ro.override_date + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
-                  ) < NOW()
+                  ) < NOW() AT TIME ZONE 'Asia/Seoul'
                   AND CASE WHEN td.id IS NOT NULL THEN td.is_completed
                            ELSE COALESCE(ro.is_completed, FALSE)
                       END = FALSE)                                     AS isOverdue

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -34,31 +34,50 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
       nativeQuery = true,
       value =
           """
-          SELECT r.id                                    AS routineId,
-                 COALESCE(ro.title, r.title)             AS title,
-                 r.due_date                              AS dueDate,
-                 r.routine_time                          AS routineTime,
-                 r.routine_type                          AS routineType,
-                 r.routine_date                          AS routineDate,
-                 COALESCE(ro.tag_id, r.tag_id)           AS tagId,
-                 t.title                                 AS tagTitle,
-                 t.color                                 AS tagColor,
-                 r.goal_id                               AS goalId,
-                 td.id                                   AS todoId,
-                 ro.sort_order                           AS overrideSortOrder,
-                 r.default_sort_order                    AS defaultSortOrder,
-                 COALESCE(ro.is_skipped,   FALSE)        AS isSkipped,
-                 COALESCE(ro.is_pinned,    FALSE)        AS isPinned,
-                 COALESCE(ro.is_completed, FALSE)        AS isCompleted,
-                 (ro.id IS NOT NULL)                     AS hasOverride
+          SELECT r.id                                                  AS routineId,
+                 COALESCE(td.title, COALESCE(ro.title, r.title))      AS title,
+                 r.due_date                                            AS repeatEndDate,
+                 COALESCE(td.due_date,
+                   CAST(CAST(:targetDate AS date) + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
+                 )                                                     AS dueDate,
+                 r.routine_time                                        AS routineTime,
+                 r.routine_type                                        AS routineType,
+                 r.routine_date                                        AS routineDate,
+                 CASE WHEN td.id IS NOT NULL THEN td.tag_id
+                      ELSE COALESCE(ro.tag_id, r.tag_id)
+                 END                                                   AS tagId,
+                 t.title                                               AS tagTitle,
+                 t.color                                               AS tagColor,
+                 r.goal_id                                             AS goalId,
+                 td.id                                                 AS todoId,
+                 COALESCE(td.sort_order,
+                   COALESCE(ro.sort_order, r.default_sort_order))      AS sortOrder,
+                 (ro.id IS NOT NULL)                                   AS hasOverride,
+                 CASE WHEN td.id IS NOT NULL THEN td.is_pinned
+                      ELSE COALESCE(ro.is_pinned, FALSE)
+                 END                                                   AS isPinned,
+                 CASE WHEN td.id IS NOT NULL THEN td.is_completed
+                      ELSE COALESCE(ro.is_completed, FALSE)
+                 END                                                   AS isCompleted,
+                 ro.override_date                                      AS overrideDate,
+                 (COALESCE(td.due_date,
+                    CAST(CAST(:targetDate AS date) + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
+                  ) < NOW()
+                  AND CASE WHEN td.id IS NOT NULL THEN td.is_completed
+                           ELSE COALESCE(ro.is_completed, FALSE)
+                      END = FALSE)                                     AS isOverdue
           FROM routine r
           LEFT JOIN routine_override ro
                  ON ro.routine_id = r.id AND ro.override_date = :targetDate
-          LEFT JOIN tag t ON COALESCE(ro.tag_id, r.tag_id) = t.id AND t.deleted_at IS NULL
           LEFT JOIN todo td ON td.routine_id = r.id
                             AND td.deleted_at IS NULL
                             AND td.parent_id IS NULL
                             AND CAST(td.due_date AS date) = :targetDate
+          LEFT JOIN tag t ON (
+                            CASE WHEN td.id IS NOT NULL THEN td.tag_id
+                                 ELSE COALESCE(ro.tag_id, r.tag_id)
+                            END
+                          ) = t.id AND t.deleted_at IS NULL
           WHERE r.user_id = :userId
             AND r.deleted_at IS NULL
             AND r.parent_id IS NULL
@@ -67,10 +86,70 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
               OR (r.routine_type = 'WEEKLY'  AND (r.routine_date & :dayBit) != 0)
               OR (r.routine_type = 'MONTHLY' AND (r.routine_date & :monthDayBit) != 0)
             )
+            AND COALESCE(ro.is_skipped, FALSE) = FALSE
           """)
   List<RoutineDateProjection> findMotherRoutinesByDate(
       @Param("userId") Long userId,
       @Param("dayBit") int dayBit,
       @Param("monthDayBit") int monthDayBit,
       @Param("targetDate") LocalDate targetDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          """
+          SELECT r.id                                                  AS routineId,
+                 COALESCE(td.title, COALESCE(ro.title, r.title))      AS title,
+                 r.due_date                                            AS repeatEndDate,
+                 COALESCE(td.due_date,
+                   CAST(ro.override_date + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
+                 )                                                     AS dueDate,
+                 r.routine_time                                        AS routineTime,
+                 r.routine_type                                        AS routineType,
+                 r.routine_date                                        AS routineDate,
+                 CASE WHEN td.id IS NOT NULL THEN td.tag_id
+                      ELSE COALESCE(ro.tag_id, r.tag_id)
+                 END                                                   AS tagId,
+                 t.title                                               AS tagTitle,
+                 t.color                                               AS tagColor,
+                 r.goal_id                                             AS goalId,
+                 td.id                                                 AS todoId,
+                 COALESCE(td.sort_order,
+                   COALESCE(ro.sort_order, r.default_sort_order))      AS sortOrder,
+                 TRUE                                                  AS hasOverride,
+                 CASE WHEN td.id IS NOT NULL THEN td.is_pinned
+                      ELSE COALESCE(ro.is_pinned, FALSE)
+                 END                                                   AS isPinned,
+                 CASE WHEN td.id IS NOT NULL THEN td.is_completed
+                      ELSE COALESCE(ro.is_completed, FALSE)
+                 END                                                   AS isCompleted,
+                 ro.override_date                                      AS overrideDate,
+                 (COALESCE(td.due_date,
+                    CAST(ro.override_date + COALESCE(r.routine_time, TIME '23:59:59') AS timestamp)
+                  ) < NOW()
+                  AND CASE WHEN td.id IS NOT NULL THEN td.is_completed
+                           ELSE COALESCE(ro.is_completed, FALSE)
+                      END = FALSE)                                     AS isOverdue
+          FROM routine_override ro
+          INNER JOIN routine r ON r.id = ro.routine_id
+          LEFT JOIN todo td ON td.routine_id = r.id
+                            AND td.deleted_at IS NULL
+                            AND td.parent_id IS NULL
+                            AND CAST(td.due_date AS date) = ro.override_date
+          LEFT JOIN tag t ON (
+                            CASE WHEN td.id IS NOT NULL THEN td.tag_id
+                                 ELSE COALESCE(ro.tag_id, r.tag_id)
+                            END
+                          ) = t.id AND t.deleted_at IS NULL
+          WHERE r.user_id = :userId
+            AND r.deleted_at IS NULL
+            AND r.parent_id IS NULL
+            AND CASE WHEN td.id IS NOT NULL THEN td.is_pinned
+                     ELSE COALESCE(ro.is_pinned, FALSE)
+                END = TRUE
+            AND COALESCE(ro.is_skipped, FALSE) = FALSE
+          ORDER BY ro.override_date ASC,
+                   COALESCE(td.sort_order, COALESCE(ro.sort_order, r.default_sort_order)) ASC
+          """)
+  List<RoutineDateProjection> findPinnedMotherRoutines(@Param("userId") Long userId);
 }

--- a/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineOverrideService.java
@@ -153,7 +153,7 @@ public class RoutineOverrideService {
   }
 
   @Transactional
-  public void unskip(Long userId, Long routineId, LocalDate date) {
+  public void undo(Long userId, Long routineId, LocalDate date) {
     Routine routine = findOwnedMotherRoutine(userId, routineId);
 
     // skip된 override가 없으면 no-op (ghost override row 생성 방지)

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -218,6 +218,23 @@ public class RoutineService {
         .collect(Collectors.toList());
   }
 
+  @Transactional(readOnly = true)
+  public Map<String, List<RoutineResponseDto>> getPinnedRoutines(Long userId) {
+    if (userId == null) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+    userRepository
+        .findById(userId)
+        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    return routineRepository.findPinnedMotherRoutines(userId).stream()
+        .collect(
+            Collectors.groupingBy(
+                p -> p.getOverrideDate().toString(),
+                LinkedHashMap::new,
+                Collectors.mapping(RoutineResponseDto::from, Collectors.toList())));
+  }
+
   /** 엄마 루틴 전용 삭제. 하위 루틴 ID를 넘기면 400(ROUTINE_INVALID_TARGET). */
   @Transactional
   public void deleteMotherRoutine(Long userId, Long routineId) {

--- a/src/main/java/plana/replan/domain/todo/controller/TodoController.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoController.java
@@ -97,8 +97,8 @@ public class TodoController implements TodoControllerDocs {
   }
 
   @Override
-  @PatchMapping("/{todoId}/restore")
-  public ResponseEntity<ApiResult<Void>> restoreTodo(
+  @PatchMapping("/{todoId}/undo")
+  public ResponseEntity<ApiResult<Void>> undoTodo(
       @AuthenticationPrincipal Long userId, @PathVariable Long todoId) {
     todoService.restoreTodo(userId, todoId);
     return ResponseEntity.ok(ApiResult.ok(null));

--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -1668,7 +1668,7 @@ public interface TodoControllerDocs {
 
           삭제된 일반 투두를 복원합니다. 하위 투두도 함께 복원됩니다.
 
-          - 루틴 투두는 이 API로 복원할 수 없습니다. 루틴 투두는 `PATCH /api/routines/{routineId}/overrides/{date}/unskip` 을 사용하세요.
+          - 루틴 투두는 이 API로 복원할 수 없습니다. 루틴 투두는 `PATCH /api/routines/{routineId}/overrides/{date}/undo` 를 사용하세요.
 
           **Request Headers**
 
@@ -1763,7 +1763,7 @@ public interface TodoControllerDocs {
                           """)
                 }))
   })
-  ResponseEntity<ApiResult<Void>> restoreTodo(
+  ResponseEntity<ApiResult<Void>> undoTodo(
       @AuthenticationPrincipal Long userId,
       @Parameter(description = "복원할 투두 ID", example = "1") @PathVariable Long todoId);
 }

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -55,20 +55,22 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
-          + " AND t.isActive = true")
+          + " AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findActiveTodosForUser(@Param("user") User user);
 
-  @Query("SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isActive = true")
+  @Query(
+      "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isActive = true"
+          + " AND t.routine IS NULL")
   List<Todo> findAllActiveTodosForUser(@Param("user") User user);
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
-          + " AND t.isPinned = true AND t.isActive = true")
+          + " AND t.isPinned = true AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findPinnedActiveTodosForUser(@Param("user") User user);
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
-          + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true")
+          + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findActiveTodosByDueDateRange(
       @Param("user") User user,
       @Param("start") LocalDateTime start,
@@ -76,7 +78,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
-          + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true")
+          + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findAllTodosByDueDateRange(
       @Param("user") User user,
       @Param("start") LocalDateTime start,
@@ -84,7 +86,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = true"
-          + " AND t.completedTime BETWEEN :start AND :end AND t.isActive = true")
+          + " AND t.completedTime BETWEEN :start AND :end AND t.isActive = true"
+          + " AND t.routine IS NULL")
   List<Todo> findCompletedTodosByCompletedTimeRange(
       @Param("user") User user,
       @Param("start") LocalDateTime start,

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -75,6 +75,7 @@ class RoutineControllerTest {
                 "아침 스트레칭",
                 null,
                 null,
+                null,
                 RoutineType.DAILY,
                 null,
                 null,
@@ -117,6 +118,7 @@ class RoutineControllerTest {
             new RoutineResponseDto(
                 2L,
                 "영어 단어",
+                null,
                 dueDate,
                 null,
                 RoutineType.WEEKLY,
@@ -166,6 +168,7 @@ class RoutineControllerTest {
             new RoutineResponseDto(
                 3L,
                 "월간 회고",
+                null,
                 null,
                 null,
                 RoutineType.MONTHLY,
@@ -370,6 +373,7 @@ class RoutineControllerTest {
             new RoutineResponseDto(
                 1L,
                 "수정된 루틴",
+                null,
                 dueDate,
                 null,
                 RoutineType.WEEKLY,

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -179,7 +179,7 @@ class RoutineServiceTest {
     assertThat(result.getRoutineDays()).isNull();
     assertThat(result.getTagId()).isNull();
     assertThat(result.getGoalId()).isNull();
-    assertThat(result.getDueDate()).isNull();
+    assertThat(result.getRepeatEndDate()).isNull();
   }
 
   @Test
@@ -235,7 +235,7 @@ class RoutineServiceTest {
     assertThat(result.getTitle()).isEqualTo("영어 단어");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
     assertThat(result.getRoutineDays()).containsExactly(0, 2, 4);
-    assertThat(result.getDueDate()).isEqualTo(dueDate);
+    assertThat(result.getRepeatEndDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
     assertThat(result.getGoalId()).isEqualTo(2L);
   }
@@ -711,7 +711,7 @@ class RoutineServiceTest {
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.DAILY);
     assertThat(result.getRoutineDays()).isNull();
-    assertThat(result.getDueDate()).isNull();
+    assertThat(result.getRepeatEndDate()).isNull();
     assertThat(result.getTagId()).isNull();
   }
 
@@ -732,7 +732,7 @@ class RoutineServiceTest {
     assertThat(result.getTitle()).isEqualTo("수정된 루틴");
     assertThat(result.getRoutineType()).isEqualTo(RoutineType.WEEKLY);
     assertThat(result.getRoutineDays()).containsExactly(0, 2, 4);
-    assertThat(result.getDueDate()).isEqualTo(dueDate);
+    assertThat(result.getRepeatEndDate()).isEqualTo(dueDate);
     assertThat(result.getTagId()).isEqualTo(5L);
   }
 


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #248 


## 변경 사항
> GET /api/routines/pinned 추가 및 루틴-투두 API 분리

### GET /api/routines/pinned 신규
핀된 루틴 인스턴스를 override_date 기준 오름차순으로 날짜별 그룹핑해서 반환. 미래 날짜(todo 미생성)도 핀 가능하며 이 경우 todoId: null로 반환.

### RoutineResponseDto 재구조화
- dueDate → 인스턴스 마감 일시(instanceDate + routineTime)로 의미 변경
- repeatEndDate 신규: 기존 dueDate(반복 종료일)의 역할
- sortOrder, isPinned, isCompleted, isOverdue, hasOverride 신규 필드 추가
- isSkipped 제거 (skip된 인스턴스는 목록에서 아예 제외)

### 루틴-투두 API 분리
GET /api/todos* 하위 쿼리 6개에 AND t.routine IS NULL 추가. findMonthlyTodos는 리포트 집계 쿼리이므로 제외(루틴 포함 유지).

### 엔드포인트 리네임
- PATCH /api/todos/{todoId}/restore → /undo
- PATCH /api/routines/{routineId}/overrides/{date}/unskip → /undo

### SQL 수정
- COALESCE(td.is_pinned, ...) → CASE WHEN td.id IS NOT NULL THEN td.is_pinned ELSE ... 교체. todo.is_pinned가 NOT NULL boolean이라 false일 때 override 값을 차단하는 구조적 문제 해소.
- ::timestamp 캐스트를 CAST(... AS timestamp)로 통일. Hibernate가 :param::type 패턴에서 파라미터명을 잘못 파싱하는 오류 방지.

### 테스트 수정
RoutineServiceTest에서 result.getDueDate().isNull() → result.getRepeatEndDate().isNull() (2곳). from(Routine)이 dueDate를 항상 null로 고정해 기존 어서션이 항상 통과하는 거짓 양성이었음.


## 테스트 결과

./gradlew test 전체 통과.

수동 E2E: day/week/month 필터, pinned 조회, skip/undo, complete, isOverdue, content override, 루틴-투두 분리 전 항목 정상 동작 확인.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 핀된 루틴을 날짜별로 조회할 수 있는 기능이 추가되었습니다.
* **Bug Fixes**
  * 루틴 조회 응답의 반복 종료일, 정렬값, 지연 여부(오버듀) 표시가 더 정확해졌습니다.
  * 루틴/오버라이드 기반 조회 범위 및 상태 필터링이 정리되었습니다.
* **Documentation**
  * 루틴/투두 API의 응답 예시 및 필드 설명이 최신 변경사항에 맞게 업데이트되었습니다.
* **Chores**
  * 삭제 취소 동작 경로가 `undo`로 통일되었습니다(루틴 오버라이드/투두 모두).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->