### PR TITLE
Fix: 웹푸시 알림이 2개씩 뜨는 중복 표시 수정 (data-only 발송)

### DIFF
--- a/src/main/java/plana/replan/domain/notification/infra/FcmPushSender.java
+++ b/src/main/java/plana/replan/domain/notification/infra/FcmPushSender.java
@@ -5,11 +5,13 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import plana.replan.domain.notification.entity.Platform;
 
 @Slf4j
 @Component
@@ -24,13 +26,28 @@ public class FcmPushSender implements PushSender {
   private final FirebaseMessaging firebaseMessaging;
 
   @Override
-  public PushResult send(String token, String title, String body, Map<String, String> data) {
-    Message message =
-        Message.builder()
-            .setToken(token)
-            .setNotification(Notification.builder().setTitle(title).setBody(body).build())
-            .putAllData(data == null ? java.util.Map.of() : data)
-            .build();
+  public PushResult send(
+      String token, String title, String body, Map<String, String> data, Platform platform) {
+    Message.Builder builder = Message.builder().setToken(token);
+
+    if (platform == Platform.WEB) {
+      // 웹은 notification 블록을 넣으면 브라우저 자동표시(1) + 서비스워커 표시(1)로 알림이 2개 뜬다.
+      // 그래서 제목·본문을 data에 담아 data-only로 보내고, 서비스워커가 data를 읽어 단독으로 표시한다.
+      Map<String, String> payload = new HashMap<>();
+      if (data != null) {
+        payload.putAll(data);
+      }
+      payload.put("title", title == null ? "" : title);
+      payload.put("body", body == null ? "" : body);
+      builder.putAllData(payload);
+    } else {
+      // 네이티브(IOS/ANDROID)는 OS 트레이 자동표시를 위해 notification 블록을 담는다(기존 동작 유지).
+      builder
+          .setNotification(Notification.builder().setTitle(title).setBody(body).build())
+          .putAllData(data == null ? Map.of() : data);
+    }
+
+    Message message = builder.build();
     try {
       firebaseMessaging.send(message);
       return PushResult.SUCCESS;

--- a/src/main/java/plana/replan/domain/notification/infra/NoOpPushSender.java
+++ b/src/main/java/plana/replan/domain/notification/infra/NoOpPushSender.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import plana.replan.domain.notification.entity.Platform;
 
 /**
  * Firebase를 끈 환경(firebase.enabled=false)에서 쓰는 발송기. 실제 푸시는 보내지 않고 로그만 남긴다. 푸시를 끈 상태로도 서버가 정상 기동하고
@@ -15,7 +16,8 @@ import org.springframework.stereotype.Component;
 public class NoOpPushSender implements PushSender {
 
   @Override
-  public PushResult send(String token, String title, String body, Map<String, String> data) {
+  public PushResult send(
+      String token, String title, String body, Map<String, String> data, Platform platform) {
     log.debug("푸시 비활성(firebase.enabled=false) - 발송 생략. title={}", title);
     return PushResult.SUCCESS;
   }

--- a/src/main/java/plana/replan/domain/notification/infra/PushSender.java
+++ b/src/main/java/plana/replan/domain/notification/infra/PushSender.java
@@ -1,8 +1,18 @@
 package plana.replan.domain.notification.infra;
 
 import java.util.Map;
+import plana.replan.domain.notification.entity.Platform;
 
 /** 푸시 발송 포트. 단위 테스트에서는 mock으로 대체한다. */
 public interface PushSender {
-  PushResult send(String token, String title, String body, Map<String, String> data);
+
+  /**
+   * 푸시를 발송한다.
+   *
+   * <p>플랫폼에 따라 메시지 구성이 다르다. WEB은 브라우저 자동표시와 서비스워커 표시가 겹쳐 알림이 2개 뜨는 것을 막기 위해 {@code notification} 블록
+   * 없이 data-only로 보내고(서비스워커가 data를 읽어 단독 표시), 네이티브(IOS/ANDROID)는 OS 트레이 자동표시를 위해 {@code
+   * notification} 블록을 담는다.
+   */
+  PushResult send(
+      String token, String title, String body, Map<String, String> data, Platform platform);
 }

--- a/src/main/java/plana/replan/domain/notification/service/NotificationService.java
+++ b/src/main/java/plana/replan/domain/notification/service/NotificationService.java
@@ -68,7 +68,7 @@ public class NotificationService {
     for (DeviceToken token : tokens) {
       PushResult result;
       try {
-        result = pushSender.send(token.getToken(), title, body, data);
+        result = pushSender.send(token.getToken(), title, body, data, token.getPlatform());
       } catch (Exception e) {
         // 푸시 실패가 알림함 저장/다음 처리를 막으면 안 된다.
         log.warn("푸시 발송 중 예외 - tokenId={}", token.getId(), e);

--- a/src/test/java/plana/replan/domain/notification/infra/FcmPushSenderTest.java
+++ b/src/test/java/plana/replan/domain/notification/infra/FcmPushSenderTest.java
@@ -1,10 +1,20 @@
 package plana.replan.domain.notification.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.notification.entity.Platform;
 
 class FcmPushSenderTest {
 
@@ -22,5 +32,42 @@ class FcmPushSenderTest {
   void classifiesOtherFailures() {
     assertThat(FcmPushSender.classify(MessagingErrorCode.INTERNAL)).isEqualTo(PushResult.FAILURE);
     assertThat(FcmPushSender.classify(null)).isEqualTo(PushResult.FAILURE);
+  }
+
+  @Test
+  @DisplayName("WEB은 notification 블록 없이 data-only로 보낸다(제목·본문을 data에 담음)")
+  void webSendsDataOnly() throws Exception {
+    FirebaseMessaging fm = mock(FirebaseMessaging.class);
+    given(fm.send(any(Message.class))).willReturn("msg-id");
+
+    new FcmPushSender(fm).send("tok", "제목", "본문", Map.of("type", "TODO_DUE_SOON"), Platform.WEB);
+
+    Message sent = captureSent(fm);
+    // 브라우저 자동표시를 막기 위해 notification 블록이 없어야 한다.
+    assertThat(ReflectionTestUtils.getField(sent, "notification")).isNull();
+    @SuppressWarnings("unchecked")
+    Map<String, String> data = (Map<String, String>) ReflectionTestUtils.getField(sent, "data");
+    assertThat(data)
+        .containsEntry("title", "제목")
+        .containsEntry("body", "본문")
+        .containsEntry("type", "TODO_DUE_SOON");
+  }
+
+  @Test
+  @DisplayName("네이티브(IOS/ANDROID)는 OS 트레이 표시를 위해 notification 블록을 담는다")
+  void nativeSendsNotificationBlock() throws Exception {
+    FirebaseMessaging fm = mock(FirebaseMessaging.class);
+    given(fm.send(any(Message.class))).willReturn("msg-id");
+
+    new FcmPushSender(fm).send("tok", "제목", "본문", Map.of("type", "TODO_DUE_SOON"), Platform.IOS);
+
+    Message sent = captureSent(fm);
+    assertThat(ReflectionTestUtils.getField(sent, "notification")).isNotNull();
+  }
+
+  private Message captureSent(FirebaseMessaging fm) throws Exception {
+    ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+    verify(fm).send(captor.capture());
+    return captor.getValue();
   }
 }

--- a/src/test/java/plana/replan/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/plana/replan/domain/notification/service/NotificationServiceTest.java
@@ -63,7 +63,7 @@ class NotificationServiceTest {
         userWithReportOff(), NotificationType.REPORT_READY, "t", "b", TargetType.REPORT, 1L);
 
     verify(notificationRepository, never()).save(any());
-    verify(pushSender, never()).send(any(), any(), any(), anyMap());
+    verify(pushSender, never()).send(any(), any(), any(), anyMap(), any());
   }
 
   @Test
@@ -73,14 +73,15 @@ class NotificationServiceTest {
     DeviceToken t1 = DeviceToken.builder().user(u).token("a").platform(Platform.WEB).build();
     DeviceToken t2 = DeviceToken.builder().user(u).token("b").platform(Platform.ANDROID).build();
     given(deviceTokenRepository.findAllByUser(u)).willReturn(List.of(t1, t2));
-    given(pushSender.send(any(), any(), any(), anyMap())).willReturn(PushResult.SUCCESS);
+    given(pushSender.send(any(), any(), any(), anyMap(), any())).willReturn(PushResult.SUCCESS);
 
     notificationService.send(
         u, NotificationType.TODO_DUE_SOON, "title", "body", TargetType.TODO, 9L);
 
     verify(notificationRepository).save(any(Notification.class));
-    verify(pushSender).send(eq("a"), eq("title"), eq("body"), anyMap());
-    verify(pushSender).send(eq("b"), eq("title"), eq("body"), anyMap());
+    // 토큰의 플랫폼이 그대로 전달돼야 한다(웹/네이티브 분기의 근거).
+    verify(pushSender).send(eq("a"), eq("title"), eq("body"), anyMap(), eq(Platform.WEB));
+    verify(pushSender).send(eq("b"), eq("title"), eq("body"), anyMap(), eq(Platform.ANDROID));
   }
 
   @Test
@@ -89,7 +90,7 @@ class NotificationServiceTest {
     User u = userAllOn();
     DeviceToken dead = DeviceToken.builder().user(u).token("dead").platform(Platform.WEB).build();
     given(deviceTokenRepository.findAllByUser(u)).willReturn(List.of(dead));
-    given(pushSender.send(any(), any(), any(), anyMap())).willReturn(PushResult.DEAD_TOKEN);
+    given(pushSender.send(any(), any(), any(), anyMap(), any())).willReturn(PushResult.DEAD_TOKEN);
 
     notificationService.send(
         u, NotificationType.TODO_DUE_SOON, "title", "body", TargetType.TODO, 9L);


### PR DESCRIPTION
## PR 타입
- [x] 버그 수정

## Related Issues
close #251

## 변경 사항
웹(PWA) 푸시가 **한 번 보냈는데 2개** 뜨는 중복 표시를 고쳤습니다.

**원인:** 서버가 FCM 메시지에 `notification`(제목·본문) 블록 + `data`를 둘 다 담아 보내서,
- 브라우저가 `notification` 블록을 보고 자동으로 1개 표시
- 서비스워커가 `onBackgroundMessage`로 또 1개 표시 → 합쳐서 2개.

**수정:** 발송을 **플랫폼별로** 나눔.
- **WEB**: `notification` 블록 없이 **data-only**(제목·본문을 `data`에 담음). 브라우저 자동표시가 안 일어나고, 서비스워커가 `data`를 읽어 단독 1개 표시.
- **IOS / ANDROID(네이티브)**: 기존처럼 `notification` 블록 유지(OS 트레이 자동표시). 동작 변화 없음.

세부:
- `PushSender.send`에 `Platform` 인자 추가
- `FcmPushSender`: WEB=data-only, 네이티브=notification 블록
- `NotificationService`: 토큰의 `platform`을 그대로 전달

## ⚠️ 프론트 동반 변경 + 배포 순서 (중요)
- 프론트 `firebase-messaging-sw.js`가 `payload.data`에서 제목·본문을 읽도록 함께 바뀌어야 합니다(짝꿍 변경).
- **프론트(가능하면 `data ?? notification` fallback)를 먼저 배포**한 뒤 이 서버 변경을 배포해야 기존 웹 사용자에게 "빈 알림"이 안 뜹니다.

## 테스트 결과
- 단위테스트 추가: WEB은 `notification` 없이 data에 title/body 담김 / 네이티브는 notification 블록 담김 / 토큰 platform이 그대로 전달됨.
- `./gradlew build`(JDK17, Spotless) 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 웹과 앱(iOS/Android)에서 푸시 알림 전송 방식이 플랫폼별로 달라졌습니다.
  * 웹에서는 알림 본문을 데이터 형태로 전송해 더 안정적으로 수신되도록 개선했습니다.
  * 앱에서는 기존처럼 제목/본문이 포함된 알림 전송을 유지합니다.

* **Bug Fixes**
  * 플랫폼에 따라 빈 데이터가 포함될 때의 처리 방식이 정리되어, 일부 푸시 전송 오류 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->