### PR TITLE
Fix: filter=day 조회 시 마감기한이 아닌 완료 시각 기준으로 투두가 섞이는 문제 수정

### DIFF
--- a/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
+++ b/src/main/java/plana/replan/domain/todo/controller/TodoControllerDocs.java
@@ -1067,9 +1067,9 @@ public interface TodoControllerDocs {
           | filter | 조회 대상 |
           |--------|----------|
           | `all` | 완료되지 않은 모든 투두 (마감일 무관, date 무시) |
-          | `day` | 기준 날짜에 마감인 미완료 투두 + 기준 날짜에 완료된 투두 |
-          | `week` | 기준 날짜부터 7일 이내 마감인 미완료 투두 |
-          | `month` | 기준 날짜부터 한 달 이내 마감인 미완료 투두 |
+          | `day` | 기준 날짜에 마감인 미완료 투두 + 기준 날짜에 마감인 완료 투두 |
+          | `week` | 기준 날짜부터 7일 이내 마감인 미완료 투두 + 완료 투두 |
+          | `month` | 기준 날짜부터 한 달 이내 마감인 미완료 투두 + 완료 투두 |
 
           **sort 값별 정렬 기준**
 
@@ -1078,7 +1078,7 @@ public interface TodoControllerDocs {
           | `priority` | sortOrder ASC |
           | `dueDate` | dueDate ASC (null 마지막) |
 
-          **day 필터의 추가 정렬 규칙**
+          **공통 추가 정렬 규칙 (모든 filter 값 공통)**
           - 미완료 투두 먼저, 완료 투두 나중 → 각 그룹 내에서 선택한 sort 기준 적용
 
           **반환 필드**

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -69,26 +69,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   List<Todo> findPinnedActiveTodosForUser(@Param("user") User user);
 
   @Query(
-      "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
-          + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true AND t.routine IS NULL")
-  List<Todo> findActiveTodosByDueDateRange(
-      @Param("user") User user,
-      @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
-
-  @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL"
           + " AND t.dueDate BETWEEN :start AND :end AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findAllTodosByDueDateRange(
-      @Param("user") User user,
-      @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
-
-  @Query(
-      "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = true"
-          + " AND t.completedTime BETWEEN :start AND :end AND t.isActive = true"
-          + " AND t.routine IS NULL")
-  List<Todo> findCompletedTodosByCompletedTimeRange(
       @Param("user") User user,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);

--- a/src/main/java/plana/replan/domain/todo/service/TodoService.java
+++ b/src/main/java/plana/replan/domain/todo/service/TodoService.java
@@ -199,12 +199,8 @@ public class TodoService {
         todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       case "day" -> {
-        List<Todo> active =
-            todoRepository.findActiveTodosByDueDateRange(user, startOfDay, endOfDay);
-        List<Todo> completed =
-            todoRepository.findCompletedTodosByCompletedTimeRange(user, startOfDay, endOfDay);
-        todos = new ArrayList<>(active);
-        todos.addAll(completed);
+        todos =
+            new ArrayList<>(todoRepository.findAllTodosByDueDateRange(user, startOfDay, endOfDay));
         todos.sort(Comparator.comparing(Todo::isCompleted).thenComparing(sortComparator));
       }
       case "week" -> {

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -627,16 +627,30 @@ class TodoServiceTest {
   void getTodos_day_activeTodosBeforeCompleted() {
     User user = testUser();
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosByDueDateRange(any(), any(), any()))
-        .willReturn(List.of(activeTodo(1L, user)));
-    given(todoRepository.findCompletedTodosByCompletedTimeRange(any(), any(), any()))
-        .willReturn(List.of(completedTodo(2L, user)));
+    given(todoRepository.findAllTodosByDueDateRange(any(), any(), any()))
+        .willReturn(List.of(activeTodo(1L, user), completedTodo(2L, user)));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority", null);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0).isCompleted()).isFalse();
     assertThat(result.get(1).isCompleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("getTodos - day 필터: 완료 시각이 아닌 마감기한(dueDate) 기준으로만 조회")
+  void getTodos_day_filtersByDueDateOnly() {
+    User user = testUser();
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    given(todoRepository.findAllTodosByDueDateRange(any(), any(), any())).willReturn(List.of());
+
+    todoService.getTodos(1L, "day", "priority", LocalDate.of(2026, 7, 1));
+
+    ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
+    assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 7, 1).atStartOfDay());
+    assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 7, 1).atTime(23, 59, 59, 999999999));
   }
 
   @Test
@@ -654,8 +668,6 @@ class TodoServiceTest {
     verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
     assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 6, 18).atStartOfDay());
     assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 6, 24).atTime(23, 59, 59, 999999999));
-    verify(todoRepository, never()).findActiveTodosByDueDateRange(any(), any(), any());
-    verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
   }
 
   @Test
@@ -673,8 +685,6 @@ class TodoServiceTest {
     verify(todoRepository).findAllTodosByDueDateRange(any(), start.capture(), end.capture());
     assertThat(start.getValue()).isEqualTo(LocalDate.of(2026, 6, 18).atStartOfDay());
     assertThat(end.getValue()).isEqualTo(LocalDate.of(2026, 7, 17).atTime(23, 59, 59, 999999999));
-    verify(todoRepository, never()).findActiveTodosByDueDateRange(any(), any(), any());
-    verify(todoRepository, never()).findCompletedTodosByCompletedTimeRange(any(), any(), any());
   }
 
   @Test
@@ -806,8 +816,7 @@ class TodoServiceTest {
     ReflectionTestUtils.setField(completed, "dueDate", LocalDateTime.of(2020, 1, 1, 0, 0));
 
     given(userRepository.findById(1L)).willReturn(Optional.of(user));
-    given(todoRepository.findActiveTodosByDueDateRange(any(), any(), any())).willReturn(List.of());
-    given(todoRepository.findCompletedTodosByCompletedTimeRange(any(), any(), any()))
+    given(todoRepository.findAllTodosByDueDateRange(any(), any(), any()))
         .willReturn(List.of(completed));
 
     List<TodoListResponseDto> result = todoService.getTodos(1L, "day", "priority", null);


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #253 


## 변경 사항
> 
completedTime 기준으로 완료 투두를 별도 조회해 합치던 로직을 제거하고, week/month와 동일하게 dueDate 범위 단일 조회로 통일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 일정(일/주/월) 조회가 due date 범위 중심으로 단순화되어, 해당 기간의 미완료/완료 Todo를 함께 확인할 수 있습니다.
  * 월간 조회 시 due date 및 완료 시점 기준을 함께 반영해 표시 범위가 확대되었습니다.
* **버그 수정**
  * day 필터의 기준일 시작~종료 범위 적용이 더 정확해졌습니다.
* **테스트**
  * 변경된 조회 로직과 범위 캡처/과버로직 검증에 맞춰 테스트가 갱신되었습니다.
* **문서**
  * filter별 조회 조건 및 정렬 규칙 OpenAPI 설명을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->