### PR TITLE
v0.23.1

### DIFF
--- a/src/main/java/plana/replan/domain/replan/controller/ReplanControllerDocs.java
+++ b/src/main/java/plana/replan/domain/replan/controller/ReplanControllerDocs.java
@@ -77,12 +77,25 @@ public interface ReplanControllerDocs {
                                   "title": "데이터 분석 공부하기",
                                   "dueDate": "2026-06-26",
                                   "dueTime": "23:59",
-                                  "tagId": null,
+                                  "tagId": 3,
+                                  "tagName": "Study",
                                   "routineType": null,
                                   "routineDays": null,
                                   "changedFields": [
                                     {"field": "dueDate", "before": "2026-06-25", "after": "2026-06-26"}
                                   ]
+                                },
+                                {
+                                  "action": "ADD",
+                                  "targetTodoId": null,
+                                  "title": "데이터 분석 3~4강 수강",
+                                  "dueDate": "2026-06-27",
+                                  "dueTime": null,
+                                  "tagId": 3,
+                                  "tagName": "Study",
+                                  "routineType": null,
+                                  "routineDays": null,
+                                  "changedFields": []
                                 }
                               ]
                             },

--- a/src/main/java/plana/replan/domain/replan/dto/RecommendInput.java
+++ b/src/main/java/plana/replan/domain/replan/dto/RecommendInput.java
@@ -13,8 +13,14 @@ public record RecommendInput(
     List<String> reasonLabels,
     List<AnswerInput> answers,
     String today,
-    int refreshCount) {
+    int refreshCount,
+    // 유저가 가진 태그 목록(id+이름). AI가 신규 투두에 배정할 태그를 이 안에서 고르게 하고,
+    // 응답 파싱 시 AI가 준 tagId가 실제 내 태그인지 검증하는 데 쓴다.
+    List<TagOption> tags) {
 
   public record AnswerInput(
       String key, String text, List<Long> selectedTodoIds, List<String> selectedTodoLabels) {}
+
+  /** 프롬프트/검증에 쓰는 태그 한 건(엔티티 대신 값만). */
+  public record TagOption(Long id, String name) {}
 }

--- a/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
+++ b/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
@@ -41,4 +41,19 @@ public record ReplanOperation(
         routineDays,
         changedFields);
   }
+
+  /** 마감 날짜(dueDate)만 바꾼 복사본을 만든다. 추천 결과에 마감기한이 비지 않도록 채울 때 쓴다. */
+  public ReplanOperation withDueDate(String dueDate) {
+    return new ReplanOperation(
+        action,
+        targetTodoId,
+        title,
+        dueDate,
+        dueTime,
+        tagId,
+        tagName,
+        routineType,
+        routineDays,
+        changedFields);
+  }
 }

--- a/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
+++ b/src/main/java/plana/replan/domain/replan/dto/ReplanOperation.java
@@ -14,6 +14,7 @@ public record ReplanOperation(
     @Schema(description = "마감 시간 HH:mm. 없으면 null", nullable = true, example = "23:59")
         String dueTime,
     @Schema(description = "태그 ID. 없으면 null", nullable = true, example = "5") Long tagId,
+    @Schema(description = "태그 이름. 없으면 null", nullable = true, example = "공부") String tagName,
     @Schema(
             description = "반복 유형 DAILY/WEEKLY/MONTHLY. 반복 아니면 null",
             nullable = true,
@@ -24,4 +25,20 @@ public record ReplanOperation(
             nullable = true,
             example = "[0, 2, 4]")
         List<Integer> routineDays,
-    @Schema(description = "바뀐 필드 목록") List<ChangedField> changedFields) {}
+    @Schema(description = "바뀐 필드 목록") List<ChangedField> changedFields) {
+
+  /** 태그(id·이름)만 바꾼 복사본을 만든다. 수정(MODIFY) 작업의 태그를 기존 투두 값으로 고정할 때 쓴다. */
+  public ReplanOperation withTag(Long tagId, String tagName) {
+    return new ReplanOperation(
+        action,
+        targetTodoId,
+        title,
+        dueDate,
+        dueTime,
+        tagId,
+        tagName,
+        routineType,
+        routineDays,
+        changedFields);
+  }
+}

--- a/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
@@ -3,6 +3,7 @@ package plana.replan.domain.replan.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ public class ReplanAiService {
 
   /** 카테고리별 로직에 따른 추천 작업 목록을 생성한다. */
   public List<ReplanOperation> generateRecommend(RecommendInput input) {
-    return parseRecommend(callGemini(buildRecommendPrompt(input)));
+    return parseRecommend(callGemini(buildRecommendPrompt(input)), input.tags());
   }
 
   public String buildRecommendPrompt(RecommendInput input) {
@@ -64,6 +65,13 @@ public class ReplanAiService {
         실패 이유: %s
         추가 질문 답변:
         %s
+
+        [사용 가능한 태그 목록]
+        %s
+        새로 추가하는 투두(ADD/CREATE_ROUTINE)에는 위 목록에서 가장 적절한 태그 하나를 골라 그 태그의 id를 tagId에 넣으세요.
+        - tagId는 반드시 위 목록에 있는 id 중 하나(숫자)여야 합니다. 목록에 없는 id나 태그 '이름'을 넣지 마세요.
+        - 마땅한 태그가 없거나 목록이 "없음"이면 tagId는 null로 두세요.
+        - 기존 투두/루틴 수정(MODIFY_TODO/MODIFY_ROUTINE)은 태그를 바꾸지 않으니 tagId는 신경 쓰지 마세요(서버가 기존 태그를 유지합니다).
 
         [카테고리별 개선 로직 — 실패 이유와 답변에 맞는 것을 적용]
         ▷ 심리적 저항
@@ -117,8 +125,21 @@ public class ReplanAiService {
                 input.anchorDueDate() != null ? input.anchorDueDate() : "없음",
                 input.anchorTagName() != null ? input.anchorTagName() : "없음",
                 String.join(", ", input.reasonLabels()),
-                answers);
+                answers,
+                buildTagInfo(input.tags()));
     return prompt + refreshStyleBlock(input.refreshCount());
+  }
+
+  /** 유저 태그 목록을 프롬프트용 문자열로 만든다. 태그가 없으면 "없음". */
+  private String buildTagInfo(List<RecommendInput.TagOption> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return "없음";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (RecommendInput.TagOption tag : tags) {
+      sb.append("- id=").append(tag.id()).append(", name=").append(tag.name()).append("\n");
+    }
+    return sb.toString();
   }
 
   /** 새로고침 회차(1~3)에 맞는 스타일 안내 블록. 0/그 외는 빈 문자열(0회차는 프롬프트 변경 없음). */
@@ -180,7 +201,14 @@ public class ReplanAiService {
     }
   }
 
