### PR TITLE
Fix: 투두 응답 JSON에서 boolean 필드가 isXxx/xxx로 중복 반환되는 문제 수정

### DIFF
--- a/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoDetailResponseDto.java
@@ -27,7 +27,7 @@ public class TodoDetailResponseDto {
 
   @JsonProperty("isCompleted")
   @Schema(description = "완료 여부", example = "false")
-  private boolean isCompleted;
+  private boolean completed;
 
   @Schema(description = "태그 ID (없으면 null)", example = "3")
   private Long tagId;
@@ -62,7 +62,7 @@ public class TodoDetailResponseDto {
 
     @JsonProperty("isCompleted")
     @Schema(description = "완료 여부", example = "false")
-    private boolean isCompleted;
+    private boolean completed;
 
     public static SubTodoDto from(Todo todo) {
       return new SubTodoDto(todo.getId(), todo.getTitle(), todo.isCompleted());

--- a/src/main/java/plana/replan/domain/todo/dto/TodoListResponseDto.java
+++ b/src/main/java/plana/replan/domain/todo/dto/TodoListResponseDto.java
@@ -26,14 +26,14 @@ public class TodoListResponseDto {
 
   @JsonProperty("isPinned")
   @Schema(description = "핀 여부", example = "false")
-  private boolean isPinned;
+  private boolean pinned;
 
   @Schema(description = "정렬 순서", example = "10000.0")
   private double sortOrder;
 
   @JsonProperty("isCompleted")
   @Schema(description = "완료 여부", example = "false")
-  private boolean isCompleted;
+  private boolean completed;
 
   @Schema(description = "태그 ID (없으면 null)", example = "3")
   private Long tagId;
@@ -49,7 +49,7 @@ public class TodoListResponseDto {
 
   @JsonProperty("isOverdue")
   @Schema(description = "기한 초과 여부 (미완료이고 dueDate가 현재 시각 이전인 경우 true)", example = "false")
-  private boolean isOverdue;
+  private boolean overdue;
 
   public static TodoListResponseDto from(Todo todo, Clock clock) {
     Tag tag = todo.getTag();

--- a/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/plana/replan/domain/todo/service/TodoServiceTest.java
@@ -986,7 +986,7 @@ class TodoServiceTest {
     List<TodoListResponseDto> result = todoService.getPinnedTodos(1L);
 
     assertThat(result).hasSize(2);
-    assertThat(result).extracting("isPinned").containsOnly(true);
+    assertThat(result).extracting("pinned").containsOnly(true);
   }
 
   @Test


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #255 


## 변경 사항
Lombok이 생성하는 isXxx() getter와 @JsonProperty가 붙은 isXxx 필드명이 서로 다른 프로퍼티로 인식되어 발생한 중복. 필드명에서 is 접두어를 제거해 getter와 동일한 프로퍼티로 병합되도록 수정
