### PR TITLE
v0.23.2

### DIFF
--- a/src/main/resources/db/migration/V20__drop_users_provider_check.sql
+++ b/src/main/resources/db/migration/V20__drop_users_provider_check.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_provider_check;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_login_type_check;


### PR DESCRIPTION
## 변경 사항

애플 로그인으로 **처음 가입하는 사용자**가 운영에서 500 에러로 가입에 실패하던 문제를 수정했습니다.

- 운영 `users` 테이블에 예전부터 남아 있던 낡은 검사 규칙(`users_provider_check`)이 로그인 종류 `APPLE`을 거부하고 있었습니다. 이 낡은 규칙을 지우는 마이그레이션(`V20`)을 추가했습니다.
- 지난 태그 색상 문제(`tag_color_check`, V12)와 같은 패턴입니다.
- 로그인 종류 검증은 애플리케이션(`Provider` enum)에서 이미 하므로 DB 규칙 없이도 안전합니다.

## Related Issues
#263

## 테스트 결과
- `./gradlew build`(JDK 17) 통과, 로컬 PostgreSQL에서 마이그레이션 SQL 직접 실행 확인.