### PR TITLE
Fix: 애플 로그인 첫 가입이 실패하던 문제 수정

### DIFF
--- a/src/main/resources/db/migration/V20__drop_users_provider_check.sql
+++ b/src/main/resources/db/migration/V20__drop_users_provider_check.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_provider_check;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_login_type_check;


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## Related Issues
close #263


## 변경 사항

애플 로그인으로 **처음 가입하는 사용자**가 운영 환경에서 500 에러로 가입에 실패하던 문제를 고쳤습니다.

- 운영 `users` 테이블에는 예전에 자동으로 만들어져 남아 있던 낡은 검사 규칙(`users_provider_check`)이 있었습니다. 이 규칙은 로그인 종류로 `LOCAL / KAKAO / GOOGLE / NAVER`만 허용하고, 나중에 추가된 `APPLE`은 거부했습니다.
- 이 규칙은 우리 마이그레이션 어디에도 없는, 운영 DB에만 남은 잔재였습니다. 그래서 로컬에서는 재현되지 않고 운영에서만 터졌습니다.
- 지난번 태그 색상 문제(`tag_color_check`, V12에서 제거)와 똑같은 패턴입니다.
- 이 낡은 규칙을 지우는 마이그레이션(`V20`)을 추가했습니다. 로그인 종류 검증은 애플리케이션(`Provider` enum)에서 이미 하고 있어 DB 규칙 없이도 안전합니다.
- 혹시 다른 환경에서 이 검사가 컬럼 이름 기준(`users_login_type_check`)으로 만들어졌을 경우까지 대비해, 두 이름 모두 지우도록 했습니다. 둘 다 `IF EXISTS`라 없으면 조용히 넘어갑니다.

운영 에러 로그:
```text
new row for relation "users" violates check constraint "users_provider_check"
Detail: Failing row contains (56, seongyeon0810@naver.com, ㅇㅇ, null, APPLE, ...)
```


## 테스트 결과

- `./gradlew build` (JDK 17, Spotless 포맷 검사 포함) 통과.
- 로컬 PostgreSQL에서 마이그레이션 SQL 두 문장 직접 실행 — 오류 없이 통과(제약 없으면 `IF EXISTS`로 건너뜀, 멱등성 확인).