### PR TITLE
Fix/258: GET /api/tourines?filter=all 추가

### DIFF
--- a/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineController.java
@@ -46,7 +46,7 @@ public class RoutineController implements RoutineControllerDocs {
   public ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getRoutinesByFilter(
       @AuthenticationPrincipal Long userId,
       @RequestParam(defaultValue = "day") String filter,
-      @RequestParam LocalDate date) {
+      @RequestParam(required = false) LocalDate date) {
     return ResponseEntity.ok(
         ApiResult.ok(routineService.getRoutinesByFilter(userId, filter, date)));
   }

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -464,7 +464,9 @@ public interface RoutineControllerDocs {
           @RequestParam(defaultValue = "day")
           String filter,
       @Parameter(
-              description = "기준 시작 날짜 (yyyy-MM-dd). filter=day/week/month에서는 필수, filter=all에서는 무시됨",
+              description =
+                  "기준 시작 날짜 (yyyy-MM-dd). filter=day/week/month에서는 필수(생략 시 400), filter=all에서는"
+                      + " 생략 가능(주더라도 무시됨). 단, 값 자체가 yyyy-MM-dd 형식이 아니면 filter 값과 무관하게 400 발생",
               example = "2025-06-20")
           @RequestParam(required = false)
           LocalDate date);

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -155,16 +155,25 @@ public interface RoutineControllerDocs {
       @AuthenticationPrincipal Long userId);
 
   @Operation(
-      summary = "루틴 조회 (날짜 / 주간 / 월간)",
+      summary = "루틴 조회 (전체 / 날짜 / 주간 / 월간)",
       description =
           """
-          `filter`와 `date`를 기준으로 해당 기간의 루틴 목록을 날짜별로 묶어 반환합니다.
+          `filter`와 `date`를 기준으로 루틴 목록을 반환합니다.
 
-          - `DAILY` 루틴: 기간 내 모든 날짜에 포함
-          - `WEEKLY` 루틴: 해당 날짜의 요일 인덱스가 `routineDays` 배열에 포함된 날짜에만 포함
-          - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDays` 배열에 포함된 날짜에만 포함
+          - `filter=all`: 미래 날짜를 무한히 전개하는 대신(반복 종료일이 없는 루틴은 끝이 없어 전개 자체가 불가능),
+            활성 상태인 엄마 루틴마다 아래 두 종류의 항목을 반환합니다. `date` 생략 가능.
+            1. **완료된 Todo 전부** — 기간 제한 없이, 그 루틴에 연결된 완료 Todo를 모두 각각 하나의 항목으로 반환
+            2. **아직 해야 할 일 1건** — 완료되지 않은 Todo 중 가장 최근 것(과거에 놓친 회차 포함)이 있으면 그 상태를,
+               없으면 다음 발생일의 override가 있으면 그 값으로, override도 없으면 루틴 기본값으로 구성
+          - `filter=day` / `week` / `month`: 해당 기간의 루틴 목록을 날짜별로 묶어 반환합니다. `date` 필수.
+            - `DAILY` 루틴: 기간 내 모든 날짜에 포함
+            - `WEEKLY` 루틴: 해당 날짜의 요일 인덱스가 `routineDays` 배열에 포함된 날짜에만 포함
+            - `MONTHLY` 루틴: 해당 날짜의 일(day)이 `routineDays` 배열에 포함된 날짜에만 포함
 
-          각 루틴에 해당 날짜의 Todo가 이미 생성되어 있으면 `todoId`가 포함되고, 아직 없으면 `null`입니다.
+          각 루틴에 해당 날짜(또는 `all`의 "아직 해야 할 일" 항목)의 Todo가 이미 생성되어 있으면 `todoId`가
+          포함되고, 아직 없으면 `null`입니다. `filter=all`의 "아직 해야 할 일" 항목에서 Todo도 override도
+          없는 경우 `dueDate`는 `null`, `todoId`는 `null`, `isPinned`/`isCompleted`/`isOverdue`/`hasOverride`는
+          `false`로 고정됩니다.
 
           ---
 
@@ -180,10 +189,11 @@ public interface RoutineControllerDocs {
 
           | 파라미터명 | 필수 여부 | 타입 | 기본값 | 설명 | 예시 |
           |-----------|-----------|------|--------|------|------|
-          | filter | ❌ 선택 | string | `day` | 조회 범위 (`day` / `week` / `month`) | `week` |
-          | date | ✅ 필수 | string | 없음 | 기준 시작 날짜 (yyyy-MM-dd 형식) | `2025-06-20` |
+          | filter | ❌ 선택 | string | `day` | 조회 범위 (`all` / `day` / `week` / `month`) | `week` |
+          | date | ❌ 선택 | string | 없음 | 기준 시작 날짜 (yyyy-MM-dd 형식). `filter=day/week/month`에서는 필수이며 생략 시 400 | `2025-06-20` |
 
           **filter 범위 기준**
+          - `all`: date 무관, 활성 엄마 루틴마다 완료 Todo 전부 + 아직 해야 할 일 1건
           - `day`: date 당일 1일치
           - `week`: date 포함 7일 (date ~ date+6)
           - `month`: date부터 정확히 1개월 전날까지 (28~31일, 시작 월에 따라 다름)
@@ -192,13 +202,15 @@ public interface RoutineControllerDocs {
 
           ### Response Elements
 
-          응답 `data`는 날짜(yyyy-MM-dd)를 키로 하는 객체이며, 값은 해당 날짜의 루틴 배열입니다.
+          `filter=day/week/month`는 날짜(yyyy-MM-dd)를 키로 하는 객체를, `filter=all`은 `"all"` 하나를
+          키로 하는 객체를 반환합니다. 값은 각각 해당 범위의 루틴 배열이며, `filter=all`의 경우 루틴 하나당
+          완료 Todo 개수 + 1(아직 해야 할 일)건이 들어갑니다.
 
           | 필드명 | 타입 | 설명 |
           |--------|------|------|
           | routineId | integer | 루틴 ID |
-          | title | string | 루틴 제목 (override 적용값) |
-          | dueDate | string | 해당 날짜 인스턴스 마감 일시 (ISO 8601 형식). instanceDate + routineTime (없으면 23:59:59) |
+          | title | string | 루틴 제목 (override 적용값). Todo가 이미 생성됐으면 그 Todo의 제목 |
+          | dueDate | string | 마감 일시 (ISO 8601 형식). `filter=all`에서 Todo도 override도 없으면 null |
           | repeatEndDate | string | 반복 종료 마감일 (ISO 8601 형식). 없으면 null |
           | routineTime | string | 마감 시각 (HH:mm:ss 형식). 없으면 null |
           | routineType | string | 반복 유형 (`DAILY` / `WEEKLY` / `MONTHLY`) |
@@ -207,12 +219,12 @@ public interface RoutineControllerDocs {
           | tagTitle | string | 태그 제목. 없으면 null |
           | tagColor | string | 태그 색상. 없으면 null |
           | goalId | integer | 목표 ID. 없으면 null |
-          | todoId | integer | 해당 날짜에 생성된 Todo ID. 아직 생성 안 됐으면 null |
-          | sortOrder | number | 해당 날짜 인스턴스의 정렬 순서 |
-          | isPinned | boolean | 해당 날짜 핀 여부 |
-          | isCompleted | boolean | 해당 날짜 완료 여부 |
+          | todoId | integer | 생성된 Todo ID. `filter=all`에서 아직 생성 안 된 "해야 할 일" 항목은 null |
+          | sortOrder | number | 정렬 순서. `filter=all`에서 Todo/override가 없으면 루틴의 기본 정렬 순서 |
+          | isPinned | boolean | 핀 여부. `filter=all`에서 Todo/override가 없으면 false |
+          | isCompleted | boolean | 완료 여부. `filter=all`의 완료 Todo 항목은 항상 true |
           | isOverdue | boolean | 마감 시각이 지났고 미완료인 경우 true |
-          | hasOverride | boolean | override 존재 여부 |
+          | hasOverride | boolean | override 존재 여부. `filter=all`에서 Todo 기반 항목은 항상 false로 고정(개별 override 반영 여부를 조회하지 않음) |
           """,
       security = @SecurityRequirement(name = "Bearer Authentication"))
   @ApiResponses({
@@ -221,79 +233,153 @@ public interface RoutineControllerDocs {
         description = "조회 성공",
         content =
             @Content(
-                examples =
-                    @ExampleObject(
-                        value =
-                            """
-                            {
-                              "status": 200,
-                              "success": true,
-                              "data": {
-                                "2025-06-20": [
-                                  {
-                                    "routineId": 1,
-                                    "title": "아침 스트레칭",
-                                    "dueDate": "2025-06-20T08:00:00",
-                                    "repeatEndDate": null,
-                                    "routineTime": "08:00:00",
-                                    "routineType": "DAILY",
-                                    "routineDays": null,
-                                    "tagId": null,
-                                    "tagTitle": null,
-                                    "tagColor": null,
-                                    "goalId": null,
-                                    "todoId": 42,
-                                    "sortOrder": 10000.0,
-                                    "isPinned": false,
-                                    "isCompleted": false,
-                                    "isOverdue": false,
-                                    "hasOverride": false
-                                  }
-                                ],
-                                "2025-06-21": [
-                                  {
-                                    "routineId": 1,
-                                    "title": "아침 스트레칭",
-                                    "dueDate": "2025-06-21T08:00:00",
-                                    "repeatEndDate": null,
-                                    "routineTime": "08:00:00",
-                                    "routineType": "DAILY",
-                                    "routineDays": null,
-                                    "tagId": null,
-                                    "tagTitle": null,
-                                    "tagColor": null,
-                                    "goalId": null,
-                                    "todoId": null,
-                                    "sortOrder": 10000.0,
-                                    "isPinned": false,
-                                    "isCompleted": false,
-                                    "isOverdue": false,
-                                    "hasOverride": false
-                                  },
-                                  {
-                                    "routineId": 2,
-                                    "title": "영어 단어 외우기",
-                                    "dueDate": "2025-06-21T09:00:00",
-                                    "repeatEndDate": "2025-12-31T00:00:00",
-                                    "routineTime": "09:00:00",
-                                    "routineType": "WEEKLY",
-                                    "routineDays": [0, 2, 4],
-                                    "tagId": 3,
-                                    "tagTitle": "영어",
-                                    "tagColor": "BLUE",
-                                    "goalId": 2,
-                                    "todoId": 43,
-                                    "sortOrder": 20000.0,
-                                    "isPinned": false,
-                                    "isCompleted": false,
-                                    "isOverdue": false,
-                                    "hasOverride": false
-                                  }
-                                ]
-                              },
-                              "error": null
-                            }
-                            """))),
+                examples = {
+                  @ExampleObject(
+                      name = "filter=day/week/month",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "2025-06-20": [
+                                {
+                                  "routineId": 1,
+                                  "title": "아침 스트레칭",
+                                  "dueDate": "2025-06-20T08:00:00",
+                                  "repeatEndDate": null,
+                                  "routineTime": "08:00:00",
+                                  "routineType": "DAILY",
+                                  "routineDays": null,
+                                  "tagId": null,
+                                  "tagTitle": null,
+                                  "tagColor": null,
+                                  "goalId": null,
+                                  "todoId": 42,
+                                  "sortOrder": 10000.0,
+                                  "isPinned": false,
+                                  "isCompleted": false,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                }
+                              ],
+                              "2025-06-21": [
+                                {
+                                  "routineId": 1,
+                                  "title": "아침 스트레칭",
+                                  "dueDate": "2025-06-21T08:00:00",
+                                  "repeatEndDate": null,
+                                  "routineTime": "08:00:00",
+                                  "routineType": "DAILY",
+                                  "routineDays": null,
+                                  "tagId": null,
+                                  "tagTitle": null,
+                                  "tagColor": null,
+                                  "goalId": null,
+                                  "todoId": null,
+                                  "sortOrder": 10000.0,
+                                  "isPinned": false,
+                                  "isCompleted": false,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                },
+                                {
+                                  "routineId": 2,
+                                  "title": "영어 단어 외우기",
+                                  "dueDate": "2025-06-21T09:00:00",
+                                  "repeatEndDate": "2025-12-31T00:00:00",
+                                  "routineTime": "09:00:00",
+                                  "routineType": "WEEKLY",
+                                  "routineDays": [0, 2, 4],
+                                  "tagId": 3,
+                                  "tagTitle": "영어",
+                                  "tagColor": "BLUE",
+                                  "goalId": 2,
+                                  "todoId": 43,
+                                  "sortOrder": 20000.0,
+                                  "isPinned": false,
+                                  "isCompleted": false,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                }
+                              ]
+                            },
+                            "error": null
+                          }
+                          """),
+                  @ExampleObject(
+                      name = "filter=all",
+                      summary = "루틴 1(완료 이력 없음, 해야 할 일만 1건) + 루틴 2(완료 1건 + 오늘 해야 할 일 1건)",
+                      value =
+                          """
+                          {
+                            "status": 200,
+                            "success": true,
+                            "data": {
+                              "all": [
+                                {
+                                  "routineId": 1,
+                                  "title": "아침 스트레칭",
+                                  "dueDate": null,
+                                  "repeatEndDate": null,
+                                  "routineTime": "08:00:00",
+                                  "routineType": "DAILY",
+                                  "routineDays": null,
+                                  "tagId": null,
+                                  "tagTitle": null,
+                                  "tagColor": null,
+                                  "goalId": null,
+                                  "todoId": null,
+                                  "sortOrder": 10000.0,
+                                  "isPinned": false,
+                                  "isCompleted": false,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                },
+                                {
+                                  "routineId": 2,
+                                  "title": "영어 단어 외우기",
+                                  "dueDate": "2025-06-19T09:00:00",
+                                  "repeatEndDate": "2025-12-31T00:00:00",
+                                  "routineTime": "09:00:00",
+                                  "routineType": "WEEKLY",
+                                  "routineDays": [0, 2, 4],
+                                  "tagId": 3,
+                                  "tagTitle": "영어",
+                                  "tagColor": "BLUE",
+                                  "goalId": 2,
+                                  "todoId": 40,
+                                  "sortOrder": 20000.0,
+                                  "isPinned": false,
+                                  "isCompleted": true,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                },
+                                {
+                                  "routineId": 2,
+                                  "title": "영어 단어 외우기",
+                                  "dueDate": "2025-06-20T09:00:00",
+                                  "repeatEndDate": "2025-12-31T00:00:00",
+                                  "routineTime": "09:00:00",
+                                  "routineType": "WEEKLY",
+                                  "routineDays": [0, 2, 4],
+                                  "tagId": 3,
+                                  "tagTitle": "영어",
+                                  "tagColor": "BLUE",
+                                  "goalId": 2,
+                                  "todoId": 43,
+                                  "sortOrder": 20000.0,
+                                  "isPinned": true,
+                                  "isCompleted": false,
+                                  "isOverdue": false,
+                                  "hasOverride": false
+                                }
+                              ]
+                            },
+                            "error": null
+                          }
+                          """)
+                })),
     @ApiResponse(
         responseCode = "400",
         description = "date 파라미터 누락·형식 오류 또는 filter 값 오류",
@@ -374,10 +460,13 @@ public interface RoutineControllerDocs {
   })
   ResponseEntity<ApiResult<Map<String, List<RoutineResponseDto>>>> getRoutinesByFilter(
       @AuthenticationPrincipal Long userId,
-      @Parameter(description = "조회 범위 (day / week / month)", example = "week")
+      @Parameter(description = "조회 범위 (all / day / week / month)", example = "week")
           @RequestParam(defaultValue = "day")
           String filter,
-      @Parameter(description = "기준 시작 날짜 (yyyy-MM-dd)", example = "2025-06-20") @RequestParam
+      @Parameter(
+              description = "기준 시작 날짜 (yyyy-MM-dd). filter=day/week/month에서는 필수, filter=all에서는 무시됨",
+              example = "2025-06-20")
+          @RequestParam(required = false)
           LocalDate date);
 
   @Operation(

--- a/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
+++ b/src/main/java/plana/replan/domain/routine/controller/RoutineControllerDocs.java
@@ -162,7 +162,8 @@ public interface RoutineControllerDocs {
 
           - `filter=all`: 미래 날짜를 무한히 전개하는 대신(반복 종료일이 없는 루틴은 끝이 없어 전개 자체가 불가능),
             활성 상태인 엄마 루틴마다 아래 두 종류의 항목을 반환합니다. `date` 생략 가능.
-            1. **완료된 Todo 전부** — 기간 제한 없이, 그 루틴에 연결된 완료 Todo를 모두 각각 하나의 항목으로 반환
+            1. **완료 이력 전부** — 기간 제한 없이, (a) 그 루틴에 연결된 완료 Todo 전부와 (b) Todo가 아직 생성되지
+               않았더라도 override로 완료 처리된 날짜(둘 다 각각 하나의 항목)를 합쳐서 반환
             2. **아직 해야 할 일 1건** — 완료되지 않은 Todo 중 가장 최근 것(과거에 놓친 회차 포함)이 있으면 그 상태를,
                없으면 다음 발생일의 override가 있으면 그 값으로, override도 없으면 루틴 기본값으로 구성
           - `filter=day` / `week` / `month`: 해당 기간의 루틴 목록을 날짜별로 묶어 반환합니다. `date` 필수.
@@ -193,7 +194,7 @@ public interface RoutineControllerDocs {
           | date | ❌ 선택 | string | 없음 | 기준 시작 날짜 (yyyy-MM-dd 형식). `filter=day/week/month`에서는 필수이며 생략 시 400 | `2025-06-20` |
 
           **filter 범위 기준**
-          - `all`: date 무관, 활성 엄마 루틴마다 완료 Todo 전부 + 아직 해야 할 일 1건
+          - `all`: date 무관, 활성 엄마 루틴마다 완료 이력 전부(Todo + override 기반) + 아직 해야 할 일 1건
           - `day`: date 당일 1일치
           - `week`: date 포함 7일 (date ~ date+6)
           - `month`: date부터 정확히 1개월 전날까지 (28~31일, 시작 월에 따라 다름)
@@ -204,7 +205,7 @@ public interface RoutineControllerDocs {
 
           `filter=day/week/month`는 날짜(yyyy-MM-dd)를 키로 하는 객체를, `filter=all`은 `"all"` 하나를
           키로 하는 객체를 반환합니다. 값은 각각 해당 범위의 루틴 배열이며, `filter=all`의 경우 루틴 하나당
-          완료 Todo 개수 + 1(아직 해야 할 일)건이 들어갑니다.
+          완료 이력 개수(완료 Todo + Todo 없이 override로만 완료 처리된 날짜) + 1(아직 해야 할 일)건이 들어갑니다.
 
           | 필드명 | 타입 | 설명 |
           |--------|------|------|

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
@@ -20,6 +20,9 @@ public interface RoutineOverrideRepository extends JpaRepository<RoutineOverride
 
   void deleteByRoutineAndOverrideDateGreaterThanEqual(Routine routine, LocalDate date);
 
+  @Query("SELECT o FROM RoutineOverride o LEFT JOIN FETCH o.tag WHERE o.routine IN :routines")
+  List<RoutineOverride> findByRoutineIn(@Param("routines") List<Routine> routines);
+
   @Modifying
   @Query("UPDATE RoutineOverride o SET o.tag = null WHERE o.tag = :tag")
   void clearTagFromOverrides(@Param("tag") Tag tag);

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineOverrideRepository.java
@@ -4,8 +4,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import plana.replan.domain.routine.entity.Routine;
 import plana.replan.domain.routine.entity.RoutineOverride;
+import plana.replan.domain.tag.entity.Tag;
 
 public interface RoutineOverrideRepository extends JpaRepository<RoutineOverride, Long> {
 
@@ -15,4 +19,8 @@ public interface RoutineOverrideRepository extends JpaRepository<RoutineOverride
       List<Long> routineIds, LocalDate overrideDate);
 
   void deleteByRoutineAndOverrideDateGreaterThanEqual(Routine routine, LocalDate date);
+
+  @Modifying
+  @Query("UPDATE RoutineOverride o SET o.tag = null WHERE o.tag = :tag")
+  void clearTagFromOverrides(@Param("tag") Tag tag);
 }

--- a/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/plana/replan/domain/routine/repository/RoutineRepository.java
@@ -31,6 +31,11 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
   List<Routine> findAllActiveMotherRoutines();
 
   @Query(
+      "SELECT r FROM Routine r WHERE r.user.id = :userId AND r.parent IS NULL"
+          + " AND r.isActive = true ORDER BY r.defaultSortOrder ASC")
+  List<Routine> findAllActiveMotherRoutinesByUser(@Param("userId") Long userId);
+
+  @Query(
       nativeQuery = true,
       value =
           """

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -200,12 +200,7 @@ public class RoutineService {
 
     String normalizedFilter = filter.toLowerCase();
     if (normalizedFilter.equals("all")) {
-      LocalDate today = LocalDate.now(clock);
-      List<RoutineResponseDto> routines =
-          routineRepository.findAllActiveMotherRoutinesByUser(userId).stream()
-              .flatMap(routine -> buildAllFilterResponses(routine, today).stream())
-              .collect(Collectors.toList());
-      return Map.of("all", routines);
+      return Map.of("all", getAllFilterRoutines(userId));
     }
 
     if (date == null) {
@@ -227,39 +222,92 @@ public class RoutineService {
     return result;
   }
 
-  /**
-   * 루틴 1건에 대한 all 필터 응답: (1) 존재하는 완료 Todo 전부 + (2) 아직 해야 할 일 1건. (2)는 완료 안 된 Todo 중 가장 최근 것(과거 미완료
-   * 포함)이 있으면 그 상태로, 없으면 다음 발생일의 override 또는 루틴 기본값으로 구성한다.
-   */
-  private List<RoutineResponseDto> buildAllFilterResponses(Routine routine, LocalDate today) {
-    List<Todo> completedTodos = todoRepository.findCompletedMotherTodosByRoutine(routine);
-    Stream<RoutineResponseDto> completed =
-        completedTodos.stream().map(todo -> toRoutineResponseFromTodo(routine, todo));
-    return Stream.concat(
-            completed, Stream.of(toNextActionableRoutineResponse(routine, today, completedTodos)))
+  /** all 필터 전체 처리. 완료/미완료 Todo와 override를 루틴별로 한 번씩만 배치 조회해(N+1 방지) 각 루틴의 응답을 구성한다. */
+  private List<RoutineResponseDto> getAllFilterRoutines(Long userId) {
+    List<Routine> routines = routineRepository.findAllActiveMotherRoutinesByUser(userId);
+    if (routines.isEmpty()) {
+      return List.of();
+    }
+
+    LocalDate today = LocalDate.now(clock);
+    Map<Long, List<Todo>> completedByRoutine =
+        todoRepository.findCompletedMotherTodosByRoutines(routines).stream()
+            .collect(Collectors.groupingBy(t -> t.getRoutine().getId()));
+    Map<Long, Todo> latestIncompleteByRoutine =
+        todoRepository.findIncompleteMotherTodosByRoutines(routines).stream()
+            .collect(Collectors.toMap(t -> t.getRoutine().getId(), t -> t, (a, b) -> a));
+    Map<Long, List<RoutineOverride>> overridesByRoutine =
+        routineOverrideRepository.findByRoutineIn(routines).stream()
+            .collect(Collectors.groupingBy(o -> o.getRoutine().getId()));
+
+    return routines.stream()
+        .flatMap(
+            routine ->
+                buildAllFilterResponses(
+                    routine,
+                    today,
+                    completedByRoutine.getOrDefault(routine.getId(), List.of()),
+                    Optional.ofNullable(latestIncompleteByRoutine.get(routine.getId())),
+                    overridesByRoutine.getOrDefault(routine.getId(), List.of()))
+                    .stream())
         .collect(Collectors.toList());
   }
 
   /**
-   * 완료 안 된 Todo 중 가장 최근 것이 있으면 그 상태를 반환한다. 없으면 다음 발생일부터 하루씩 훑어, 이미 완료 Todo가 있거나(completedTodos)
-   * override로 완료/스킵 처리된 날짜는 건너뛰고, 아직 해결되지 않은 첫 날짜를 override(있으면) 또는 루틴 기본값으로 구성한다. (DAILY 루틴은 오늘
-   * 회차가 이미 끝났어도 nextOccurrence가 항상 오늘을 가리키므로, 이 건너뛰기 로직이 없으면 방금 완료 처리한 오늘 회차를 "다음 할 일"로 다시 보여주는 문제가
-   * 생긴다.)
+   * 루틴 1건에 대한 all 필터 응답: (1) 완료 Todo 전부 + Todo 없이 override만으로 완료 처리된 날짜 + (2) 아직 해야 할 일 1건. (2)는 완료
+   * 안 된 Todo 중 가장 최근 것(과거 미완료 포함)이 있으면 그 상태로, 없으면 다음 발생일의 override 또는 루틴 기본값으로 구성한다.
    */
-  private RoutineResponseDto toNextActionableRoutineResponse(
-      Routine routine, LocalDate today, List<Todo> completedTodos) {
-    Optional<Todo> latestIncomplete =
-        todoRepository.findLatestIncompleteMotherTodoByRoutine(routine);
-    if (latestIncomplete.isPresent()) {
-      return toRoutineResponseFromTodo(routine, latestIncomplete.get());
-    }
-
+  private List<RoutineResponseDto> buildAllFilterResponses(
+      Routine routine,
+      LocalDate today,
+      List<Todo> completedTodos,
+      Optional<Todo> latestIncomplete,
+      List<RoutineOverride> overrides) {
     Set<LocalDate> completedDates =
         completedTodos.stream()
             .map(Todo::getDueDate)
             .filter(Objects::nonNull)
             .map(LocalDateTime::toLocalDate)
             .collect(Collectors.toSet());
+
+    Map<LocalDate, RoutineOverride> overridesByDate =
+        overrides.stream()
+            .collect(Collectors.toMap(RoutineOverride::getOverrideDate, o -> o, (a, b) -> a));
+
+    Stream<RoutineResponseDto> completedFromTodos =
+        completedTodos.stream().map(todo -> toRoutineResponseFromTodo(routine, todo));
+
+    // Todo가 아직 생성되지 않은 날짜라도 override로 완료 처리됐다면 완료 이력에서 빠지지 않도록 포함한다.
+    Stream<RoutineResponseDto> completedFromOverrides =
+        overrides.stream()
+            .filter(o -> Boolean.TRUE.equals(o.getIsCompleted()))
+            .filter(o -> !completedDates.contains(o.getOverrideDate()))
+            .map(o -> toRoutineResponseFromOverride(routine, o.getOverrideDate(), o));
+
+    RoutineResponseDto nextAction =
+        toNextActionableRoutineResponse(
+            routine, today, completedDates, latestIncomplete, overridesByDate);
+
+    return Stream.concat(
+            Stream.concat(completedFromTodos, completedFromOverrides), Stream.of(nextAction))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 완료 안 된 Todo 중 가장 최근 것이 있으면 그 상태를 반환한다. 없으면 다음 발생일부터 하루씩 훑어, 이미 완료 처리된 날짜(Todo 또는 override)이거나
+   * skip override가 있는 날짜는 건너뛰고, 아직 해결되지 않은 첫 날짜를 override(있으면) 또는 루틴 기본값으로 구성한다. 반복
+   * 종료일(routine.getDueDate())을 넘어서면 더 찾지 않고 루틴 기본값으로 되돌아간다. (DAILY 루틴은 오늘 회차가 이미 끝났어도
+   * nextOccurrence가 항상 오늘을 가리키므로, 이 건너뛰기 로직이 없으면 방금 완료 처리한 오늘 회차를 "다음 할 일"로 다시 보여주는 문제가 생긴다.)
+   */
+  private RoutineResponseDto toNextActionableRoutineResponse(
+      Routine routine,
+      LocalDate today,
+      Set<LocalDate> completedDates,
+      Optional<Todo> latestIncomplete,
+      Map<LocalDate, RoutineOverride> overridesByDate) {
+    if (latestIncomplete.isPresent()) {
+      return toRoutineResponseFromTodo(routine, latestIncomplete.get());
+    }
 
     LocalDate repeatEndDate =
         routine.getDueDate() != null ? routine.getDueDate().toLocalDate() : null;
@@ -272,62 +320,64 @@ public class RoutineService {
         candidate = nextOccurrence(routine, candidate.plusDays(1));
         continue;
       }
-      RoutineOverride override =
-          routineOverrideRepository.findByRoutineAndOverrideDate(routine, candidate).orElse(null);
+      RoutineOverride override = overridesByDate.get(candidate);
       if (override != null
           && (override.isSkipped() || Boolean.TRUE.equals(override.getIsCompleted()))) {
         candidate = nextOccurrence(routine, candidate.plusDays(1));
         continue;
       }
-      return toRoutineResponseFromOverrideOrDefault(routine, candidate, override);
+      return override != null
+          ? toRoutineResponseFromOverride(routine, candidate, override)
+          : RoutineResponseDto.from(routine);
     }
     return RoutineResponseDto.from(routine);
   }
 
   private RoutineResponseDto toRoutineResponseFromTodo(Routine routine, Todo todo) {
-    Tag tag = todo.getTag();
-    boolean overdue =
-        !todo.isCompleted()
-            && todo.getDueDate() != null
-            && todo.getDueDate().isBefore(LocalDateTime.now(clock));
-
-    return new RoutineResponseDto(
-        routine.getId(),
+    return buildRoutineResponse(
+        routine,
         todo.getTitle(),
         todo.getDueDate(),
-        routine.getDueDate(),
-        routine.getRoutineTime(),
-        routine.getRoutineType(),
-        RoutineDays.toDays(routine.getRoutineType(), routine.getRoutineDate()),
-        tag != null ? tag.getId() : null,
-        tag != null ? tag.getTitle() : null,
-        tag != null ? tag.getColor() : null,
-        routine.getGoal() != null ? routine.getGoal().getId() : null,
+        todo.getTag(),
         todo.getId(),
         todo.getSortOrder(),
         todo.isPinned(),
         todo.isCompleted(),
-        overdue,
         false);
   }
 
-  private RoutineResponseDto toRoutineResponseFromOverrideOrDefault(
-      Routine routine, LocalDate nextDate, RoutineOverride override) {
-    if (override == null) {
-      return RoutineResponseDto.from(routine);
-    }
-
+  private RoutineResponseDto toRoutineResponseFromOverride(
+      Routine routine, LocalDate date, RoutineOverride override) {
     LocalTime time =
         routine.getRoutineTime() != null ? routine.getRoutineTime() : LocalTime.of(23, 59, 59);
-    LocalDateTime dueDate = nextDate.atTime(time);
     Tag tag = override.getTag() != null ? override.getTag() : routine.getTag();
-    boolean isCompleted = Boolean.TRUE.equals(override.getIsCompleted());
-    boolean isPinned = Boolean.TRUE.equals(override.getIsPinned());
-    boolean overdue = !isCompleted && dueDate.isBefore(LocalDateTime.now(clock));
+    return buildRoutineResponse(
+        routine,
+        override.getTitle() != null ? override.getTitle() : routine.getTitle(),
+        date.atTime(time),
+        tag,
+        null,
+        override.getSortOrder() != null ? override.getSortOrder() : routine.getDefaultSortOrder(),
+        Boolean.TRUE.equals(override.getIsPinned()),
+        Boolean.TRUE.equals(override.getIsCompleted()),
+        true);
+  }
+
+  private RoutineResponseDto buildRoutineResponse(
+      Routine routine,
+      String title,
+      LocalDateTime dueDate,
+      Tag tag,
+      Long todoId,
+      double sortOrder,
+      boolean isPinned,
+      boolean isCompleted,
+      boolean hasOverride) {
+    boolean overdue = !isCompleted && dueDate != null && dueDate.isBefore(LocalDateTime.now(clock));
 
     return new RoutineResponseDto(
         routine.getId(),
-        override.getTitle() != null ? override.getTitle() : routine.getTitle(),
+        title,
         dueDate,
         routine.getDueDate(),
         routine.getRoutineTime(),
@@ -337,12 +387,12 @@ public class RoutineService {
         tag != null ? tag.getTitle() : null,
         tag != null ? tag.getColor() : null,
         routine.getGoal() != null ? routine.getGoal().getId() : null,
-        null,
-        override.getSortOrder() != null ? override.getSortOrder() : routine.getDefaultSortOrder(),
+        todoId,
+        sortOrder,
         isPinned,
         isCompleted,
         overdue,
-        true);
+        hasOverride);
   }
 
   private List<RoutineResponseDto> getRoutinesForDate(Long userId, LocalDate date) {

--- a/src/main/java/plana/replan/domain/routine/service/RoutineService.java
+++ b/src/main/java/plana/replan/domain/routine/service/RoutineService.java
@@ -7,8 +7,11 @@ import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -195,8 +198,22 @@ public class RoutineService {
         .findById(userId)
         .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
+    String normalizedFilter = filter.toLowerCase();
+    if (normalizedFilter.equals("all")) {
+      LocalDate today = LocalDate.now(clock);
+      List<RoutineResponseDto> routines =
+          routineRepository.findAllActiveMotherRoutinesByUser(userId).stream()
+              .flatMap(routine -> buildAllFilterResponses(routine, today).stream())
+              .collect(Collectors.toList());
+      return Map.of("all", routines);
+    }
+
+    if (date == null) {
+      throw new CustomException(GlobalErrorCode.INVALID_INPUT);
+    }
+
     List<LocalDate> dates =
-        switch (filter.toLowerCase()) {
+        switch (normalizedFilter) {
           case "day" -> List.of(date);
           case "week" -> date.datesUntil(date.plusWeeks(1)).collect(Collectors.toList());
           case "month" -> date.datesUntil(date.plusMonths(1)).collect(Collectors.toList());
@@ -208,6 +225,124 @@ public class RoutineService {
       result.put(d.toString(), getRoutinesForDate(userId, d));
     }
     return result;
+  }
+
+  /**
+   * 루틴 1건에 대한 all 필터 응답: (1) 존재하는 완료 Todo 전부 + (2) 아직 해야 할 일 1건. (2)는 완료 안 된 Todo 중 가장 최근 것(과거 미완료
+   * 포함)이 있으면 그 상태로, 없으면 다음 발생일의 override 또는 루틴 기본값으로 구성한다.
+   */
+  private List<RoutineResponseDto> buildAllFilterResponses(Routine routine, LocalDate today) {
+    List<Todo> completedTodos = todoRepository.findCompletedMotherTodosByRoutine(routine);
+    Stream<RoutineResponseDto> completed =
+        completedTodos.stream().map(todo -> toRoutineResponseFromTodo(routine, todo));
+    return Stream.concat(
+            completed, Stream.of(toNextActionableRoutineResponse(routine, today, completedTodos)))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 완료 안 된 Todo 중 가장 최근 것이 있으면 그 상태를 반환한다. 없으면 다음 발생일부터 하루씩 훑어, 이미 완료 Todo가 있거나(completedTodos)
+   * override로 완료/스킵 처리된 날짜는 건너뛰고, 아직 해결되지 않은 첫 날짜를 override(있으면) 또는 루틴 기본값으로 구성한다. (DAILY 루틴은 오늘
+   * 회차가 이미 끝났어도 nextOccurrence가 항상 오늘을 가리키므로, 이 건너뛰기 로직이 없으면 방금 완료 처리한 오늘 회차를 "다음 할 일"로 다시 보여주는 문제가
+   * 생긴다.)
+   */
+  private RoutineResponseDto toNextActionableRoutineResponse(
+      Routine routine, LocalDate today, List<Todo> completedTodos) {
+    Optional<Todo> latestIncomplete =
+        todoRepository.findLatestIncompleteMotherTodoByRoutine(routine);
+    if (latestIncomplete.isPresent()) {
+      return toRoutineResponseFromTodo(routine, latestIncomplete.get());
+    }
+
+    Set<LocalDate> completedDates =
+        completedTodos.stream()
+            .map(Todo::getDueDate)
+            .filter(Objects::nonNull)
+            .map(LocalDateTime::toLocalDate)
+            .collect(Collectors.toSet());
+
+    LocalDate repeatEndDate =
+        routine.getDueDate() != null ? routine.getDueDate().toLocalDate() : null;
+    LocalDate candidate = nextOccurrence(routine, today);
+    for (int i = 0; i < 366; i++) {
+      if (repeatEndDate != null && candidate.isAfter(repeatEndDate)) {
+        break;
+      }
+      if (completedDates.contains(candidate)) {
+        candidate = nextOccurrence(routine, candidate.plusDays(1));
+        continue;
+      }
+      RoutineOverride override =
+          routineOverrideRepository.findByRoutineAndOverrideDate(routine, candidate).orElse(null);
+      if (override != null
+          && (override.isSkipped() || Boolean.TRUE.equals(override.getIsCompleted()))) {
+        candidate = nextOccurrence(routine, candidate.plusDays(1));
+        continue;
+      }
+      return toRoutineResponseFromOverrideOrDefault(routine, candidate, override);
+    }
+    return RoutineResponseDto.from(routine);
+  }
+
+  private RoutineResponseDto toRoutineResponseFromTodo(Routine routine, Todo todo) {
+    Tag tag = todo.getTag();
+    boolean overdue =
+        !todo.isCompleted()
+            && todo.getDueDate() != null
+            && todo.getDueDate().isBefore(LocalDateTime.now(clock));
+
+    return new RoutineResponseDto(
+        routine.getId(),
+        todo.getTitle(),
+        todo.getDueDate(),
+        routine.getDueDate(),
+        routine.getRoutineTime(),
+        routine.getRoutineType(),
+        RoutineDays.toDays(routine.getRoutineType(), routine.getRoutineDate()),
+        tag != null ? tag.getId() : null,
+        tag != null ? tag.getTitle() : null,
+        tag != null ? tag.getColor() : null,
+        routine.getGoal() != null ? routine.getGoal().getId() : null,
+        todo.getId(),
+        todo.getSortOrder(),
+        todo.isPinned(),
+        todo.isCompleted(),
+        overdue,
+        false);
+  }
+
+  private RoutineResponseDto toRoutineResponseFromOverrideOrDefault(
+      Routine routine, LocalDate nextDate, RoutineOverride override) {
+    if (override == null) {
+      return RoutineResponseDto.from(routine);
+    }
+
+    LocalTime time =
+        routine.getRoutineTime() != null ? routine.getRoutineTime() : LocalTime.of(23, 59, 59);
+    LocalDateTime dueDate = nextDate.atTime(time);
+    Tag tag = override.getTag() != null ? override.getTag() : routine.getTag();
+    boolean isCompleted = Boolean.TRUE.equals(override.getIsCompleted());
+    boolean isPinned = Boolean.TRUE.equals(override.getIsPinned());
+    boolean overdue = !isCompleted && dueDate.isBefore(LocalDateTime.now(clock));
+
+    return new RoutineResponseDto(
+        routine.getId(),
+        override.getTitle() != null ? override.getTitle() : routine.getTitle(),
+        dueDate,
+        routine.getDueDate(),
+        routine.getRoutineTime(),
+        routine.getRoutineType(),
+        RoutineDays.toDays(routine.getRoutineType(), routine.getRoutineDate()),
+        tag != null ? tag.getId() : null,
+        tag != null ? tag.getTitle() : null,
+        tag != null ? tag.getColor() : null,
+        routine.getGoal() != null ? routine.getGoal().getId() : null,
+        null,
+        override.getSortOrder() != null ? override.getSortOrder() : routine.getDefaultSortOrder(),
+        isPinned,
+        isCompleted,
+        overdue,
+        true);
   }
 
   private List<RoutineResponseDto> getRoutinesForDate(Long userId, LocalDate date) {

--- a/src/main/java/plana/replan/domain/tag/service/TagService.java
+++ b/src/main/java/plana/replan/domain/tag/service/TagService.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.dto.TagCreateRequestDto;
 import plana.replan.domain.tag.dto.TagResponseDto;
@@ -38,6 +39,7 @@ public class TagService {
   private final UserRepository userRepository;
   private final TodoRepository todoRepository;
   private final RoutineRepository routineRepository;
+  private final RoutineOverrideRepository routineOverrideRepository;
 
   @Transactional(readOnly = true)
   public List<TagResponseDto> getTags(Long userId) {
@@ -134,6 +136,7 @@ public class TagService {
 
     todoRepository.clearTagFromTodos(tag);
     routineRepository.clearTagFromRoutines(tag);
+    routineOverrideRepository.clearTagFromOverrides(tag);
     tag.softDelete();
   }
 }

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -59,7 +59,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   List<Todo> findCompletedMotherTodosByRoutines(@Param("routines") List<Routine> routines);
 
   @Query(
-      "SELECT t FROM Todo t WHERE t.routine IN :routines AND t.parent IS NULL"
+      "SELECT t FROM Todo t LEFT JOIN FETCH t.tag WHERE t.routine IN :routines AND t.parent IS NULL"
           + " AND t.isCompleted = false AND t.isActive = true ORDER BY t.dueDate DESC")
   List<Todo> findIncompleteMotherTodosByRoutines(@Param("routines") List<Routine> routines);
 

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -54,6 +54,23 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   }
 
   @Query(
+      "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
+          + " AND t.isCompleted = true AND t.isActive = true ORDER BY t.dueDate DESC")
+  List<Todo> findCompletedMotherTodosByRoutine(@Param("routine") Routine routine);
+
+  @Query(
+      "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
+          + " AND t.isCompleted = false AND t.isActive = true ORDER BY t.dueDate DESC")
+  List<Todo> findIncompleteMotherTodosByRoutineOrderByDueDateDesc(
+      @Param("routine") Routine routine, Pageable pageable);
+
+  default Optional<Todo> findLatestIncompleteMotherTodoByRoutine(Routine routine) {
+    return findIncompleteMotherTodosByRoutineOrderByDueDateDesc(routine, PageRequest.of(0, 1))
+        .stream()
+        .findFirst();
+  }
+
+  @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"
           + " AND t.isActive = true AND t.routine IS NULL")
   List<Todo> findActiveTodosForUser(@Param("user") User user);

--- a/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/plana/replan/domain/todo/repository/TodoRepository.java
@@ -54,21 +54,14 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
   }
 
   @Query(
-      "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
+      "SELECT t FROM Todo t LEFT JOIN FETCH t.tag WHERE t.routine IN :routines AND t.parent IS NULL"
           + " AND t.isCompleted = true AND t.isActive = true ORDER BY t.dueDate DESC")
-  List<Todo> findCompletedMotherTodosByRoutine(@Param("routine") Routine routine);
+  List<Todo> findCompletedMotherTodosByRoutines(@Param("routines") List<Routine> routines);
 
   @Query(
-      "SELECT t FROM Todo t WHERE t.routine = :routine AND t.parent IS NULL"
+      "SELECT t FROM Todo t WHERE t.routine IN :routines AND t.parent IS NULL"
           + " AND t.isCompleted = false AND t.isActive = true ORDER BY t.dueDate DESC")
-  List<Todo> findIncompleteMotherTodosByRoutineOrderByDueDateDesc(
-      @Param("routine") Routine routine, Pageable pageable);
-
-  default Optional<Todo> findLatestIncompleteMotherTodoByRoutine(Routine routine) {
-    return findIncompleteMotherTodosByRoutineOrderByDueDateDesc(routine, PageRequest.of(0, 1))
-        .stream()
-        .findFirst();
-  }
+  List<Todo> findIncompleteMotherTodosByRoutines(@Param("routines") List<Routine> routines);
 
   @Query(
       "SELECT t FROM Todo t WHERE t.user = :user AND t.parent IS NULL AND t.isCompleted = false"

--- a/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/plana/replan/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import plana.replan.global.common.ApiResult;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.exc.StreamReadException;
@@ -48,6 +50,23 @@ public class GlobalExceptionHandler {
             .map(v -> v.getPropertyPath() + ": " + v.getMessage())
             .orElse(e.getMessage());
     log.error("ConstraintViolationException: {}", detail);
+    return ResponseEntity.badRequest()
+        .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiResult<?>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+    String detail = e.getName() + ": 값 형식이 올바르지 않습니다";
+    log.error("MethodArgumentTypeMismatchException: {}", detail);
+    return ResponseEntity.badRequest()
+        .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ApiResult<?>> handleMissingParameter(
+      MissingServletRequestParameterException e) {
+    String detail = e.getParameterName() + ": 필수 파라미터입니다";
+    log.error("MissingServletRequestParameterException: {}", detail);
     return ResponseEntity.badRequest()
         .body(ApiResult.error(400, ErrorDetail.of(GlobalErrorCode.INVALID_INPUT, detail)));
   }

--- a/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
+++ b/src/test/java/plana/replan/domain/routine/controller/RoutineControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -491,5 +492,27 @@ class RoutineControllerTest {
                     """))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("ROUTINE_NOT_FOUND"));
+  }
+
+  // ========== getRoutinesByFilter: date 파라미터 형식 오류 ==========
+
+  @Test
+  @DisplayName("filter=day, date 형식 오류: status=400, error.code=INVALID_INPUT (500 아님)")
+  void getRoutinesByFilter_day_malformedDate_returns400NotInternalServerError() throws Exception {
+    mockMvc
+        .perform(get("/api/routines?filter=day&date=notadate").with(authentication(authToken(1L))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  @DisplayName("filter=all, date 형식 오류: status=400, error.code=INVALID_INPUT (500 아님)")
+  void getRoutinesByFilter_all_malformedDate_returns400NotInternalServerError() throws Exception {
+    mockMvc
+        .perform(get("/api/routines?filter=all&date=notadate").with(authentication(authToken(1L))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
   }
 }

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -3,7 +3,6 @@ package plana.replan.domain.routine.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -916,17 +915,35 @@ class RoutineServiceTest {
 
   // ========== getRoutinesByFilter ==========
 
+  private Todo routineTodo(Routine routine, String title, LocalDateTime dueDate) {
+    return Todo.builder()
+        .title(title)
+        .dueDate(dueDate)
+        .user(testUser())
+        .isPinned(false)
+        .routine(routine)
+        .build();
+  }
+
+  private void givenAllFilterData(
+      Routine routine,
+      List<Todo> completed,
+      List<Todo> incomplete,
+      List<RoutineOverride> overrides) {
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+    given(todoRepository.findCompletedMotherTodosByRoutines(List.of(routine)))
+        .willReturn(completed);
+    given(todoRepository.findIncompleteMotherTodosByRoutines(List.of(routine)))
+        .willReturn(incomplete);
+    given(routineOverrideRepository.findByRoutineIn(List.of(routine))).willReturn(overrides);
+  }
+
   @Test
   void getRoutinesByFilter_all_완료된Todo도_미완료Todo도_없으면_루틴_기본값_1건() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     ReflectionTestUtils.setField(routine, "id", 10L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.empty());
-    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
-        .willReturn(Optional.empty());
+    givenAllFilterData(routine, List.of(), List.of(), List.of());
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
@@ -941,11 +958,24 @@ class RoutineServiceTest {
   }
 
   @Test
+  void getRoutinesByFilter_all_라우틴이_없으면_배치조회_없이_빈리스트() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of());
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    assertThat(result.get("all")).isEmpty();
+    verify(todoRepository, never()).findCompletedMotherTodosByRoutines(any());
+    verify(todoRepository, never()).findIncompleteMotherTodosByRoutines(any());
+    verify(routineOverrideRepository, never()).findByRoutineIn(any());
+  }
+
+  @Test
   void getRoutinesByFilter_all_완료된_Todo는_기간제한없이_전부_반환() {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     ReflectionTestUtils.setField(routine, "id", 10L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
 
     Todo oldCompleted = routineTodo(routine, "예전 스트레칭", TEST_DATE.minusDays(30).atTime(8, 0));
     ReflectionTestUtils.setField(oldCompleted, "id", 100L);
@@ -954,12 +984,7 @@ class RoutineServiceTest {
     ReflectionTestUtils.setField(todayCompleted, "id", 200L);
     todayCompleted.updateCompleted(true, TEST_DATE.atStartOfDay());
 
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine))
-        .willReturn(List.of(todayCompleted, oldCompleted));
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.empty());
-    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
-        .willReturn(Optional.empty());
+    givenAllFilterData(routine, List.of(todayCompleted, oldCompleted), List.of(), List.of());
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
@@ -976,14 +1001,12 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     ReflectionTestUtils.setField(routine, "id", 10L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
 
     Todo overdueIncomplete =
         routineTodo(routine, "어제 못한 스트레칭", TEST_DATE.minusDays(1).atTime(8, 0));
     ReflectionTestUtils.setField(overdueIncomplete, "id", 300L);
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.of(overdueIncomplete));
+
+    givenAllFilterData(routine, List.of(), List.of(overdueIncomplete), List.of());
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
@@ -1000,34 +1023,45 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     ReflectionTestUtils.setField(routine, "id", 10L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.empty());
 
     RoutineOverride override =
         RoutineOverride.builder().routine(routine).overrideDate(TEST_DATE).build();
     override.updateContent("오버라이드 제목", null);
-    given(routineOverrideRepository.findByRoutineAndOverrideDate(routine, TEST_DATE))
-        .willReturn(Optional.of(override));
+
+    givenAllFilterData(routine, List.of(), List.of(), List.of(override));
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
 
+    assertThat(result.get("all")).hasSize(1);
     RoutineResponseDto dto = result.get("all").get(0);
     assertThat(dto.getTodoId()).isNull();
     assertThat(dto.getTitle()).isEqualTo("오버라이드 제목");
     assertThat(dto.isHasOverride()).isTrue();
   }
 
-  private Todo routineTodo(Routine routine, String title, LocalDateTime dueDate) {
-    return Todo.builder()
-        .title(title)
-        .dueDate(dueDate)
-        .user(testUser())
-        .isPinned(false)
-        .routine(routine)
-        .build();
+  @Test
+  void getRoutinesByFilter_all_Todo없이_override로만_완료처리된_날짜도_완료이력에_포함된다() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+
+    // Todo가 아직 생성 안 된 미래 날짜에 override로만 완료 처리 (예: 미리 당겨서 완료 체크)
+    RoutineOverride completedOverride =
+        RoutineOverride.builder().routine(routine).overrideDate(TEST_DATE.plusDays(1)).build();
+    completedOverride.updateComplete(true, TEST_DATE.atStartOfDay());
+
+    givenAllFilterData(routine, List.of(), List.of(), List.of(completedOverride));
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    // override 기반 완료 이력 1건 + 다음 할 일(오늘, 루틴 기본값) 1건
+    assertThat(result.get("all")).hasSize(2);
+    assertThat(result.get("all"))
+        .extracting(RoutineResponseDto::isCompleted)
+        .containsExactly(true, false);
+    assertThat(result.get("all").get(0).isHasOverride()).isTrue();
   }
 
   @Test
@@ -1035,18 +1069,12 @@ class RoutineServiceTest {
     given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
     Routine routine = buildRoutine(RoutineType.DAILY, null);
     ReflectionTestUtils.setField(routine, "id", 10L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
 
     Todo completedNoDueDate = routineTodo(routine, "일반 투두였다가 루틴이 붙음", null);
     ReflectionTestUtils.setField(completedNoDueDate, "id", 400L);
     completedNoDueDate.updateCompleted(true, TEST_DATE.atStartOfDay());
 
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine))
-        .willReturn(List.of(completedNoDueDate));
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.empty());
-    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
-        .willReturn(Optional.empty());
+    givenAllFilterData(routine, List.of(completedNoDueDate), List.of(), List.of());
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
@@ -1068,10 +1096,7 @@ class RoutineServiceTest {
             .user(testUser())
             .build();
     ReflectionTestUtils.setField(routine, "id", 11L);
-    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
-    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
-    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
-        .willReturn(Optional.empty());
+    givenAllFilterData(routine, List.of(), List.of(), List.of());
 
     Map<String, List<RoutineResponseDto>> result =
         routineService.getRoutinesByFilter(1L, "all", null);
@@ -1081,7 +1106,6 @@ class RoutineServiceTest {
     assertThat(dto.getTodoId()).isNull();
     assertThat(dto.getDueDate()).isNull();
     assertThat(dto.isHasOverride()).isFalse();
-    verify(routineOverrideRepository, never()).findByRoutineAndOverrideDate(any(), any());
   }
 
   @Test

--- a/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
+++ b/src/test/java/plana/replan/domain/routine/service/RoutineServiceTest.java
@@ -3,6 +3,7 @@ package plana.replan.domain.routine.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,7 @@ import plana.replan.domain.user.entity.User;
 import plana.replan.domain.user.exception.UserErrorCode;
 import plana.replan.domain.user.repository.UserRepository;
 import plana.replan.global.exception.CustomException;
+import plana.replan.global.exception.GlobalErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class RoutineServiceTest {
@@ -909,5 +912,187 @@ class RoutineServiceTest {
         1L, 10L, new RoutineUpdateRequestDto("수정된 루틴", null, null, RoutineType.DAILY, null, null));
 
     assertThat(existingTodo.getTitle()).isEqualTo("수정된 루틴");
+  }
+
+  // ========== getRoutinesByFilter ==========
+
+  @Test
+  void getRoutinesByFilter_all_완료된Todo도_미완료Todo도_없으면_루틴_기본값_1건() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.empty());
+    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
+        .willReturn(Optional.empty());
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    assertThat(result).containsOnlyKeys("all");
+    assertThat(result.get("all")).hasSize(1);
+    RoutineResponseDto dto = result.get("all").get(0);
+    assertThat(dto.getRoutineId()).isEqualTo(10L);
+    assertThat(dto.getTodoId()).isNull();
+    assertThat(dto.isCompleted()).isFalse();
+    assertThat(dto.isPinned()).isFalse();
+  }
+
+  @Test
+  void getRoutinesByFilter_all_완료된_Todo는_기간제한없이_전부_반환() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+
+    Todo oldCompleted = routineTodo(routine, "예전 스트레칭", TEST_DATE.minusDays(30).atTime(8, 0));
+    ReflectionTestUtils.setField(oldCompleted, "id", 100L);
+    oldCompleted.updateCompleted(true, TEST_DATE.minusDays(30).atStartOfDay());
+    Todo todayCompleted = routineTodo(routine, "오늘의 스트레칭", TEST_DATE.atTime(8, 0));
+    ReflectionTestUtils.setField(todayCompleted, "id", 200L);
+    todayCompleted.updateCompleted(true, TEST_DATE.atStartOfDay());
+
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine))
+        .willReturn(List.of(todayCompleted, oldCompleted));
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.empty());
+    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
+        .willReturn(Optional.empty());
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    // 완료 2건(기간 제한 없이 전부) + 다음 할 일(루틴 기본값) 1건
+    assertThat(result.get("all")).hasSize(3);
+    assertThat(result.get("all"))
+        .extracting(RoutineResponseDto::getTodoId)
+        .containsExactly(200L, 100L, null);
+  }
+
+  @Test
+  void getRoutinesByFilter_all_과거_미완료Todo가_있으면_그것을_다음할일로_반영() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
+
+    Todo overdueIncomplete =
+        routineTodo(routine, "어제 못한 스트레칭", TEST_DATE.minusDays(1).atTime(8, 0));
+    ReflectionTestUtils.setField(overdueIncomplete, "id", 300L);
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.of(overdueIncomplete));
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    assertThat(result.get("all")).hasSize(1);
+    RoutineResponseDto dto = result.get("all").get(0);
+    assertThat(dto.getTodoId()).isEqualTo(300L);
+    assertThat(dto.getTitle()).isEqualTo("어제 못한 스트레칭");
+    assertThat(dto.isCompleted()).isFalse();
+  }
+
+  @Test
+  void getRoutinesByFilter_all_Todo_없고_override_있으면_override로_구성() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.empty());
+
+    RoutineOverride override =
+        RoutineOverride.builder().routine(routine).overrideDate(TEST_DATE).build();
+    override.updateContent("오버라이드 제목", null);
+    given(routineOverrideRepository.findByRoutineAndOverrideDate(routine, TEST_DATE))
+        .willReturn(Optional.of(override));
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    RoutineResponseDto dto = result.get("all").get(0);
+    assertThat(dto.getTodoId()).isNull();
+    assertThat(dto.getTitle()).isEqualTo("오버라이드 제목");
+    assertThat(dto.isHasOverride()).isTrue();
+  }
+
+  private Todo routineTodo(Routine routine, String title, LocalDateTime dueDate) {
+    return Todo.builder()
+        .title(title)
+        .dueDate(dueDate)
+        .user(testUser())
+        .isPinned(false)
+        .routine(routine)
+        .build();
+  }
+
+  @Test
+  void getRoutinesByFilter_all_완료된_Todo의_dueDate가_null이어도_NPE_없이_반환() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine = buildRoutine(RoutineType.DAILY, null);
+    ReflectionTestUtils.setField(routine, "id", 10L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+
+    Todo completedNoDueDate = routineTodo(routine, "일반 투두였다가 루틴이 붙음", null);
+    ReflectionTestUtils.setField(completedNoDueDate, "id", 400L);
+    completedNoDueDate.updateCompleted(true, TEST_DATE.atStartOfDay());
+
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine))
+        .willReturn(List.of(completedNoDueDate));
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.empty());
+    given(routineOverrideRepository.findByRoutineAndOverrideDate(eq(routine), any()))
+        .willReturn(Optional.empty());
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    assertThat(result.get("all")).hasSize(2);
+    assertThat(result.get("all"))
+        .extracting(RoutineResponseDto::getTodoId)
+        .containsExactly(400L, null);
+  }
+
+  @Test
+  void getRoutinesByFilter_all_반복종료일_지난_루틴은_다음할일을_지어내지_않고_루틴_기본값_반환() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+    Routine routine =
+        Routine.builder()
+            .title("종료된 루틴")
+            .routineType(RoutineType.DAILY)
+            .dueDate(TEST_DATE.minusDays(1).atStartOfDay())
+            .user(testUser())
+            .build();
+    ReflectionTestUtils.setField(routine, "id", 11L);
+    given(routineRepository.findAllActiveMotherRoutinesByUser(1L)).willReturn(List.of(routine));
+    given(todoRepository.findCompletedMotherTodosByRoutine(routine)).willReturn(List.of());
+    given(todoRepository.findLatestIncompleteMotherTodoByRoutine(routine))
+        .willReturn(Optional.empty());
+
+    Map<String, List<RoutineResponseDto>> result =
+        routineService.getRoutinesByFilter(1L, "all", null);
+
+    assertThat(result.get("all")).hasSize(1);
+    RoutineResponseDto dto = result.get("all").get(0);
+    assertThat(dto.getTodoId()).isNull();
+    assertThat(dto.getDueDate()).isNull();
+    assertThat(dto.isHasOverride()).isFalse();
+    verify(routineOverrideRepository, never()).findByRoutineAndOverrideDate(any(), any());
+  }
+
+  @Test
+  void getRoutinesByFilter_day_date없으면_INVALID_INPUT_예외() {
+    given(userRepository.findById(1L)).willReturn(Optional.of(testUser()));
+
+    assertThatThrownBy(() -> routineService.getRoutinesByFilter(1L, "day", null))
+        .isInstanceOf(CustomException.class)
+        .satisfies(
+            e ->
+                assertThat(((CustomException) e).getErrorCode())
+                    .isEqualTo(GlobalErrorCode.INVALID_INPUT));
   }
 }

--- a/src/test/java/plana/replan/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/plana/replan/domain/tag/service/TagServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import plana.replan.domain.routine.repository.RoutineOverrideRepository;
 import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.tag.dto.TagCreateRequestDto;
 import plana.replan.domain.tag.dto.TagResponseDto;
@@ -39,6 +40,7 @@ class TagServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private TodoRepository todoRepository;
   @Mock private RoutineRepository routineRepository;
+  @Mock private RoutineOverrideRepository routineOverrideRepository;
 
   @InjectMocks private TagService tagService;
 
@@ -319,7 +321,7 @@ class TagServiceTest {
   }
 
   @Test
-  @DisplayName("deleteTag - 성공: 연관 todo·루틴 tag null 처리 후 soft delete")
+  @DisplayName("deleteTag - 성공: 연관 todo·루틴·루틴 오버라이드 tag null 처리 후 soft delete")
   void deleteTag_success() {
     User user = testUser();
     Tag tag = testTag(1L, user);
@@ -329,6 +331,7 @@ class TagServiceTest {
 
     verify(todoRepository).clearTagFromTodos(tag);
     verify(routineRepository).clearTagFromRoutines(tag);
+    verify(routineOverrideRepository).clearTagFromOverrides(tag);
     assertThat(ReflectionTestUtils.getField(tag, "deletedAt")).isNotNull();
   }
 }

--- a/src/test/java/plana/replan/domain/todo/repository/TodoRepositoryIsActiveTest.java
+++ b/src/test/java/plana/replan/domain/todo/repository/TodoRepositoryIsActiveTest.java
@@ -115,7 +115,7 @@ class TodoRepositoryIsActiveTest {
     retiredCompleted.deactivate();
     todoRepository.saveAndFlush(retiredCompleted);
 
-    List<Todo> result = todoRepository.findCompletedMotherTodosByRoutine(routine);
+    List<Todo> result = todoRepository.findCompletedMotherTodosByRoutines(List.of(routine));
 
     assertThat(result).extracting(Todo::getTitle).containsExactly("활성 완료");
   }
@@ -145,7 +145,7 @@ class TodoRepositoryIsActiveTest {
     retiredIncomplete.deactivate();
     todoRepository.saveAndFlush(retiredIncomplete);
 
-    var result = todoRepository.findLatestIncompleteMotherTodoByRoutine(routine);
+    List<Todo> result = todoRepository.findIncompleteMotherTodosByRoutines(List.of(routine));
 
     assertThat(result).isEmpty();
   }

--- a/src/test/java/plana/replan/domain/todo/repository/TodoRepositoryIsActiveTest.java
+++ b/src/test/java/plana/replan/domain/todo/repository/TodoRepositoryIsActiveTest.java
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
+import plana.replan.domain.routine.entity.Routine;
+import plana.replan.domain.routine.entity.RoutineType;
+import plana.replan.domain.routine.repository.RoutineRepository;
 import plana.replan.domain.todo.entity.Todo;
 import plana.replan.domain.user.entity.Provider;
 import plana.replan.domain.user.entity.Role;
@@ -25,6 +28,7 @@ class TodoRepositoryIsActiveTest {
 
   @Autowired private TodoRepository todoRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private RoutineRepository routineRepository;
 
   @Test
   void 전체조회는_비활성_투두를_제외한다() {
@@ -73,5 +77,76 @@ class TodoRepositoryIsActiveTest {
             user, LocalDateTime.of(2026, 6, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0));
 
     assertThat(result).extracting(Todo::getTitle).contains("실패원본");
+  }
+
+  @Test
+  void 루틴_완료투두_조회는_비활성화된_투두를_제외한다() {
+    User user =
+        userRepository.save(
+            User.builder()
+                .email("isactive-routine-completed@test.com")
+                .nickname("o")
+                .role(Role.ROLE_USER)
+                .provider(Provider.LOCAL)
+                .build());
+    Routine routine =
+        routineRepository.save(
+            Routine.builder().title("루틴").routineType(RoutineType.DAILY).user(user).build());
+
+    Todo activeCompleted =
+        todoRepository.save(
+            Todo.builder()
+                .title("활성 완료")
+                .dueDate(LocalDateTime.of(2026, 6, 10, 10, 0))
+                .user(user)
+                .routine(routine)
+                .build());
+    activeCompleted.updateCompleted(true, LocalDateTime.of(2026, 6, 10, 10, 0));
+
+    Todo retiredCompleted =
+        todoRepository.save(
+            Todo.builder()
+                .title("비활성화된 완료")
+                .dueDate(LocalDateTime.of(2026, 6, 9, 10, 0))
+                .user(user)
+                .routine(routine)
+                .build());
+    retiredCompleted.updateCompleted(true, LocalDateTime.of(2026, 6, 9, 10, 0));
+    retiredCompleted.deactivate();
+    todoRepository.saveAndFlush(retiredCompleted);
+
+    List<Todo> result = todoRepository.findCompletedMotherTodosByRoutine(routine);
+
+    assertThat(result).extracting(Todo::getTitle).containsExactly("활성 완료");
+  }
+
+  @Test
+  void 루틴_미완료투두_조회는_비활성화된_투두를_제외한다() {
+    User user =
+        userRepository.save(
+            User.builder()
+                .email("isactive-routine-incomplete@test.com")
+                .nickname("p")
+                .role(Role.ROLE_USER)
+                .provider(Provider.LOCAL)
+                .build());
+    Routine routine =
+        routineRepository.save(
+            Routine.builder().title("루틴").routineType(RoutineType.DAILY).user(user).build());
+
+    Todo retiredIncomplete =
+        todoRepository.save(
+            Todo.builder()
+                .title("비활성화된 미완료")
+                .dueDate(LocalDateTime.of(2026, 6, 9, 10, 0))
+                .user(user)
+                .routine(routine)
+                .build());
+    retiredIncomplete.deactivate();
+    todoRepository.saveAndFlush(retiredIncomplete);
+
+    var result = todoRepository.findLatestIncompleteMotherTodoByRoutine(routine);
+
+    assertThat(result).isEmpty();
   }
 }


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #258 


## 변경 사항
api/routines의 all filter를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 루틴 조회에서 `date` 입력이 일부 경우 선택 사항이 되었고, `all/day/week/month` 기준으로 더 유연하게 조회할 수 있게 되었습니다.
  * 태그 삭제 시 루틴 오버라이드에 연결된 태그도 함께 정리됩니다.
  * 루틴 및 투두 조회 범위가 확장되어, 완료/미완료 항목을 더 정확히 불러옵니다.

* **Bug Fixes**
  * 잘못된 날짜 형식이나 누락된 필수 파라미터에 대해 더 명확한 400 오류가 반환됩니다.
  * 태그 삭제 후 일부 연관 데이터가 남는 문제가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->