-  public List<ReplanOperation> parseRecommend(String raw) {
+  public List<ReplanOperation> parseRecommend(String raw, List<RecommendInput.TagOption> tags) {
+    // 유저의 실제 태그만 담은 (id -> 이름) 맵. AI가 준 tagId 검증·태그명 확정에 쓴다.
+    Map<Long, String> validTags = new LinkedHashMap<>();
+    if (tags != null) {
+      for (RecommendInput.TagOption tag : tags) {
+        validTags.put(tag.id(), tag.name());
+      }
+    }
     try {
       JsonNode root = objectMapper.readTree(extractJson(raw));
       List<ReplanOperation> operations = new ArrayList<>();
@@ -197,6 +225,27 @@ public class ReplanAiService {
                     textOrNull(cf.path("after"))));
           }
         }
+        // AI가 준 tagId를 유저의 실제 태그로 검증한다. 숫자로 못 바꾸거나(예: 태그 이름을 넣음)
+        // 목록에 없는 값이면 예외로 터뜨리지 않고 태그 없이(null) 처리한다. 이름은 DB 기준으로 확정한다.
+        Long tagId = null;
+        String tagName = null;
+        JsonNode tagIdNode = op.path("tagId");
+        if (!tagIdNode.isNull() && !tagIdNode.isMissingNode()) {
+          Long candidate = null;
+          if (tagIdNode.canConvertToLong()) {
+            candidate = tagIdNode.asLong();
+          } else if (tagIdNode.isTextual()) {
+            try {
+              candidate = Long.valueOf(tagIdNode.asText().trim());
+            } catch (NumberFormatException ignored) {
+              candidate = null;
+            }
+          }
+          if (candidate != null && validTags.containsKey(candidate)) {
+            tagId = candidate;
+            tagName = validTags.get(candidate);
+          }
+        }
         operations.add(
             new ReplanOperation(
                 action,
@@ -204,7 +253,8 @@ public class ReplanAiService {
                 textOrNull(op.path("title")),
                 textOrNull(op.path("dueDate")),
                 textOrNull(op.path("dueTime")),
-                longOrNull(op.path("tagId")),
+                tagId,
+                tagName,
                 textOrNull(op.path("routineType")),
                 intListOrNull(op.path("routineDays")),
                 changed));
@@ -221,7 +271,7 @@ public class ReplanAiService {
     return node.isNull() || node.isMissingNode() ? null : node.asText(null);
   }
 
-  // 숫자 필드는 숫자/숫자문자열만 허용한다. 그 외 값은 0으로 묵시 변환하지 않고 파싱 실패로 처리한다.
+  // targetTodoId는 숫자/숫자문자열만 허용한다. 그 외 값은 0으로 묵시 변환하지 않고 파싱 실패로 처리한다.
   private Long longOrNull(JsonNode node) {
     if (node.isNull() || node.isMissingNode()) {
       return null;
@@ -232,7 +282,7 @@ public class ReplanAiService {
     if (node.isTextual()) {
       return Long.parseLong(node.asText().trim());
     }
-    throw new IllegalArgumentException("숫자 필드(targetTodoId/tagId)가 숫자가 아닙니다: " + node);
+    throw new IllegalArgumentException("숫자 필드(targetTodoId)가 숫자가 아닙니다: " + node);
   }
 
   /** routineDays: 정수 배열. 없으면 null. 각 원소는 숫자/숫자문자열만 허용. */

--- a/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanAiService.java
@@ -111,7 +111,8 @@ public class ReplanAiService {
            - MODIFY_TODO의 targetTodoId에는 위 '대상 투두 ID'를, 다른 기존 투두 수정(우선순위 등)은 아래 '선택 투두' 목록의 실제 ID만 사용. ID를 임의로 만들지 않는다.
         5. changedFields: 수정(MODIFY_TODO/MODIFY_ROUTINE)에서 바뀐 필드만 {field, before, after}로 채운다. field는 title/dueDate/dueTime/tag/routineType/routineDays.
            새로 만드는 ADD·CREATE_ROUTINE은 changedFields를 빈 배열([])로 둔다.
-        6. dueDate는 yyyy-MM-dd 또는 null, dueTime은 HH:mm 또는 null. routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDays는 정수 배열 또는 null (DAILY는 null / WEEKLY는 요일 인덱스 배열: 월=0·화=1·수=2·목=3·금=4·토=5·일=6, 예 월·수·금=[0,2,4] / MONTHLY는 일자 배열 1~31, 예 3일·20일=[3,20]).
+        6. 새로 추가하거나(ADD) 기존 투두를 수정하는(MODIFY_TODO) 경우 dueDate(yyyy-MM-dd)를 반드시 오늘 이후의 구체적 날짜로 정한다. 절대 null로 두지 않는다(모든 투두는 마감기한이 있어야 한다). dueTime은 HH:mm 또는 null.
+           routineType은 DAILY/WEEKLY/MONTHLY 또는 null. routineDays는 정수 배열 또는 null (DAILY는 null / WEEKLY는 요일 인덱스 배열: 월=0·화=1·수=2·목=3·금=4·토=5·일=6, 예 월·수·금=[0,2,4] / MONTHLY는 일자 배열 1~31, 예 3일·20일=[3,20]).
            - CREATE_ROUTINE의 dueDate는 '반복을 끝낼 종료일'을 뜻한다(이 날짜 이후로는 회차를 만들지 않음). 무기한 반복이면 null로 둔다. 새 루틴의 반복 시각은 dueTime으로 지정한다.
 
         반드시 아래 JSON만 출력 (다른 설명 없이):

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -90,8 +90,44 @@ public class ReplanService {
     }
 
     RecommendInput input = buildInput(anchor, req.reasonCodes(), null, req.answers(), refreshCount);
-    List<ReplanOperation> operations = aiService.generateRecommend(input);
+    List<ReplanOperation> operations =
+        applyModifyTagPolicy(aiService.generateRecommend(input), anchor);
     return ReplanRecommendResponse.recommendation(operations, reasonLabels);
+  }
+
+  /**
+   * 수정(MODIFY_TODO/MODIFY_ROUTINE) 작업의 태그를 AI가 고른 값 대신 대상 투두의 기존 태그로 고정한다. 리플랜은 투두를 쪼개거나 미루는 것이지
+   * 카테고리(태그)를 바꾸는 게 아니므로 태그는 그대로 유지한다. 신규 추가(ADD/CREATE_ROUTINE)는 AI가 배정한 태그를 그대로 둔다. 대상이 앵커가 아닌 다른
+   * 투두일 수도 있으므로(우선순위 재정렬 등) targetTodoId로 조회해 그 투두의 태그를 쓴다.
+   */
+  private List<ReplanOperation> applyModifyTagPolicy(
+      List<ReplanOperation> operations, Todo anchor) {
+    List<ReplanOperation> result = new ArrayList<>();
+    for (ReplanOperation op : operations) {
+      if (op.action() == ReplanAction.MODIFY_TODO || op.action() == ReplanAction.MODIFY_ROUTINE) {
+        Tag tag = existingTagForModify(op.targetTodoId(), anchor);
+        result.add(
+            op.withTag(tag == null ? null : tag.getId(), tag == null ? null : tag.getTitle()));
+      } else {
+        result.add(op);
+      }
+    }
+    return result;
+  }
+
+  /** 수정 대상 투두의 기존 태그를 찾는다. 앵커면 앵커 태그, 아니면 소유한 투두를 조회해 그 태그(없으면 null). */
+  private Tag existingTagForModify(Long targetTodoId, Todo anchor) {
+    if (targetTodoId == null) {
+      return null;
+    }
+    if (targetTodoId.equals(anchor.getId())) {
+      return anchor.getTag();
+    }
+    return todoRepository
+        .findById(targetTodoId)
+        .filter(t -> t.getUser().getId().equals(anchor.getUser().getId()))
+        .map(Todo::getTag)
+        .orElse(null);
   }
 
   /**
@@ -151,6 +187,11 @@ public class ReplanService {
         answerInputs.add(new RecommendInput.AnswerInput(a.key(), a.text(), ownedIds, todoLabels));
       }
     }
+    // 유저가 가진 태그(id+이름)를 함께 넘겨, AI가 신규 투두에 실제 존재하는 태그를 배정하게 한다.
+    List<RecommendInput.TagOption> tagOptions =
+        tagRepository.findAllByUserId(anchor.getUser().getId()).stream()
+            .map(t -> new RecommendInput.TagOption(t.getId(), t.getTitle()))
+            .toList();
     return new RecommendInput(
         anchor.getId(),
         anchor.getTitle(),
@@ -162,7 +203,8 @@ public class ReplanService {
         labels,
         answerInputs,
         LocalDate.now(clock).format(DateTimeFormatter.ISO_LOCAL_DATE),
-        refreshCount);
+        refreshCount,
+        tagOptions);
   }
 
   /** 선택한 투두 ID 중 해당 사용자의 것만 추려 엔티티로 반환한다(없거나 남의 것은 제외). */
@@ -392,8 +434,8 @@ public class ReplanService {
         (op.dueDate() != null || op.dueTime() != null)
             ? resolveModifiedDueDate(target, op)
             : target.getDueDate();
-    Tag tag =
-        op.tagId() != null ? resolveTag(op.tagId(), target.getUser().getId()) : target.getTag();
+    // 수정(MODIFY_TODO)은 태그를 바꾸지 않고 기존 투두 태그를 그대로 유지한다(AI/프론트가 tagId를 줘도 무시).
+    Tag tag = target.getTag();
     Todo created =
         Todo.builder()
             .title(title)
@@ -469,8 +511,8 @@ public class ReplanService {
     if (routine.isChild()) {
       throw new CustomException(ReplanErrorCode.REPLAN_INVALID_OPERATION);
     }
-    Tag tag =
-        op.tagId() != null ? resolveTag(op.tagId(), anchor.getUser().getId()) : routine.getTag();
+    // 수정(MODIFY_ROUTINE)은 태그를 바꾸지 않고 기존 루틴 태그를 그대로 유지한다(AI/프론트가 tagId를 줘도 무시).
+    Tag tag = routine.getTag();
     RoutineType effectiveType =
         op.routineType() != null ? parseRoutineType(op.routineType()) : routine.getRoutineType();
     // 반복 유형이 바뀌면 기존 값은 의미가 달라 재사용하지 않고, 새 유형에 맞는 routineDays를 op가 명시하도록 강제한다.

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -112,10 +112,13 @@ public class ReplanService {
     List<ReplanOperation> result = new ArrayList<>();
     for (ReplanOperation op : operations) {
       Tag tag;
-      if (op.action() == ReplanAction.MODIFY_ROUTINE) {
-        // MODIFY_ROUTINE은 항상 앵커(=루틴 회차)를 대상으로 하며, 저장 때 엄마 루틴 태그를 유지한다.
+      if (op.action() == ReplanAction.MODIFY_ROUTINE && isAnchorTarget(op, anchor)) {
+        // 저장 경로(applyModifyRoutine)는 targetTodoId가 앵커일 때만 유효하고 엄마 루틴 태그를 유지한다.
+        // 미리보기도 같은 조건일 때만 엄마 루틴 태그를 붙여 저장될 값과 일치시킨다.
         tag = anchor.getRoutine() != null ? anchor.getRoutine().getTag() : null;
-      } else if (op.action() == ReplanAction.MODIFY_TODO) {
+      } else if (op.action() == ReplanAction.MODIFY_TODO
+          || op.action() == ReplanAction.MODIFY_ROUTINE) {
+        // MODIFY_TODO, 그리고 대상이 앵커가 아닌(저장 시 거부될) MODIFY_ROUTINE은 대상 투두의 기존 태그를 쓴다.
         tag = existingTagForModify(op.targetTodoId(), anchor);
       } else {
         result.add(op); // ADD/CREATE_ROUTINE: AI가 배정한 태그 그대로 둔다.
@@ -124,6 +127,11 @@ public class ReplanService {
       result.add(op.withTag(tag == null ? null : tag.getId(), tag == null ? null : tag.getTitle()));
     }
     return result;
+  }
+
+  /** op의 대상이 앵커 투두인지 확인한다. */
+  private boolean isAnchorTarget(ReplanOperation op, Todo anchor) {
+    return op.targetTodoId() != null && op.targetTodoId().equals(anchor.getId());
   }
 
   /** 수정 대상 투두의 기존 태그를 찾는다. 앵커면 앵커 태그, 아니면 소유한 투두를 조회해 그 태그(없으면 null). */

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -96,21 +96,32 @@ public class ReplanService {
   }
 
   /**
-   * 수정(MODIFY_TODO/MODIFY_ROUTINE) 작업의 태그를 AI가 고른 값 대신 대상 투두의 기존 태그로 고정한다. 리플랜은 투두를 쪼개거나 미루는 것이지
-   * 카테고리(태그)를 바꾸는 게 아니므로 태그는 그대로 유지한다. 신규 추가(ADD/CREATE_ROUTINE)는 AI가 배정한 태그를 그대로 둔다. 대상이 앵커가 아닌 다른
-   * 투두일 수도 있으므로(우선순위 재정렬 등) targetTodoId로 조회해 그 투두의 태그를 쓴다.
+   * 수정(MODIFY_TODO/MODIFY_ROUTINE) 작업의 태그를 AI가 고른 값 대신 대상의 기존 태그로 고정한다. 리플랜은 투두를 쪼개거나 미루는 것이지
+   * 카테고리(태그)를 바꾸는 게 아니므로 태그는 그대로 유지한다. 신규 추가(ADD/CREATE_ROUTINE)는 AI가 배정한 태그를 그대로 둔다.
+   *
+   * <p>미리보기에 넣는 태그는 실제 저장될 태그와 일치해야 한다.
+   *
+   * <ul>
+   *   <li>MODIFY_ROUTINE: 저장 시 회차 오버라이드 태그가 아니라 엄마 루틴 태그(routine.getTag())를 유지하므로 미리보기도 루틴 태그를 쓴다.
+   *   <li>MODIFY_TODO: 저장 시 대상 투두(target.getTag())를 유지한다. 대상이 앵커가 아닌 다른 투두일 수도 있으므로(우선순위 재정렬 등)
+   *       targetTodoId로 조회해 그 투두의 태그를 쓴다.
+   * </ul>
    */
   private List<ReplanOperation> applyModifyTagPolicy(
       List<ReplanOperation> operations, Todo anchor) {
     List<ReplanOperation> result = new ArrayList<>();
     for (ReplanOperation op : operations) {
-      if (op.action() == ReplanAction.MODIFY_TODO || op.action() == ReplanAction.MODIFY_ROUTINE) {
-        Tag tag = existingTagForModify(op.targetTodoId(), anchor);
-        result.add(
-            op.withTag(tag == null ? null : tag.getId(), tag == null ? null : tag.getTitle()));
+      Tag tag;
+      if (op.action() == ReplanAction.MODIFY_ROUTINE) {
+        // MODIFY_ROUTINE은 항상 앵커(=루틴 회차)를 대상으로 하며, 저장 때 엄마 루틴 태그를 유지한다.
+        tag = anchor.getRoutine() != null ? anchor.getRoutine().getTag() : null;
+      } else if (op.action() == ReplanAction.MODIFY_TODO) {
+        tag = existingTagForModify(op.targetTodoId(), anchor);
       } else {
-        result.add(op);
+        result.add(op); // ADD/CREATE_ROUTINE: AI가 배정한 태그 그대로 둔다.
+        continue;
       }
+      result.add(op.withTag(tag == null ? null : tag.getId(), tag == null ? null : tag.getTitle()));
     }
     return result;
   }

--- a/src/main/java/plana/replan/domain/replan/service/ReplanService.java
+++ b/src/main/java/plana/replan/domain/replan/service/ReplanService.java
@@ -91,40 +91,60 @@ public class ReplanService {
 
     RecommendInput input = buildInput(anchor, req.reasonCodes(), null, req.answers(), refreshCount);
     List<ReplanOperation> operations =
-        applyModifyTagPolicy(aiService.generateRecommend(input), anchor);
+        normalizeRecommendedOperations(aiService.generateRecommend(input), anchor);
     return ReplanRecommendResponse.recommendation(operations, reasonLabels);
   }
 
   /**
-   * 수정(MODIFY_TODO/MODIFY_ROUTINE) 작업의 태그를 AI가 고른 값 대신 대상의 기존 태그로 고정한다. 리플랜은 투두를 쪼개거나 미루는 것이지
-   * 카테고리(태그)를 바꾸는 게 아니므로 태그는 그대로 유지한다. 신규 추가(ADD/CREATE_ROUTINE)는 AI가 배정한 태그를 그대로 둔다.
+   * AI가 만든 추천 작업을 응답용으로 보정한다.
    *
-   * <p>미리보기에 넣는 태그는 실제 저장될 태그와 일치해야 한다.
-   *
-   * <ul>
-   *   <li>MODIFY_ROUTINE: 저장 시 회차 오버라이드 태그가 아니라 엄마 루틴 태그(routine.getTag())를 유지하므로 미리보기도 루틴 태그를 쓴다.
-   *   <li>MODIFY_TODO: 저장 시 대상 투두(target.getTag())를 유지한다. 대상이 앵커가 아닌 다른 투두일 수도 있으므로(우선순위 재정렬 등)
-   *       targetTodoId로 조회해 그 투두의 태그를 쓴다.
-   * </ul>
+   * <ol>
+   *   <li><b>태그</b>: 수정(MODIFY) 작업의 태그를 AI 값 대신 실제 저장될 태그로 고정한다. 리플랜은 투두를 쪼개거나 미루는 것이지 카테고리(태그)를
+   *       바꾸는 게 아니다. MODIFY_ROUTINE(대상=앵커)은 엄마 루틴 태그를, MODIFY_TODO는 대상 투두의 기존 태그를 쓴다(저장 경로와 동일). 신규
+   *       추가(ADD/CREATE_ROUTINE)는 AI가 배정한 태그를 그대로 둔다.
+   *   <li><b>마감일</b>: 새 투두(ADD)·기존 투두 수정(MODIFY_TODO)에 dueDate가 없으면 채워, 추천 결과의 모든 투두에 마감기한이 있게 한다.
+   *       MODIFY_TODO는 대상 투두의 기존 마감일을, 없으면 앵커/오늘 날짜를 쓴다. ADD는 앵커/오늘 날짜를 쓴다. (CREATE_ROUTINE의
+   *       dueDate는 '반복 종료일'이라 무기한이면 null이 정상이므로 건드리지 않는다.)
+   * </ol>
    */
-  private List<ReplanOperation> applyModifyTagPolicy(
+  private List<ReplanOperation> normalizeRecommendedOperations(
       List<ReplanOperation> operations, Todo anchor) {
     List<ReplanOperation> result = new ArrayList<>();
     for (ReplanOperation op : operations) {
-      Tag tag;
-      if (op.action() == ReplanAction.MODIFY_ROUTINE && isAnchorTarget(op, anchor)) {
-        // 저장 경로(applyModifyRoutine)는 targetTodoId가 앵커일 때만 유효하고 엄마 루틴 태그를 유지한다.
-        // 미리보기도 같은 조건일 때만 엄마 루틴 태그를 붙여 저장될 값과 일치시킨다.
-        tag = anchor.getRoutine() != null ? anchor.getRoutine().getTag() : null;
-      } else if (op.action() == ReplanAction.MODIFY_TODO
-          || op.action() == ReplanAction.MODIFY_ROUTINE) {
-        // MODIFY_TODO, 그리고 대상이 앵커가 아닌(저장 시 거부될) MODIFY_ROUTINE은 대상 투두의 기존 태그를 쓴다.
-        tag = existingTagForModify(op.targetTodoId(), anchor);
-      } else {
-        result.add(op); // ADD/CREATE_ROUTINE: AI가 배정한 태그 그대로 둔다.
-        continue;
+      ReplanOperation normalized = op;
+      switch (op.action()) {
+        case MODIFY_ROUTINE -> {
+          // 대상이 앵커일 때만 엄마 루틴 태그(저장 경로와 동일), 아니면 대상 투두의 기존 태그.
+          Tag tag =
+              isAnchorTarget(op, anchor)
+                  ? (anchor.getRoutine() != null ? anchor.getRoutine().getTag() : null)
+                  : tagOf(ownedTargetTodo(op.targetTodoId(), anchor));
+          normalized = normalized.withTag(idOf(tag), titleOf(tag));
+        }
+        case MODIFY_TODO -> {
+          Todo target = ownedTargetTodo(op.targetTodoId(), anchor);
+          Tag tag = tagOf(target);
+          normalized = normalized.withTag(idOf(tag), titleOf(tag));
+          if (op.dueDate() == null) {
+            LocalDate due =
+                target != null && target.getDueDate() != null
+                    ? target.getDueDate().toLocalDate()
+                    : anchorDueDateOrToday(anchor);
+            normalized = normalized.withDueDate(due.format(DateTimeFormatter.ISO_LOCAL_DATE));
+          }
+        }
+        case ADD -> {
+          if (op.dueDate() == null) {
+            normalized =
+                normalized.withDueDate(
+                    anchorDueDateOrToday(anchor).format(DateTimeFormatter.ISO_LOCAL_DATE));
+          }
+        }
+        case CREATE_ROUTINE -> {
+          // 루틴 종료일(dueDate)은 무기한이면 null이 정상 — 태그·마감일 모두 그대로 둔다.
+        }
       }
-      result.add(op.withTag(tag == null ? null : tag.getId(), tag == null ? null : tag.getTitle()));
+      result.add(normalized);
     }
     return result;
   }
@@ -134,19 +154,35 @@ public class ReplanService {
     return op.targetTodoId() != null && op.targetTodoId().equals(anchor.getId());
   }
 
-  /** 수정 대상 투두의 기존 태그를 찾는다. 앵커면 앵커 태그, 아니면 소유한 투두를 조회해 그 태그(없으면 null). */
-  private Tag existingTagForModify(Long targetTodoId, Todo anchor) {
+  /** 수정 대상 투두를 찾는다. 앵커면 앵커, 아니면 소유한 투두를 조회(없거나 남의 것이면 null). */
+  private Todo ownedTargetTodo(Long targetTodoId, Todo anchor) {
     if (targetTodoId == null) {
       return null;
     }
     if (targetTodoId.equals(anchor.getId())) {
-      return anchor.getTag();
+      return anchor;
     }
     return todoRepository
         .findById(targetTodoId)
         .filter(t -> t.getUser().getId().equals(anchor.getUser().getId()))
-        .map(Todo::getTag)
         .orElse(null);
+  }
+
+  /** 앵커 투두의 마감 날짜(시간 제외). 없으면 오늘 날짜. 마감일이 없는 투두의 기본 마감일로 쓴다. */
+  private LocalDate anchorDueDateOrToday(Todo anchor) {
+    return anchor.getDueDate() != null ? anchor.getDueDate().toLocalDate() : LocalDate.now(clock);
+  }
+
+  private Tag tagOf(Todo todo) {
+    return todo != null ? todo.getTag() : null;
+  }
+
+  private Long idOf(Tag tag) {
+    return tag != null ? tag.getId() : null;
+  }
+
+  private String titleOf(Tag tag) {
+    return tag != null ? tag.getTitle() : null;
   }
 
   /**

--- a/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
@@ -137,6 +137,29 @@ class ReplanAiServiceTest {
   }
 
   @Test
+  void 추천_프롬프트에_마감일_필수_규칙이_포함된다() {
+    RecommendInput input =
+        new RecommendInput(
+            7L,
+            "데이터 분석 공부하기",
+            "2026-06-07",
+            null,
+            false,
+            null,
+            List.of("목표 개선 필요"),
+            List.of(),
+            "2026-06-18",
+            0,
+            List.of());
+
+    String prompt = service.buildRecommendPrompt(input);
+
+    // ADD/MODIFY_TODO는 dueDate를 반드시 채우도록 지시해야 한다.
+    assertThat(prompt).contains("dueDate");
+    assertThat(prompt).contains("절대 null로 두지 않는다");
+  }
+
+  @Test
   void 추천_프롬프트에_대상_투두ID와_규칙이_포함된다() {
     RecommendInput input =
         new RecommendInput(

--- a/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanAiServiceTest.java
@@ -28,13 +28,16 @@ class ReplanAiServiceTest {
         ]} 뒤 텍스트
         """;
 
-    List<ReplanOperation> ops = service.parseRecommend(raw);
+    List<ReplanOperation> ops =
+        service.parseRecommend(raw, List.of(new RecommendInput.TagOption(5L, "공부")));
 
     assertThat(ops).hasSize(2);
     ReplanOperation first = ops.get(0);
     assertThat(first.action()).isEqualTo(ReplanAction.MODIFY_TODO);
     assertThat(first.targetTodoId()).isEqualTo(42L);
+    // 유효한 태그 id면 그대로 두고 이름은 목록 기준으로 확정한다.
     assertThat(first.tagId()).isEqualTo(5L);
+    assertThat(first.tagName()).isEqualTo("공부");
     // 수정(MODIFY)은 changedFields를 유지
     assertThat(first.changedFields()).hasSize(1);
     assertThat(first.changedFields().get(0).before()).isEqualTo("데이터 분석 공부");
@@ -42,6 +45,46 @@ class ReplanAiServiceTest {
     assertThat(ops.get(1).action()).isEqualTo(ReplanAction.ADD);
     assertThat(ops.get(1).targetTodoId()).isNull();
     assertThat(ops.get(1).changedFields()).isEmpty();
+  }
+
+  @Test
+  void tagId에_태그_이름이_와도_예외없이_null로_처리된다() {
+    // 과거 버그: AI가 tagId 자리에 태그 '이름'("공부")을 넣으면 Long 변환에서 터져 502가 났다.
+    String raw =
+        """
+        {"operations":[
+          {"action":"ADD","targetTodoId":null,"title":"3~4강","dueDate":null,
+           "dueTime":null,"tagId":"공부","routineType":null,"routineDays":null,
+           "changedFields":[]}
+        ]}
+        """;
+
+    List<ReplanOperation> ops =
+        service.parseRecommend(raw, List.of(new RecommendInput.TagOption(5L, "공부")));
+
+    assertThat(ops).hasSize(1);
+    // 숫자가 아니라 예외 대신 태그 없이 처리된다(크래시 없음).
+    assertThat(ops.get(0).tagId()).isNull();
+    assertThat(ops.get(0).tagName()).isNull();
+  }
+
+  @Test
+  void 내_태그가_아닌_tagId는_버려진다() {
+    // AI가 목록에 없는 id(999)를 지어내면 태그 없이 처리한다.
+    String raw =
+        """
+        {"operations":[
+          {"action":"ADD","targetTodoId":null,"title":"3~4강","dueDate":null,
+           "dueTime":null,"tagId":999,"routineType":null,"routineDays":null,
+           "changedFields":[]}
+        ]}
+        """;
+
+    List<ReplanOperation> ops =
+        service.parseRecommend(raw, List.of(new RecommendInput.TagOption(5L, "공부")));
+
+    assertThat(ops.get(0).tagId()).isNull();
+    assertThat(ops.get(0).tagName()).isNull();
   }
 
   @Test
@@ -57,7 +100,8 @@ class ReplanAiServiceTest {
             List.of("목표 개선 필요", "우선 순위를 정하지 못했어요"),
             List.of(new RecommendInput.AnswerInput("free", "ADsP 4챕터", null, null)),
             "2026-06-18",
-            0);
+            0,
+            List.of());
 
     String prompt = service.buildRecommendPrompt(input);
 
@@ -66,6 +110,30 @@ class ReplanAiServiceTest {
     assertThat(prompt).contains("ADsP 4챕터");
     assertThat(prompt).contains("2026-06-18");
     assertThat(prompt).contains("operations");
+  }
+
+  @Test
+  void 추천_프롬프트에_사용가능한_태그_목록이_포함된다() {
+    RecommendInput input =
+        new RecommendInput(
+            7L,
+            "데이터 분석 공부하기",
+            "2026-06-07",
+            "공부",
+            false,
+            null,
+            List.of("목표 개선 필요"),
+            List.of(),
+            "2026-06-18",
+            0,
+            List.of(
+                new RecommendInput.TagOption(5L, "공부"), new RecommendInput.TagOption(8L, "운동")));
+
+    String prompt = service.buildRecommendPrompt(input);
+
+    assertThat(prompt).contains("사용 가능한 태그 목록");
+    assertThat(prompt).contains("id=5, name=공부");
+    assertThat(prompt).contains("id=8, name=운동");
   }
 
   @Test
@@ -81,7 +149,8 @@ class ReplanAiServiceTest {
             List.of("목표 개선 필요"),
             List.of(),
             "2026-06-18",
-            0);
+            0,
+            List.of());
 
     String prompt = service.buildRecommendPrompt(input);
 
@@ -103,7 +172,8 @@ class ReplanAiServiceTest {
             List.of("목표 개선 필요"),
             List.of(),
             "2026-06-18",
-            0);
+            0,
+            List.of());
 
     String prompt = service.buildRecommendPrompt(input);
 
@@ -123,7 +193,8 @@ class ReplanAiServiceTest {
             List.of("목표 개선 필요"),
             List.of(),
             "2026-06-18",
-            2);
+            2,
+            List.of());
 
     String prompt = service.buildRecommendPrompt(input);
 
@@ -151,7 +222,8 @@ class ReplanAiServiceTest {
                     List.of(99L, 100L),
                     List.of("99:영단어 100개 암기", "100:독서 30분"))),
             "2026-06-18",
-            0);
+            0,
+            List.of());
 
     String prompt = service.buildRecommendPrompt(input);
 

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -210,6 +210,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(add));
 
@@ -236,6 +237,7 @@ class ReplanServiceTest {
             "데이터 분석 1~2강",
             "2026-07-02",
             "23:59",
+            null,
             null,
             null,
             null,
@@ -277,6 +279,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     replanService.save(
         1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
@@ -305,7 +308,16 @@ class ReplanServiceTest {
 
     ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, 42L, "데이터 분석 다시", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "데이터 분석 다시",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(
         1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
@@ -340,6 +352,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     ReplanSaveRequest req =
         new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp));
@@ -364,7 +377,16 @@ class ReplanServiceTest {
 
     ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, 42L, null, "2026-07-02", null, null, null, null, List.of());
+            ReplanAction.MODIFY_TODO,
+            42L,
+            null,
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     ReplanSaveRequest req =
         new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
 
@@ -396,6 +418,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     ReplanSaveRequest req =
         new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp));
@@ -423,6 +446,7 @@ class ReplanServiceTest {
             "영단어 50개",
             null,
             "11:15",
+            null,
             null,
             "WEEKLY",
             java.util.List.of(1, 2, 3, 4, 5),
@@ -466,7 +490,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            "새 제목",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
     then(anchor).should().softDelete();
@@ -495,7 +528,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            "새 제목",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
     then(newInstance).should().linkReplan(any(Replan.class));
@@ -532,7 +574,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            "새 제목",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
     // 이전 리플랜도 소프트 삭제된 옛 회차가 아니라 재생성된 새 회차를 가리켜야 한다.
@@ -552,7 +603,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            "새 제목",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
 
     assertThatThrownBy(
             () ->
@@ -581,7 +641,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, "새 제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            "새 제목",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op)));
 
     then(anchor).should().deactivate();
@@ -607,6 +676,7 @@ class ReplanServiceTest {
             "스트레칭",
             null,
             "20:00",
+            null,
             null,
             "DAILY",
             null,
@@ -640,6 +710,7 @@ class ReplanServiceTest {
             "2020-01-01",
             "20:00",
             null,
+            null,
             "DAILY",
             null,
             List.of());
@@ -662,6 +733,7 @@ class ReplanServiceTest {
             "스트레칭",
             "2026-12-31", // 반복 종료일
             "20:00",
+            null,
             null,
             "DAILY",
             null,
@@ -689,6 +761,7 @@ class ReplanServiceTest {
             "스트레칭",
             null,
             "20:00",
+            null,
             null,
             "DAILY",
             java.util.List.of(),
@@ -719,6 +792,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(add));
 
@@ -737,10 +811,19 @@ class ReplanServiceTest {
 
     ReplanOperation modifyOp =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, 42L, "수정", "2026-06-25", null, null, null, null, List.of());
+            ReplanAction.MODIFY_TODO,
+            42L,
+            "수정",
+            "2026-06-25",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     ReplanOperation addOp =
         new ReplanOperation(
-            ReplanAction.ADD, null, "추가", "2026-06-26", null, null, null, null, List.of());
+            ReplanAction.ADD, null, "추가", "2026-06-26", null, null, null, null, null, List.of());
     replanService.save(
         1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modifyOp, addOp)));
 
@@ -757,7 +840,16 @@ class ReplanServiceTest {
 
     ReplanOperation addOp =
         new ReplanOperation(
-            ReplanAction.ADD, null, "조용한 장소 세팅", "2026-07-02", null, null, null, null, List.of());
+            ReplanAction.ADD,
+            null,
+            "조용한 장소 세팅",
+            "2026-07-02",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of());
     replanService.save(1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(addOp)));
 
     then(anchor).should(never()).softDelete();
@@ -785,6 +877,7 @@ class ReplanServiceTest {
             ReplanAction.MODIFY_TODO,
             99L, // 앵커(42)가 아닌 다른 투두를 대상으로 한다
             "[1] 데이터 분석 1~2강",
+            null,
             null,
             null,
             null,
@@ -829,6 +922,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     ReplanSaveRequest req =
         new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify));
@@ -870,6 +964,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             List.of());
     replanService.save(
         1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
@@ -886,7 +981,7 @@ class ReplanServiceTest {
 
     ReplanOperation addOp =
         new ReplanOperation(
-            ReplanAction.ADD, null, "새 투두", "not-a-date", null, null, null, null, List.of());
+            ReplanAction.ADD, null, "새 투두", "not-a-date", null, null, null, null, null, List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(addOp));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -909,9 +1004,10 @@ class ReplanServiceTest {
 
   @Test
   void AI입력에_앵커_마감시간이_포함된다() {
-    // buildInput만 직접 호출하므로 ownedTodo의 user stub은 불필요 — 최소 목만 둔다.
-    Todo todo = org.mockito.Mockito.mock(Todo.class);
+    // buildInput은 유저 태그 목록도 조회하므로 user·tagRepository stub이 필요하다.
+    Todo todo = ownedTodo(42L, 1L);
     given(todo.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 7, 10, 0));
+    given(tagRepository.findAllByUserId(1L)).willReturn(List.of());
 
     RecommendInput input =
         replanService.buildInput(todo, List.of("INTERRUPT_SUDDEN"), null, null, 0);
@@ -927,7 +1023,7 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, 42L, "", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_TODO, 42L, "", null, null, null, null, null, null, List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -950,7 +1046,7 @@ class ReplanServiceTest {
 
     ReplanOperation modify =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, 42L, null, null, "15:30", null, null, null, List.of());
+            ReplanAction.MODIFY_TODO, 42L, null, null, "15:30", null, null, null, null, List.of());
     replanService.save(
         1L, new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(modify)));
 
@@ -1059,6 +1155,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             "WEEKLY",
             null, // routineDate 없음 — 유효하지 않음
             List.of());
@@ -1083,7 +1180,16 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_ROUTINE, 42L, null, null, null, null, "WEEKLY", null, List.of());
+            ReplanAction.MODIFY_ROUTINE,
+            42L,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "WEEKLY",
+            null,
+            List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -1103,6 +1209,7 @@ class ReplanServiceTest {
         new ReplanOperation(
             ReplanAction.MODIFY_ROUTINE,
             99L, // 앵커(42L)와 다른 타깃
+            null,
             null,
             null,
             null,
@@ -1132,6 +1239,7 @@ class ReplanServiceTest {
             null,
             null,
             null,
+            null,
             "MONTHLY",
             java.util.List.of(), // 빈 배열은 유효하지 않음
             List.of());
@@ -1150,7 +1258,7 @@ class ReplanServiceTest {
     given(replanRepository.save(any(Replan.class))).willAnswer(inv -> inv.getArgument(0));
 
     ReplanOperation op =
-        new ReplanOperation(null, null, "제목", null, null, null, null, null, List.of());
+        new ReplanOperation(null, null, "제목", null, null, null, null, null, null, List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -1167,7 +1275,7 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.MODIFY_TODO, null, "제목", null, null, null, null, null, List.of());
+            ReplanAction.MODIFY_TODO, null, "제목", null, null, null, null, null, null, List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -1184,7 +1292,7 @@ class ReplanServiceTest {
 
     ReplanOperation op =
         new ReplanOperation(
-            ReplanAction.ADD, null, null, "2026-06-20", null, null, null, null, List.of());
+            ReplanAction.ADD, null, null, "2026-06-20", null, null, null, null, null, List.of());
     ReplanSaveRequest req = new ReplanSaveRequest(42L, List.of("GOAL_NO_PRIORITY"), List.of(op));
 
     assertThatThrownBy(() -> replanService.save(1L, req))
@@ -1207,6 +1315,7 @@ class ReplanServiceTest {
             42L,
             "가벼운 스트레칭",
             "2026-07-02",
+            null,
             null,
             null,
             null,

--- a/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
+++ b/src/test/java/plana/replan/domain/replan/service/ReplanServiceTest.java
@@ -160,6 +160,53 @@ class ReplanServiceTest {
   }
 
   @Test
+  void 추천_ADD와_MODIFY_TODO는_마감일이_없으면_앵커_마감일로_채워진다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 20, 10, 0));
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(tagRepository.findAllByUserId(1L)).willReturn(List.of());
+
+    // AI가 dueDate를 null로 준 ADD/MODIFY_TODO도 응답에는 마감일이 채워져야 한다.
+    ReplanOperation add =
+        new ReplanOperation(
+            ReplanAction.ADD, null, "새 투두", null, null, null, null, null, null, List.of());
+    ReplanOperation modify =
+        new ReplanOperation(
+            ReplanAction.MODIFY_TODO, 42L, "수정", null, null, null, null, null, null, List.of());
+    given(aiService.generateRecommend(any())).willReturn(List.of(add, modify));
+
+    ReplanRecommendResponse res =
+        replanService.recommend(
+            1L, new ReplanRecommendRequest(42L, List.of("INTERRUPT_SUDDEN"), null, null));
+
+    assertThat(res.operations()).allSatisfy(op -> assertThat(op.dueDate()).isNotNull());
+    // 앵커 마감일(2026-06-20)이 있으므로 그 날짜로 채워진다.
+    assertThat(res.operations().get(0).dueDate()).isEqualTo("2026-06-20");
+    assertThat(res.operations().get(1).dueDate()).isEqualTo("2026-06-20");
+  }
+
+  @Test
+  void 추천_AI가_준_마감일이_있으면_그대로_둔다() {
+    Todo anchor = ownedTodo(42L, 1L);
+    given(anchor.getId()).willReturn(42L);
+    given(anchor.getDueDate()).willReturn(LocalDateTime.of(2026, 6, 20, 10, 0));
+    given(todoRepository.findById(42L)).willReturn(Optional.of(anchor));
+    given(tagRepository.findAllByUserId(1L)).willReturn(List.of());
+
+    ReplanOperation add =
+        new ReplanOperation(
+            ReplanAction.ADD, null, "새 투두", "2026-06-25", null, null, null, null, null, List.of());
+    given(aiService.generateRecommend(any())).willReturn(List.of(add));
+
+    ReplanRecommendResponse res =
+        replanService.recommend(
+            1L, new ReplanRecommendRequest(42L, List.of("INTERRUPT_SUDDEN"), null, null));
+
+    assertThat(res.operations().get(0).dueDate()).isEqualTo("2026-06-25");
+  }
+
+  @Test
   void 필요한_질문중_일부만_답하면_남은_질문을_다시_묻는다() {
     Todo todo = ownedTodo(42L, 1L);
     given(todo.getId()).willReturn(42L);


### PR DESCRIPTION
## 이번 배포 내용
리플랜 추천의 태그 처리 버그 수정과 추천 투두 마감기한 보장 (#261)

- **태그 달린 투두를 리플랜하면 추천이 500 에러나던 문제 수정** — 제미나이에 태그 목록(id+이름)을 넘겨 실제 태그 id를 배정·검증하도록 변경. 태그 이름을 tagId에 넣어도 예외 대신 null 처리.
- **추천된 투두에 마감기한이 항상 있도록 보장** — 새 투두(ADD)·기존 투두 수정(MODIFY_TODO)은 dueDate를 항상 채운다(프롬프트 규칙 + 백엔드 안전망).
- 응답에 태그 이름(tagName) 필드 추가(하위호환). 수정 작업은 기존 태그를 그대로 유지.

## Related Issues
close #259

## 테스트 결과
로컬 서버에서 실제 제미나이 호출 포함 전수 테스트 통과. `./gradlew build`(JDK17+Spotless) 통과. 프론트 하위호환(기존 tagId 소비 그대로, tagName 추가는 무해) 확인.